### PR TITLE
Add default theme (and replace native theme)

### DIFF
--- a/conf/themes/Dark.lua
+++ b/conf/themes/Dark.lua
@@ -34,6 +34,7 @@ theme['widget']    = {
   text             = { default = '#E1E5F2', disabled = '#555B65' },
   bright_text      = '#AAB2BE',
   background       = '#212226',
+  alternate        = '#2D2E34', -- an alternate background color for list rows
   highlight        = { active = '#2A82DA', inactive = '#1B5B9B' },
   highlighted_text = { active = '#E1E5F2', inactive = '#E1E5F2' },
 }
@@ -58,6 +59,7 @@ theme['commits']   = {
   text             = '#E1E5F2',
   bright_text      = '#AAB2BE',
   background       = '#2D2E34',
+  alternate        = '#2D2E34', -- an alternate background color for list rows
   highlight        = { active = '#2A82DA', inactive = '#1B5B9B' },
   highlighted_text = { active = '#E1E5F2', inactive = '#E1E5F2' },
   highlighted_bright_text = { active = '#A6CBF0', inactive = '#9090A5' }

--- a/conf/themes/Default.lua
+++ b/conf/themes/Default.lua
@@ -1,82 +1,240 @@
-if theme.dark then
-  -- colors
-  lexer.property['color.red']          = '#994D4D'
-  lexer.property['color.yellow']       = '#99994D'
-  lexer.property['color.green']        = '#4D994D'
-  lexer.property['color.teal']         = '#4D9999'
-  lexer.property['color.purple']       = '#994D99'
-  lexer.property['color.orange']       = '#E6994D'
-  lexer.property['color.blue']         = '#4D99E6'
-  lexer.property['color.black']        = '#1A1A1A'
-  lexer.property['color.grey']         = '#808080'
-  lexer.property['color.white']        = '#E6E6E6'
+--
+-- Many colors support 'active', 'inactive', and 'disabled' states.
+-- They can all be set to the same color with the syntax:
+--
+--   key = '<color>'
+--
+-- Or set individually with syntax like:
+--
+--   key = { active = '<color>', inactive = '<color>', disabled = '<color>' }
+--
+-- Use the 'default' key set one state individually and the remainder
+-- to a default value:
+--
+--   key = { default = '<color>', disabled = '<color>' }
+--
 
-  -- styles
-  lexer.property['style.bracebad']     = 'fore:#CC8080'
-  lexer.property['style.bracelight']   = 'fore:#80CCFF'
-  lexer.property['style.calltip']      = 'fore:#AAB2BE,back:#333333'
-  lexer.property['style.class']        = 'fore:#F6E9D0'
-  lexer.property['style.comment']      = 'fore:#E2D9C9'
-  lexer.property['style.constant']     = 'fore:#E8C080'
-  lexer.property['style.controlchar']  = '$(style.nothing)'
-  lexer.property['style.default']      = 'fore:#AAB2BE,back:#212228'
-  lexer.property['style.definition']   = 'fore:#F6E9D0'
-  lexer.property['style.embedded']     = '$(style.tag),back:#333333'
-  lexer.property['style.error']        = 'fore:#994D4D,italics'
-  lexer.property['style.function']     = 'fore:#4D99E6'
-  lexer.property['style.identifier']   = '$(style.nothing)'
-  lexer.property['style.indentguide']  = 'fore:#333333,back:#333333'
-  lexer.property['style.keyword']      = 'fore:#53AFEC,bold'
-  lexer.property['style.label']        = 'fore:#E8C080'
-  lexer.property['style.linenumber']   = 'fore:#5F6672,back:#2A2B30,bold'
-  lexer.property['style.nothing']      = ''
-  lexer.property['style.number']       = 'fore:#4D99E6'
-  lexer.property['style.operator']     = 'fore:#CCCCCC,bold'
-  lexer.property['style.preprocessor'] = 'fore:#CC77DA,bold'
-  lexer.property['style.regex']        = 'fore:#80CC80'
-  lexer.property['style.string']       = 'fore:#93C37E'
-  lexer.property['style.tag']          = 'fore:#CCCCCC'
-  lexer.property['style.type']         = 'fore:#CC77DA'
-  lexer.property['style.variable']     = 'fore:#80CCFF'
-  lexer.property['style.whitespace']   = ''
-else
-  -- colors
-  lexer.property['color.red']          = '#800000'
-  lexer.property['color.yellow']       = '#808000'
-  lexer.property['color.green']        = '#008000'
-  lexer.property['color.teal']         = '#008080'
-  lexer.property['color.purple']       = '#800080'
-  lexer.property['color.orange']       = '#B08000'
-  lexer.property['color.blue']         = '#000080'
-  lexer.property['color.black']        = '#000000'
-  lexer.property['color.grey']         = '#808080'
-  lexer.property['color.white']        = '#FFFFFF'
+-- generic colors used to render borders and separators
+-- { default, active, inactive, disabled }
+theme['palette']   = {
+  -- These names correspond to a dark on light theme.
+  -- The values should be inverted in light on dark themes.
+  light            = '#FFFFFF', -- inverse of dark
+  midlight         = '#F7F7F6', -- inverse of middark
+  middark          = '#C4C9CD', -- inverse of midlight
+  dark             = '#888E93', -- inverse of light
 
-  -- styles
-  lexer.property['style.nothing']      = ''
-  lexer.property['style.default']      = 'fore:$(color.black),back:$(color.white)'
-  lexer.property['style.linenumber']   = 'fore:$(color.black),back:#DCDCDC'
-  lexer.property['style.bracelight']   = '$(style.nothing)'
-  lexer.property['style.bracebad']     = '$(style.nothing)'
-  lexer.property['style.controlchar']  = '$(style.nothing)'
-  lexer.property['style.indentguide']  = '$(style.nothing)'
-  lexer.property['style.calltip']      = '$(style.nothing)'
+  -- This should always be a dark color.
+  shadow           = '#474A4C'
+}
 
-  lexer.property['style.whitespace']   = '$(style.nothing)'
-  lexer.property['style.comment']      = 'fore:#0000FF,italics'
-  lexer.property['style.string']       = 'fore:#CC0000'
-  lexer.property['style.number']       = 'fore:$(color.teal)'
-  lexer.property['style.keyword']      = 'fore:$(color.blue),bold'
-  lexer.property['style.identifier']   = '$(style.nothing)'
-  lexer.property['style.operator']     = 'fore:$(color.black),bold'
-  lexer.property['style.error']        = 'fore:#FF0000'
-  lexer.property['style.preprocessor'] = 'fore:$(color.green),bold'
-  lexer.property['style.constant']     = '$(style.keyword)'
-  lexer.property['style.variable']     = '$(style.label)'
-  lexer.property['style.function']     = '$(style.label)'
-  lexer.property['style.class']        = '$(style.nothing)'
-  lexer.property['style.type']         = 'fore:$(color.blue)'
-  lexer.property['style.label']        = 'fore:$(color.red)'
-  lexer.property['style.regex']        = '$(style.nothing)'
-  lexer.property['style.embedded']     = '$(style.nothing)'
-end
+-- the colors of text entry, list view, and other widgets
+-- { default, active, inactive, disabled }
+theme['widget']    = {
+  text             = { default = '#232627', disabled = '#A0A2A2' },
+  bright_text      = '#000000', --'#FFFFFF',
+  background       = '#FCFCFC',
+  alternate        = '#EFF0F1', -- an alternate background color for list rows
+  highlight        = { active = '#3DAEE9', inactive = '#C2E0F5' },
+  highlighted_text = { active = '#FCFCFC', inactive = '#232627' },
+}
+
+-- window colors
+-- { default, active, inactive, disabled }
+theme['window']    = {
+  text             = '#232627',
+  background       = '#EFF0F1'
+}
+
+-- button colors
+-- { default, active, inactive, disabled, checked, pressed }
+theme['button']    = {
+  text             = { default = '#232627', inactive = '#232627', disabled = '#A0A2A2' },
+  background       = { default = '#EFF0F1', checked = '#EFF0F1', pressed = '#E3E5E7' }
+}
+
+-- commit list colors
+-- { default, active, inactive, disabled }
+theme['commits']   = {
+  text             = '#232627',
+  bright_text      = '#000000',
+  background       = '#FCFCFC',
+  alternate        = '#EFF0F1', -- an alternate background color for list rows
+  highlight        = { active = '#3DAEE9', inactive = '#C2E0F5' },
+  highlighted_text = { active = '#FCFCFC', inactive = '#232627' },
+  highlighted_bright_text = { active = '#FFFFFF', inactive = '#FFFFFF' }
+}
+
+-- file list colors
+-- { default, active, inactive, disabled }
+theme['files']     = {
+  text             = '#232627',
+  background       = '#FCFCFC',
+  alternate        = '#EFF0F1', -- an alternate background color for list rows
+  highlight        = { active = '#3DAEE9', inactive = '#C2E0F5' },
+  highlighted_text = { active = '#FCFCFC', inactive = '#232627' },
+}
+
+-- status badge colors
+-- { normal, selected, conflicted, head, notification }
+theme['badge']     = {
+  foreground       = {
+    normal         = '#FFFFFF',
+    selected       = '#6C6C6C'
+  },
+  background       = {
+    normal         = '#A6ACB6', -- the default color
+    selected       = '#FFFFFF', -- the color when a list item is selected
+    conflicted     = '#D22222', -- the color of conflicted items
+    head           = '#6F7379', -- a bolder color to indicate the HEAD
+    notification   = '#FF0000'  -- the color of toolbar notifications badges
+  }
+}
+
+-- blame margin heatmap background colors
+theme['blame'] = {
+  cold             = '#C0C0FF',
+  hot              = '#FFC0C0'
+}
+
+-- graph edge colors
+theme['graph']     = {
+  edge1            = '#53AFEC',
+  edge2            = '#82DA2A',
+  edge3            = '#DA2ADA',
+  edge4            = '#DA822A',
+  edge5            = '#2ADADA',
+  edge6            = '#DA2A82',
+  edge7            = '#84A896',
+  edge8            = '#2ADA82',
+  edge9            = '#822ADA',
+  edge10           = '#66D1E0',
+  edge11           = '#D3C27E',
+  edge12           = '#95CB80',
+  edge13           = '#50D4BE',
+  edge14           = '#2ADA82',
+  edge15           = '#DA822A'
+}
+
+-- checkbox colors
+-- { default, active, inactive, disabled }
+theme['checkbox']  = {
+  text             = '#232627',
+  fill             = '#FCFCFC',
+  outline          = '#EFF0F1'
+}
+
+-- commit editor colors
+theme['commiteditor'] = {
+  spellerror       = '#FF0000', -- spell check error
+  spellignore      = '#A0A0A4', -- spell check ignored word(s)
+  lengthwarning    = '#EFF0F1'  -- line length limit warning (background)
+}
+
+-- diff view colors
+theme['diff']      = {
+  addition         = '#DCFFDC', -- added lines
+  deletion         = '#FFDCDC', -- deleted lines
+  plus             = '#45CC45', -- plus icon
+  minus            = '#F28080', -- minus icon
+  ours             = '#DCFFFF', -- ours conflict lines
+  theirs           = '#FFDCFF', -- theirs conflict lines
+  word_addition    = '#B0F2B0', -- added words
+  word_deletion    = '#F2B0B0', -- deleted words
+  note             = '#000000', -- note squiggle
+  warning          = '#FFFF00', -- warning background
+  error            = '#FF0000'  -- error background
+}
+
+-- link colors
+-- { default, active, inactive, disabled }
+theme['link']      = {
+  link             = '#2980B9',
+  link_visited     = '#7F8C8D'
+}
+
+-- menubar background color
+theme['menubar']   = {
+  text             = '#232627',
+  background       = '#FCFCFC'
+}
+
+-- tabbar background color (uncomment lines to customize)
+theme['tabbar']   = {
+  -- text             = theme['widget']['text'],
+  -- base             = theme['palette']['dark'],
+  -- selected         = theme['window']['background'],
+}
+
+-- remote comment colors
+theme['comment']   = {
+  background       = '#FCFCFC',
+  body             = '#C2E0F5',
+  author           = '#3DAEE9',
+  timestamp        = '#232627'
+}
+
+-- star fill color
+theme['star']      = {
+  fill             = '#FFCE6D'
+}
+
+-- titlebar background color (currently only supported on macOS)
+theme['titlebar']  = {
+  background       = '#FCFCFC'
+}
+
+-- popup tooltip colors
+-- { default, active, inactive, disabled }
+theme['tooltip']   = {
+  text             = '#FCFCFC',
+  background       = '#232627'
+}
+
+-- editor styles
+-- Styles are composed of a string like:
+--   fore:<color>,back:<color>,bold,italics,underline
+-- Symbolic style names are allowed:
+--   $(style.name)
+-- http://www.scintilla.org/MyScintillaDoc.html#Styling
+
+-- colors
+theme.property['color.red']          = '#800000'
+theme.property['color.yellow']       = '#808000'
+theme.property['color.green']        = '#008000'
+theme.property['color.teal']         = '#008080'
+theme.property['color.purple']       = '#800080'
+theme.property['color.orange']       = '#B08000'
+theme.property['color.blue']         = '#000080'
+theme.property['color.black']        = '#000000'
+theme.property['color.grey']         = '#808080'
+theme.property['color.white']        = '#FFFFFF'
+
+-- styles
+theme.property['style.bracebad']     = '$(style.nothing)'
+theme.property['style.bracelight']   = '$(style.nothing)'
+theme.property['style.calltip']      = '$(style.nothing)'
+theme.property['style.class']        = '$(style.nothing)'
+theme.property['style.comment']      = 'fore:#0000FF,italics'
+theme.property['style.constant']     = '$(style.keyword)'
+theme.property['style.controlchar']  = '$(style.nothing)'
+theme.property['style.default']      = 'fore:$(color.black),back:$(color.white)'
+
+theme.property['style.embedded']     = '$(style.nothing)'
+theme.property['style.error']        = 'fore:#FF0000'
+theme.property['style.function']     = '$(style.label)'
+theme.property['style.identifier']   = '$(style.nothing)'
+theme.property['style.indentguide']  = '$(style.nothing)'
+theme.property['style.keyword']      = 'fore:$(color.blue),bold'
+theme.property['style.label']        = 'fore:$(color.red)'
+theme.property['style.linenumber']   = 'fore:$(color.black),back:#DCDCDC'
+theme.property['style.nothing']      = ''
+theme.property['style.number']       = 'fore:$(color.teal)'
+theme.property['style.operator']     = 'fore:$(color.black),bold'
+theme.property['style.preprocessor'] = 'fore:$(color.green),bold'
+theme.property['style.regex']        = '$(style.nothing)'
+theme.property['style.string']       = 'fore:#CC0000'
+
+theme.property['style.type']         = 'fore:$(color.blue)'
+theme.property['style.variable']     = '$(style.label)'
+theme.property['style.whitespace']   = '$(style.nothing)'

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -27,6 +27,7 @@
 #include <QNetworkReply>
 #include <QOperatingSystemVersion>
 #include <QSettings>
+#include <QStyle>
 #include <QTimer>
 #include <QTranslator>
 #include <QUrlQuery>
@@ -152,12 +153,17 @@ Application::Application(int &argc, char **argv, bool haltOnParseError)
   // Set pathspec filter.
   mPathspec = parser.value("filter");
 
+#if defined(Q_OS_WIN)
+  // Load default palette.
+  QApplication::setPalette(QApplication::style()->standardPalette());
+#endif
+
   // Initialize theme.
   mTheme.reset(Theme::create(parser.value("theme")));
   setStyle(mTheme->style());
   setStyleSheet(mTheme->styleSheet());
 
-  // Read translation settings
+  // Read translation settings.
   QSettings settings;
   if ((!settings.value("translation/disable", false).toBool()) &&
       (!parser.isSet("no-translation"))) {

--- a/src/app/CustomTheme.cpp
+++ b/src/app/CustomTheme.cpp
@@ -246,7 +246,8 @@ QString CustomTheme::styleSheet() const
     "  border-bottom: 1px solid palette(window)"
     "}"
 
-    "CommitDetail QToolButton, HunkWidget QToolButton {"
+    "CommitDetail QToolButton,"
+    "HunkWidget QToolButton {"
     "  border: 1px solid palette(shadow);"
     "  border-radius: 4px"
     "}"
@@ -400,11 +401,10 @@ QPalette CustomTheme::commitList()
   QVariantMap commitList = mMap.value("commits").toMap();
 
   QPalette palette;
-  setPaletteColors(palette, QPalette::Base, commitList.value("background"));
-
   setPaletteColors(palette, QPalette::Text, commitList.value("text"));
   setPaletteColors(palette, QPalette::BrightText, commitList.value("bright_text"));
-
+  setPaletteColors(palette, QPalette::Base, commitList.value("background"));
+  setPaletteColors(palette, QPalette::AlternateBase, commitList.value("alternate"));
   setPaletteColors(palette, QPalette::Highlight, commitList.value("highlight"));
   setPaletteColors(palette, QPalette::HighlightedText, commitList.value("highlighted_text"));
   setPaletteColors(palette, QPalette::WindowText, commitList.value("highlighted_bright_text"));
@@ -446,9 +446,9 @@ QPalette CustomTheme::fileList()
   QVariantMap fileList = mMap.value("files").toMap();
 
   QPalette palette;
+  setPaletteColors(palette, QPalette::Text, fileList.value("text"));
   setPaletteColors(palette, QPalette::Base, fileList.value("background"));
   setPaletteColors(palette, QPalette::AlternateBase, fileList.value("alternate"));
-  setPaletteColors(palette, QPalette::Text, fileList.value("text"));
   setPaletteColors(palette, QPalette::Highlight, fileList.value("highlight"));
   setPaletteColors(palette, QPalette::HighlightedText,
                    fileList.value("highlighted_text"));
@@ -489,6 +489,8 @@ QColor CustomTheme::star()
 #ifndef Q_OS_MAC
 void CustomTheme::polishWindow(QWindow *window) const
 {
+  Q_UNUSED(window)
+
   // FIXME: Change title bar color?
 }
 #endif

--- a/src/app/Theme.cpp
+++ b/src/app/Theme.cpp
@@ -22,7 +22,7 @@ class Style : public QProxyStyle
 {
 public:
   Style(const Theme *theme)
-    : mTheme(theme)
+    : QProxyStyle("fusion"), mTheme(theme)
   {}
 
   void drawPrimitive(
@@ -81,330 +81,7 @@ QStyle *Theme::style() const
 
 QString Theme::styleSheet() const
 {
-  if (mDark) {
-    return
-      "QSplitter::handle {"
-      "  border-left: 1px solid palette(light)"
-      "}"
-
-      "ColumnView, ColumnView QAbstractItemView {"
-      "  background: palette(base);"
-      "  border-right: 1px solid palette(light)"
-      "}"
-
-      "DetailView QStackedWidget {"
-      "  background: palette(base)"
-      "}"
-      "DetailView #separator {"
-      "  border-top: 1px solid palette(midlight)"
-      "}"
-      "CommitEditor {"
-      "  background: palette(window)"
-      "}"
-
-      "DiffView {"
-      "  background: palette(mid)"
-      "}"
-      "DiffView FileWidget {"
-      "  background: palette(window)"
-      "}"
-      "DiffView HunkWidget {"
-      "  border-top: 1px solid palette(mid)"
-      "}"
-      "DiffView HunkWidget QLabel {"
-      "  color: palette(bright-text)"
-      "}"
-
-      "FileList {"
-      "  border-top: 1px solid palette(midlight)"
-      "}"
-      "FileList QToolButton:pressed {"
-      "  background: #6C6C6C"
-      "}"
-
-      "FindWidget {"
-      "  background: palette(window)"
-      "}"
-      "FindWidget QToolButton {"
-      "  border: 1px solid #A2A2A2;"
-      "  border-radius: 4px"
-      "}"
-      "FindWidget QToolButton:pressed {"
-      "  background: #575757;"
-      "}"
-      "FindWidget QLineEdit {"
-      "  border: 1px solid #A2A2A2"
-      "}"
-
-      "Footer {"
-      "  background: #3C3C3C;"
-      "  border: 1px solid #7F7F7F"
-      "}"
-      "Footer QToolButton {"
-      "  background: #3C3C3C;"
-      "  margin-left: 1px;"
-      "  border: 1px solid #7F7F7F;"
-      "  border-left: none"
-      "}"
-      "Footer QToolButton:pressed {"
-      "  background: #575757;"
-      "  margin-left: -1px"
-      "}"
-
-      "ExpandButton {"
-      "  background: #656565;"
-      "  border-radius: 4px;"
-      "  padding: 0px 4px 0px 4px"
-      "}"
-      "ExpandButton:pressed {"
-      "  background: #7B7B7B"
-      "}"
-
-      "PathspecWidget ExpandButton, ReferenceWidget ExpandButton {"
-      "  border-radius: 0px;"
-      "  padding: 0px 0px 0px 0px"
-      "}"
-
-      "TabWidget::pane {"
-      "  border-top: 1px solid palette(light)" // FIXME: Color doesn't work.
-      "}"
-      "TabBar::tab {"
-      "  color: palette(text);"
-      "  border-top: 1px solid #484848;"
-      "  border-left: 1px solid #545454;"
-      "  background: #202020"
-      "}"
-      "TabBar::tab:selected {"
-      "  background: #303030"
-      "}"
-      "TabBar::tab:first {"
-      "  border-left: none"
-      "}"
-
-      "TreeWidget QColumnView {"
-      "  border-top: 1px solid palette(light);"
-      "  border-bottom: 1px solid palette(light)"
-      "}"
-
-      "QToolButton {"
-      "  color: #505050"
-      "}"
-      "QToolButton:active {"
-      "  color: #E8E8E8"
-      "}"
-      "QToolButton:disabled {"
-      "  color: #B0B0B0"
-      "}"
-
-      "ToolBar QToolButton {"
-      "  background: #3D3D3D"
-      "}"
-      "ToolBar QToolButton:active {"
-      "  background: #656565"
-      "}"
-      "ToolBar QToolButton#first, ToolBar QToolButton#middle {"
-      "  border-right: 1px solid #585858"
-      "}"
-      "ToolBar QToolButton:pressed {"
-      "  background: #7B7B7B"
-      "}"
-      "ToolBar QLineEdit {"
-      "  background: #3D3D3D"
-      "}"
-      "ToolBar QLineEdit:active {"
-      "  background: #656565"
-      "}"
-
-      "CommitDetail QToolButton,"
-      "HunkWidget QToolButton,"
-      "FileWidget QToolButton {"
-      "  border: 1px solid #363636;"
-      "  border-radius: 4px"
-      "}"
-      "CommitDetail QToolButton:pressed,"
-      "HunkWidget QToolButton:pressed,"
-      "FileWidget QToolButton:pressed {"
-      "  background: #7B7B7B"
-      "}"
-
-      "CommitToolBar QToolButton:pressed {"
-      "  background: #6C6C6C;"
-      "  color: white"
-      "}";
-  }
-
-  return
-    "ColumnView, ColumnView QAbstractItemView {"
-    "  background: palette(base);"
-    "  border-right: 1px solid palette(light)"
-    "}"
-
-    "DetailView QStackedWidget {"
-    "  background: palette(base)"
-    "}"
-    "DetailView #separator {"
-    "  border-top: 1px solid palette(light)"
-    "}"
-
-    "DiffView {"
-    "  background: palette(dark)"
-    "}"
-    "DiffView FileWidget {"
-    "  background: #E4E8EE"
-    "}"
-    "DiffView HunkWidget {"
-    "  background: palette(midlight);"
-    "  border-top: 1px solid palette(dark)"
-    "}"
-    "DiffView HunkWidget QLabel {"
-    "  color: #4F4F4F"
-    "}"
-
-    "FileList {"
-    "  border-top: 1px solid palette(light)"
-    "}"
-    "FileList QToolButton:pressed {"
-    "  background: #E2E2E2"
-    "}"
-
-    "FindWidget {"
-    "  background: qlineargradient("
-    "    x1: 0, y1: 0, x2: 0, y2: 1,"
-    "    stop: 0 #EEEEEE, stop: 1 #DADADA)"
-    "}"
-    "FindWidget QToolButton {"
-    "  border: 1px solid #A2A2A2;"
-    "  border-radius: 4px"
-    "}"
-    "FindWidget QToolButton:pressed {"
-    "  background: rgba(0, 0, 0, 20%)"
-    "}"
-    "FindWidget QLineEdit {"
-    "  border: 1px solid #A2A2A2"
-    "}"
-
-    "Footer {"
-    "  background-color: qlineargradient("
-    "    x1:0, y1: 0, x2: 0, y2: 1, stop: 0 #FCFCFC, stop: 1 #F4F4F4);"
-    "  border: 1px solid #A6A6A6;"
-    "  border-top: none"
-    "}"
-    "Footer QToolButton {"
-    "  background-color: qlineargradient("
-    "    x1:0, y1: 0, x2: 0, y2: 1, stop: 0 #FCFCFC, stop: 1 #F4F4F4);"
-    "  margin-left: 1px;"
-    "  border: 1px solid #A6A6A6;"
-    "  border-left: none;"
-    "  border-top: none"
-    "}"
-    "Footer QToolButton:pressed {"
-    "  background-color: qlineargradient("
-    "    x1:0, y1: 0, x2: 0, y2: 1, stop: 0 #BCBCBC, stop: 1 #B4B4B4);"
-    "  margin-left: -1px"
-    "}"
-    "SideBar Footer {"
-    "  border-top: 1px solid #A6A6A6"
-    "}"
-    "SideBar Footer QToolButton {"
-    "  border-top: 1px solid #A6A6A6"
-    "}"
-
-    "ExpandButton {"
-    "  background: palette(base);"
-    "  border: 1px solid palette(dark);"
-    "  border-radius: 4px;"
-    "  padding: 0px 4px 0px 4px"
-    "}"
-    "ExpandButton:pressed {"
-    "  background: palette(light)"
-    "}"
-
-    "PathspecWidget ExpandButton, ReferenceWidget ExpandButton {"
-    "  background-color: qlineargradient("
-    "    x1:0, y1: 0, x2: 0, y2: 1, stop: 0 #FCFCFC, stop: 1 #F4F4F4);"
-    "  border-radius: 0px;"
-    "  padding: 0px 0px 0px 0px"
-    "}"
-    "PathspecWidget ExpandButton:pressed, ReferenceWidget ExpandButton:pressed {"
-    "  background-color: qlineargradient("
-    "    x1:0, y1: 0, x2: 0, y2: 1, stop: 0 #BCBCBC, stop: 1 #B4B4B4)"
-    "}"
-
-    "TabBar::tab {"
-    "  border-top: 1px solid #DBDBDB;"
-    "  border-left: 1px solid #DBDBDB;"
-    "  border-bottom: 1px solid #D2D2D2;"
-    "  background: #ECECEC"
-    "}"
-    "TabBar::tab:active {"
-    "  border-top: 1px solid #A0A0A0;"
-    "  border-left: 1px solid #A0A0A0;"
-    "  border-bottom: 1px solid #9C9C9C;"
-    "  background: qlineargradient("
-    "    x1:0, y1:0, x2:0, y2:1,"
-    "    stop:0 #BBBBBB, stop:1 #B3B3B3)"
-    "}"
-    "TabBar::tab:selected {"
-    "  background: #F6F6F6"
-    "}"
-    "TabBar::tab:active:selected {"
-    "  border-top: 1px solid #B9B9B9;"
-    "  background: qlineargradient("
-    "    x1:0, y1:0, x2:0, y2:1,"
-    "    stop:0 #D7D7D7, stop:1 #CFCFCF)"
-    "}"
-    "TabBar::tab:first {"
-    "  border-left: none"
-    "}"
-
-    "TreeWidget QColumnView {"
-    "  border-top: 1px solid palette(light);"
-    "  border-bottom: 1px solid palette(light)"
-    "}"
-
-    "QToolButton {"
-    "  color: #C0C0C0"
-    "}"
-    "QToolButton:active {"
-    "  color: #686868"
-    "}"
-    "QToolButton:disabled {"
-    "  color: #C6C6C6"
-    "}"
-
-    "ToolBar QToolButton {"
-    "  background: palette(base);"
-    "  border: 1px solid #DCDCDC"
-    "}"
-    "ToolBar QToolButton:active {"
-    "  border: 1px solid #CCCCCC"
-    "}"
-    "ToolBar QToolButton:pressed {"
-    "  background: #E2E2E2"
-    "}"
-    "ToolBar QLineEdit {"
-    "  border: 1px solid #DCDCDC"
-    "}"
-    "ToolBar QLineEdit:active {"
-    "  border: 1px solid #CCCCCC"
-    "}"
-
-    "CommitDetail QToolButton,"
-    "HunkWidget QToolButton,"
-    "FileWidget QToolButton {"
-    "  border: 1px solid #DCDCDC;"
-    "  border-radius: 4px"
-    "}"
-    "CommitDetail QToolButton:pressed,"
-    "HunkWidget QToolButton:pressed,"
-    "FileWidget QToolButton:pressed {"
-    "  background: #E2E2E2"
-    "}"
-
-    "CommitToolBar QToolButton:pressed {"
-    "  background: #6C6C6C;"
-    "  color: white"
-    "}";
+  return QString();
 }
 
 void Theme::polish(QPalette &palette) const
@@ -445,7 +122,7 @@ QColor Theme::badge(BadgeRole role, BadgeState state)
             return "#52A500";
 
           case BadgeState::Notification:
-            return "#D00000";
+            return "#8C2026";
         }
     }
   }
@@ -472,7 +149,7 @@ QColor Theme::badge(BadgeRole role, BadgeState state)
           return "#D22222";
 
         case BadgeState::Head:
-          return QColor("#A6ACB6").darker(150);
+          return "#6F7379";
 
         case BadgeState::Notification:
           return Qt::red;
@@ -507,21 +184,12 @@ QPalette Theme::commitList()
 {
   QPalette palette;
   QColor bright = palette.color(QPalette::BrightText);
-
-  // highlight
-#ifdef Q_OS_WIN
-  palette.setColor(QPalette::Active, QPalette::HighlightedText, Qt::black);
-  palette.setColor(QPalette::Inactive, QPalette::HighlightedText, Qt::black);
-  palette.setColor(QPalette::Active, QPalette::WindowText, bright);
-  palette.setColor(QPalette::Inactive, QPalette::WindowText, bright);
-#else
   QColor inactive = mDark ? Qt::white : Qt::black;
+
   palette.setColor(QPalette::Active, QPalette::HighlightedText, Qt::white);
   palette.setColor(QPalette::Inactive, QPalette::HighlightedText, inactive);
   palette.setColor(QPalette::Active, QPalette::WindowText, "#C0C0C0");
   palette.setColor(QPalette::Inactive, QPalette::WindowText, bright);
-#endif
-
   return palette;
 }
 
@@ -614,7 +282,7 @@ void Theme::drawCloseButton(
   QPainter *painter)
 {
   qreal in = 3.5;
-  qreal out = 6.0;
+  qreal out = 8.0;
   QRect rect = option->rect;
   qreal x = rect.x() + (rect.width() / 2);
   qreal y = rect.y() + (rect.height() / 2);
@@ -627,14 +295,15 @@ void Theme::drawCloseButton(
     painter->save();
     painter->setPen(Qt::NoPen);
     bool selected = (option->state & QStyle::State_Selected);
-    painter->setBrush(QColor(selected ? "#BEBEBE" : "#9A9A9A"));
+    painter->setBrush(QColor(selected ? QPalette().color(QPalette::Highlight) :
+                                        QPalette().color(QPalette::Base)));
     QRectF background(x - out, y - out, 2 * out, 2 * out);
     painter->drawRoundedRect(background, 2.0, 2.0);
     painter->restore();
   }
 
   // Draw x.
-  painter->setPen(QPen(QColor("#646464"), 1.5));
+  painter->setPen(QPen(QPalette().color(QPalette::WindowText), 1.5));
   painter->drawLine(QPointF(x - in, y - in), QPointF(x + in, y + in));
   painter->drawLine(QPointF(x - in, y + in), QPointF(x + in, y - in));
   painter->restore();
@@ -657,8 +326,10 @@ Theme *Theme::create(const QString &defaultName)
     name = settings->value("window/theme").toString();
   }
 
-  if (CustomTheme::isValid(name) && name != "Default")
+  // Load custom theme.
+  if (CustomTheme::isValid(name))
     return new CustomTheme(name);
 
+  // Use Qt theme.
   return new Theme;
 }

--- a/src/dialogs/ThemeDialog.cpp
+++ b/src/dialogs/ThemeDialog.cpp
@@ -112,10 +112,10 @@ private:
 ThemeDialog::ThemeDialog(QWidget *parent)
   : QDialog(parent)
 {
-  setWindowTitle("Pick a theme for Gittyup");
+  setWindowTitle(tr("Pick a theme for Gittyup"));
   
   ThemeButton *native = new ThemeButton(
-    tr("Native Theme"),
+    tr("Default Theme"),
     QIcon(":/native.png"),
     tr("A flexible look matching system colors")
   );


### PR DESCRIPTION
Default.lua: reverse engineered native theme
Dark.lua: the existing dark theme
Theme.cpp: creates the native theme - removed styleSheet() to avoid future maintenance.
A native theme is only shown, when the selected theme fails to loaded.
CustomTheme.cpp: the one and only remaining styleSheet() for future development - used for loaded themes