### PR TITLE
Add possibility to set cursor position

### DIFF
--- a/src/ui/DetailView.cpp
+++ b/src/ui/DetailView.cpp
@@ -18,6 +18,7 @@
 #include "DoubleTreeWidget.h"
 #include "SpellChecker.h"
 #include "TreeWidget.h"
+#include "TemplateButton.h"
 #include "app/Application.h"
 #include "conf/Settings.h"
 #include "git/Branch.h"
@@ -1015,9 +1016,17 @@ public:
   }
 
 public slots:
-  void applyTemplate(const QString templ)
+  void applyTemplate(QString& templ)
   {
+	auto index = templ.indexOf(TemplateButton::cursorPositionString);
+	if (index < 0)
+		index = templ.length();
+
+	templ.replace("%|", "");
     mMessage->setText(templ);
+	auto cursor = mMessage->textCursor();
+	cursor.setPosition(index);
+	mMessage->setTextCursor(cursor);
   }
 
 private:

--- a/src/ui/TemplateButton.cpp
+++ b/src/ui/TemplateButton.cpp
@@ -12,6 +12,8 @@ namespace {
     const QString separator = ":";
 }
 
+const QString TemplateButton::cursorPositionString = QStringLiteral("%|");
+
 TemplateButton::TemplateButton(git::Config config, QWidget* parent):
     QToolButton(parent),
     mConfig(config)

--- a/src/ui/TemplateButton.h
+++ b/src/ui/TemplateButton.h
@@ -8,10 +8,12 @@
 class TemplateButton: public QToolButton {
     Q_OBJECT
 public:
-    typedef struct Template {
+	struct Template {
         QString name{""};
         QString value{""};
     };
+	static const QString cursorPositionString;
+
     TemplateButton(git::Config config, QWidget* parent = nullptr);
     QMenu* menu() const;
     void showMenu();
@@ -19,7 +21,7 @@ public:
     QList<Template> loadTemplates();
     void updateMenu();
 signals:
-    void templateChanged(const QString& str);
+	void templateChanged(QString& str);
 private:
     void actionTriggered(QAction* action);
 

--- a/src/ui/TemplateDialog.cpp
+++ b/src/ui/TemplateDialog.cpp
@@ -43,6 +43,7 @@ TemplateDialog::TemplateDialog(QList<TemplateButton::Template> &templates, QWidg
     vBox->addLayout(hBox);
     vBox->addWidget(lbl);
     vBox->addWidget(mTemplate);
+	vBox->addWidget(new QLabel("use " + TemplateButton::cursorPositionString +" to declare the position of the cursor.", this));
     vBox->addLayout(hBox2);
 
     // second column


### PR DESCRIPTION
At the moment the position when using a commit message template is at the beginning, so it is not possible to start writing the message, but it has to first click to the desired position to start writing

1) Check that you have unmerged changes
2) Create a new commit message template:
![image](https://user-images.githubusercontent.com/10099533/144825012-9c83015a-1f64-4c96-9e04-85a2632bd207.png)
![image](https://user-images.githubusercontent.com/10099533/144824955-ce12036d-76ef-481d-aaba-1f4b1aa7367d.png)
3) Use the commit message and check position of the cursor initially set


@exactly-one-kas Can you have a look over it