### PR TITLE
Fix external Merge Tool

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -6,6 +6,10 @@ add_library(tools
   ShowTool.cpp
 )
 
+if (FLATPAK)
+    target_compile_definitions(tools PRIVATE FLATPAK)
+endif()
+
 target_link_libraries(tools
   conf
   git

--- a/src/tools/ExternalTool.cpp
+++ b/src/tools/ExternalTool.cpp
@@ -16,6 +16,7 @@
 #include "git/Index.h"
 #include "git/Repository.h"
 #include <QStandardPaths>
+#include <QProcess>
 
 namespace {
 
@@ -88,7 +89,16 @@ QList<ExternalTool::Info> ExternalTool::readBuiltInTools(const QString &key)
     QString program, args;
     QString name = entry.name().section(".", 1, 1);
     splitCommand(entry.value<QString>(), program, args);
+
+#define TESTING_PROCESS 0
+#if defined(FLATPAK) || TESTING_PROCESS
+	QProcess process;
+	process.start("flatpak-spawn", {"--host", "which", program});
+	process.waitForFinished(-1); // will wait forever until finished
+	QString path  = process.readAllStandardOutput();
+#else
     QString path = QStandardPaths::findExecutable(program);
+#endif
     tools.append({name, program, args, !path.isEmpty()});
   }
 


### PR DESCRIPTION
For the flatpak package flatpak-spawn must be used to execute applications from the host