### PR TITLE
Change flatpak branch in CI

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -35,6 +35,7 @@ jobs:
         bundle: com.github.Murmele.Gittyup.flatpak
         manifest-path: com.github.Murmele.Gittyup/com.github.Murmele.Gittyup.yml
         cache: false
+        branch: development
     - name: Upload Flatpak package
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Change the flatpak branch of the flatpak package created by the CI. So it can be installed in parallel with the stable version on the same system