### PR TITLE
add description how to pass the repository path to the file browser command

### DIFF
--- a/src/dialogs/SettingsDialog.cpp
+++ b/src/dialogs/SettingsDialog.cpp
@@ -269,7 +269,10 @@ public:
     layout->addRow(tr("Backup files:"), backup);
 
     QLineEdit *mFileManagerCommand = new QLineEdit(this);
-    layout->addRow(tr("File manager command:"), mFileManagerCommand);
+	QHBoxLayout* fileManagerLayout = new QHBoxLayout();
+	fileManagerLayout->addWidget(mFileManagerCommand);
+	fileManagerLayout->addWidget(new QLabel("\"%1\" = Repo Path", this));
+	layout->addRow(tr("File manager command:"), fileManagerLayout);
 
     connect(mFileManagerCommand, &QLineEdit::textChanged, [](const QString &text) {
       Settings::instance()->setValue("filemanager/command", text);


### PR DESCRIPTION
So it is possible to use a custom command, but opening the file browser with the repository path open

In flatpak I did: flatpak-spawn --host dolphin "%1", because by default the gnome file browser is used and I prefer the KDE one.
@exactly-one-kas What do you think about?