### PR TITLE
Add Arch installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ How to Install
 -----------------
 ### Linux
 
-The easies way to install Gittyup is by using [Flatpak](https://flathub.org/apps/details/com.github.Murmele.Gittyup)
+The easiest way to install Gittyup is by using [Flatpak](https://flathub.org/apps/details/com.github.Murmele.Gittyup).
 
 **Arch Linux**
 

--- a/README.md
+++ b/README.md
@@ -106,14 +106,20 @@ How to Install
 **Linux**
 The easies way to install Gittyup is by using [Flatpak](https://www.flatpak.org/)
 
-Ubuntu: 
+Ubuntu:
 
     sudo apt-get install flatpak && flatpak install flathub com.github.Murmele.Gittyup
-Arch: 
 
-    sudo pacman -S flatpak && flatpak install flathub com.github.Murmele.Gittyup
+Arch:
 
+Install the `gittyup` package from the Arch User Repository.
 
+	git clone https://aur.archlinux.org/gittyup.git
+	cd gittyup
+	makepkg -si
+
+Or use an AUR helper.
+Install `gittyup-git` for the VCS build.
 
 How to Contribute
 -----------------

--- a/README.md
+++ b/README.md
@@ -103,14 +103,11 @@ where `<path-to-qt>` points to the Qt install directory that contains
 
 How to Install
 -----------------
-**Linux**
-The easies way to install Gittyup is by using [Flatpak](https://www.flatpak.org/)
+### Linux
 
-Ubuntu:
+The easies way to install Gittyup is by using [Flatpak](https://flathub.org/apps/details/com.github.Murmele.Gittyup)
 
-    sudo apt-get install flatpak && flatpak install flathub com.github.Murmele.Gittyup
-
-Arch:
+**Arch Linux**
 
 Install the `gittyup` package from the Arch User Repository.
 


### PR DESCRIPTION
[`gittyup`](https://aur.archlinux.org/packages/gittyup/) and [`gittyup-git`](https://aur.archlinux.org/packages/gittyup-git/) on the Arch User Repository.