### PR TITLE
Update Arch PKGBUILD

### DIFF
--- a/pack/PKGBUILD
+++ b/pack/PKGBUILD
@@ -3,58 +3,64 @@
 # Contributor: WaveHack <email@wavehack.net>
 # Contributor: Whovian9369 <Whovian9369@gmail.com>
 # Contributor: Angelo Theodorou <encelo@gmail.com>
+# Contributor: Grafcube <grafcube@protonmail.com>
 
-pkgname=gitahead
-pkgrel=3
-pkgver=2.6.3
-branch="master"
-pkgdesc='Understand your Git history!'
-url='https://www.gitahead.com/'
+pkgname=gittyup-git
+pkgver=r504.410be91
+pkgrel=1
+pkgdesc="A graphical Git client designed to help you understand and manage your source code history. Successor of Gitahead."
+url="https://github.com/Murmele/Gittyup"
 arch=('x86_64')
 license=('MIT')
 depends=('desktop-file-utils' 'qt5-base' 'git')
 makedepends=('cmake' 'ninja' 'git' 'qt5-tools' 'qt5-translations')
-source=(
-  "git+https://github.com/Murmele/gitahead#branch=${branch}"
-)
-sha256sums=(
-  'SKIP'
-)
+source=($pkgname::git+https://github.com/Murmele/gittyup.git)
+sha256sums=('SKIP')
+
+pkgver() {
+	cd "$srcdir/$pkgname"
+	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
 
 prepare() {
-  cd "$srcdir/gitahead"
+  cd "$srcdir/$pkgname"
 
   git submodule update --init --recursive
 }
 
 build() {
-  if [ ! -d "$srcdir/gitahead-build" ]; then
-    mkdir "$srcdir/gitahead-build"
+  if [ ! -d "$srcdir/$pkgname/build/release" ]; then
+    mkdir -p "$srcdir/$pkgname/build/release"
   fi
-  cd "$srcdir/gitahead-build"
-  cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib ../gitahead
+  cd "$srcdir/$pkgname/build/release"
+
+  cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib ../..
   ninja
 }
 
 package() {
-  cd "$srcdir/gitahead-build"
+  cd "$srcdir/$pkgname/build/release"
 
   ninja package
 
   mkdir -p "${pkgdir}/usr/"{share,bin}
 
-  cp -r "${srcdir}/gitahead-build/_CPack_Packages/Linux/STGZ/GitAhead-${pkgver}" "${pkgdir}/usr/share/gitahead"
+  rm "${srcdir}/${pkgname}/build/release/_CPack_Packages/Linux/STGZ/"Gittyup-*.sh
 
-  rm -rf "${pkgdir}/usr/share/gitahead/"*.so.*
-  ln -s "/usr/share/gitahead/GitAhead" "${pkgdir}/usr/bin/gitahead"
+  cp -r "${srcdir}/${pkgname}/build/release/_CPack_Packages/Linux/STGZ/Gittyup-"* "${pkgdir}/usr/share/gittyup"
 
-  install -D -m644 "${pkgdir}/usr/share/gitahead/Resources/GitAhead.iconset/icon_16x16.png" "${pkgdir}/usr/share/icons/hicolor/16x16/apps/gitahead.png"
-  install -D -m644 "${pkgdir}/usr/share/gitahead/Resources/GitAhead.iconset/icon_32x32.png" "${pkgdir}/usr/share/icons/hicolor/32x32/apps/gitahead.png"
-  install -D -m644 "${pkgdir}/usr/share/gitahead/Resources/GitAhead.iconset/icon_64x64.png" "${pkgdir}/usr/share/icons/hicolor/64x64/apps/gitahead.png"
-  install -D -m644 "${pkgdir}/usr/share/gitahead/Resources/GitAhead.iconset/icon_128x128.png" "${pkgdir}/usr/share/icons/hicolor/128x128/apps/gitahead.png"
-  install -D -m644 "${pkgdir}/usr/share/gitahead/Resources/GitAhead.iconset/icon_256x256.png" "${pkgdir}/usr/share/icons/hicolor/256x256/apps/gitahead.png"
-  install -D -m644 "${pkgdir}/usr/share/gitahead/Resources/GitAhead.iconset/icon_512x512.png" "${pkgdir}/usr/share/icons/hicolor/512x512/apps/gitahead.png"
+  rm -rf "${pkgdir}/usr/share/gittyup/"*.so.*
 
-  install -D -m644 ${srcdir}/gitahead/LICENSE.md "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
-  install -D -m644 "${srcdir}/gitahead/rsrc/linux/io.github.gitahead.gitahead.desktop" "${pkgdir}/usr/share/applications/gitahead.desktop"
+  ln -s "/usr/share/gittyup/Gittyup" "${pkgdir}/usr/bin/gittyup"
+
+  install -Dm644 "${pkgdir}/usr/share/gittyup/Resources/Gittyup.iconset/gittyup_logo.svg" "${pkgdir}/usr/share/icons/hicolor/scalable/apps/gittyup.svg"
+  install -Dm644 "${pkgdir}/usr/share/gittyup/Resources/Gittyup.iconset/icon_16x16.png" "${pkgdir}/usr/share/icons/hicolor/16x16/apps/gittyup.png"
+  install -Dm644 "${pkgdir}/usr/share/gittyup/Resources/Gittyup.iconset/icon_32x32.png" "${pkgdir}/usr/share/icons/hicolor/32x32/apps/gittyup.png"
+  install -Dm644 "${pkgdir}/usr/share/gittyup/Resources/Gittyup.iconset/icon_64x64.png" "${pkgdir}/usr/share/icons/hicolor/64x64/apps/gittyup.png"
+  install -Dm644 "${pkgdir}/usr/share/gittyup/Resources/Gittyup.iconset/icon_128x128.png" "${pkgdir}/usr/share/icons/hicolor/128x128/apps/gittyup.png"
+  install -Dm644 "${pkgdir}/usr/share/gittyup/Resources/Gittyup.iconset/icon_256x256.png" "${pkgdir}/usr/share/icons/hicolor/256x256/apps/gittyup.png"
+  install -Dm644 "${pkgdir}/usr/share/gittyup/Resources/Gittyup.iconset/icon_512x512.png" "${pkgdir}/usr/share/icons/hicolor/512x512/apps/gittyup.png"
+
+  install -Dm644 ${srcdir}/${pkgname}/LICENSE.md "${pkgdir}/usr/share/licenses/gittyup/LICENSE"
+  install -Dm755 "${srcdir}/${pkgname}/rsrc/linux/com.github.Murmele.Gittyup.desktop" "${pkgdir}/usr/share/applications/com.github.Murmele.Gittyup.desktop"
 }


### PR DESCRIPTION
Updated the old PKGBUILD for Gittyup.

- Changed name to `gittyup-git` since it builds from master. If there are tagged commits with the version numbers I can also also add `gittyup` package and if prebuilt releases are added, maybe to the releases section, I can make a `gittyup-bin`.
- Build steps were copied from the readme. I am not sure if it's correct because I'm not too familiar with cmake and ninja. It builds and installs correctly on all three of my machines.
- Included svg icon to be installed.

If it's ok, I don't mind also putting this on the AUR.