### PR TITLE
Fix DoubleTreeView Blame button

### DIFF
--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -10,27 +10,28 @@
 #include "DoubleTreeWidget.h"
 #include "BlameEditor.h"
 #include "DiffTreeModel.h"
+#include "StatePushButton.h"
 #include "TreeProxy.h"
 #include "TreeView.h"
 #include "ViewDelegate.h"
-#include "StatePushButton.h"
 #include "DiffView/DiffView.h"
-
-#include <QVBoxLayout>
-#include <QHBoxLayout>
 #include <QLabel>
+#include <QLayout>
 #include <QPushButton>
-#include <QSpacerItem>
+#include <QSettings>
 #include <QStackedWidget>
-#include <QButtonGroup>
 
 namespace {
 
-const QString kNameFmt = "<p style='font-size: large'>%1</p>";
-const QString kLabelFmt = "<p style='color: gray; font-weight: bold'>%1</p>";
-QString kExpandAll = QString(QObject::tr("Expand all"));
-QString kCollapseAll = QString(QObject::tr("Collapse all"));
-QString kUnstagedFiles = QString(QObject::tr("Unstaged Files"));
+const QString kSplitterKey = QString("diffsplitter");
+const QString kExpandAll = QString(QObject::tr("Expand all"));
+const QString kCollapseAll = QString(QObject::tr("Collapse all"));
+const QString kStagedFiles = QString(QObject::tr("Staged Files"));
+const QString kUnstagedFiles = QString(QObject::tr("Unstaged Files"));
+const QString kCommitedFiles = QString(QObject::tr("Committed Files"));
+
+const int kBlameIndex = 0;
+const int kDiffIndex = 1;
 
 class SegmentedButton : public QWidget
 {
@@ -53,14 +54,6 @@ public:
 
     mLayout->addWidget(button);
     mButtons.addButton(button, mButtons.buttons().size());
-
-    if (mButtons.buttons().size() > 1) {
-      mButtons.buttons().first()->setObjectName("first");
-      mButtons.buttons().last()->setObjectName("last");
-    }
-
-    for (int i = 1; i < mButtons.buttons().size() - 1; ++i)
-      mButtons.buttons().at(i)->setObjectName("middle");
   }
 
   const QButtonGroup *buttonGroup() const
@@ -78,43 +71,48 @@ private:
 DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
   : ContentWidget(parent)
 {
-  // first column
-  // top (Buttons to switch between Blame editor and DiffView)
-  SegmentedButton* segmentedButton = new SegmentedButton(this);
-  QPushButton* blameView = new QPushButton("Blame", this);
-  segmentedButton->addButton(blameView, "Blame", true);
-  QPushButton* diffView = new QPushButton("Diff", this);
-  segmentedButton->addButton(diffView, "Diff", true);
-  diffView->setChecked(true);
-  // bottom (Stacked widget with Blame editor and DiffView)
-  QVBoxLayout* fileViewLayout = new QVBoxLayout();
+  // First column
+  // Top (buttons to switch between BlameEditor and DiffView)
+  SegmentedButton *viewButtons = new SegmentedButton(this);
+  QPushButton *blameViewButton = new QPushButton(tr("Blame"), this);
+  viewButtons->addButton(blameViewButton, tr("Show Blame Editor"), true);
+  QPushButton *diffViewButton = new QPushButton(tr("Diff"), this);
+  diffViewButton->setChecked(true);
+  viewButtons->addButton(diffViewButton, tr("Show Diff Editor"), true);
+
+  QHBoxLayout *buttonLayout = new QHBoxLayout();
+  buttonLayout->addStretch();
+  buttonLayout->addWidget(viewButtons);
+  buttonLayout->addStretch();
+
+  mViewButtonGroup = viewButtons->buttonGroup();
+
+  // Bottom (stacked widget with BlameEditor and DiffView)
+  QVBoxLayout *fileViewLayout = new QVBoxLayout();
   mFileView = new QStackedWidget(this);
   mEditor = new BlameEditor(repo, this);
   mDiffView = new DiffView(repo, this);
+
   int index = mFileView->addWidget(mEditor);
   assert(index == DoubleTreeWidget::Blame);
   index = mFileView->addWidget(mDiffView);
   assert(index == DoubleTreeWidget::Diff);
+
   mEditor->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   mDiffView->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-  const QButtonGroup* viewGroup = segmentedButton->buttonGroup();
-  QHBoxLayout* buttonLayout = new QHBoxLayout();
-  buttonLayout->addItem(new QSpacerItem(279, 20, QSizePolicy::Expanding, QSizePolicy::Minimum));
-  buttonLayout->addWidget(segmentedButton);
-  buttonLayout->addItem(new QSpacerItem(279, 20, QSizePolicy::Expanding, QSizePolicy::Minimum));
-
   fileViewLayout->addLayout(buttonLayout);
   fileViewLayout->addWidget(mFileView);
-  mFileView->setCurrentIndex(1);
+  mFileView->setCurrentIndex(kDiffIndex);
   mFileView->show();
+
   QWidget* fileView = new QWidget(this);
   fileView->setLayout(fileViewLayout);
 
-  // second column
-  // staged files
+  // Second column
+  // Staged files
   QVBoxLayout* vBoxLayout = new QVBoxLayout();
-  QLabel* label = new QLabel(tr("Staged Files"));
+
   stagedFiles = new TreeView(this, "Staged");
   stagedFiles->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
   mDiffTreeModel = new DiffTreeModel(repo, this);
@@ -126,19 +124,19 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
   stagedFiles->setItemDelegateForColumn(0, new ViewDelegate());
 
   QHBoxLayout* hBoxLayout = new QHBoxLayout();
-  collapseButtonStagedFiles = new StatePushButton(kCollapseAll, kExpandAll, this);
-  hBoxLayout->addWidget(collapseButtonStagedFiles);
-  hBoxLayout->addItem(new QSpacerItem(40,20, QSizePolicy::Expanding, QSizePolicy::Minimum));
+  QLabel* label = new QLabel(kStagedFiles);
+  hBoxLayout->addWidget(label);
+  hBoxLayout->addStretch();
+  mCollapseButtonStagedFiles = new StatePushButton(kCollapseAll, kExpandAll, this);
+  hBoxLayout->addWidget(mCollapseButtonStagedFiles);
 
-  vBoxLayout->addWidget(label);
   vBoxLayout->addLayout(hBoxLayout);
   vBoxLayout->addWidget(stagedFiles);
   mStagedWidget = new QWidget();
   mStagedWidget->setLayout(vBoxLayout);
 
-  // unstaged files
+  // Unstaged files
   vBoxLayout = new QVBoxLayout();
-  mUnstagedCommitedFiles = new QLabel(kUnstagedFiles);
   unstagedFiles = new TreeView(this, "Unstaged");
   unstagedFiles->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
   TreeProxy* treewrapperUnstaged = new TreeProxy(false, this);
@@ -148,45 +146,54 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
   unstagedFiles->setItemDelegateForColumn(0, new ViewDelegate());
 
   hBoxLayout = new QHBoxLayout();
-  collapseButtonUnstagedFiles = new StatePushButton(kCollapseAll, kExpandAll, this);
-  hBoxLayout->addWidget(collapseButtonUnstagedFiles);
-  hBoxLayout->addItem(new QSpacerItem(40,20, QSizePolicy::Expanding, QSizePolicy::Minimum));
+  mUnstagedCommitedFiles = new QLabel(kUnstagedFiles);
+  hBoxLayout->addWidget(mUnstagedCommitedFiles);
+  hBoxLayout->addStretch();
+  mCollapseButtonUnstagedFiles = new StatePushButton(kCollapseAll, kExpandAll, this);
+  hBoxLayout->addWidget(mCollapseButtonUnstagedFiles);
 
-  vBoxLayout->addWidget(mUnstagedCommitedFiles);
   vBoxLayout->addLayout(hBoxLayout);
   vBoxLayout->addWidget(unstagedFiles);
   QWidget* unstagedWidget = new QWidget();
   unstagedWidget->setLayout(vBoxLayout);
 
-  // splitter between the staged and unstaged section
+  // Splitter between the staged and unstaged section
   QSplitter *treeViewSplitter = new QSplitter(Qt::Vertical, this);
   treeViewSplitter->setHandleWidth(10);
   treeViewSplitter->addWidget(mStagedWidget);
   treeViewSplitter->addWidget(unstagedWidget);
+  treeViewSplitter->setStretchFactor(0, 1);
   treeViewSplitter->setStretchFactor(1, 1);
 
-  // splitter between editor/diffview and TreeViews
-  QSplitter* splitter = new QSplitter(Qt::Horizontal, this);
-  splitter->setHandleWidth(0);
-  splitter->addWidget(fileView);
-  splitter->addWidget(treeViewSplitter);
-  splitter->setStretchFactor(1, 1);
+  // Splitter between editor/diffview and TreeViews
+  QSplitter *viewSplitter = new QSplitter(Qt::Horizontal, this);
+  viewSplitter->setHandleWidth(0);
+  viewSplitter->addWidget(fileView);
+  viewSplitter->addWidget(treeViewSplitter);
+  viewSplitter->setStretchFactor(0, 3);
+  viewSplitter->setStretchFactor(1, 1);
+  connect(viewSplitter, &QSplitter::splitterMoved, this, [viewSplitter] {
+    QSettings().setValue(kSplitterKey, viewSplitter->saveState());
+  });
+
+  // Restore splitter state.
+  viewSplitter->restoreState(QSettings().value(kSplitterKey).toByteArray());
 
   QVBoxLayout* layout = new QVBoxLayout(this);
   layout->setContentsMargins(0,0,0,0);
-  layout->addWidget(splitter);
+  layout->addWidget(viewSplitter);
 
   setLayout(layout);
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
-  connect(viewGroup, QOverload<int>::of(&QButtonGroup::idClicked), [this] (int id) {
+  connect(mViewButtonGroup, QOverload<int>::of(&QButtonGroup::idClicked), this, [this](int id) {
     mFileView->setCurrentIndex(id);
   });
 #else
-  connect(viewGroup, QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
-          [this, viewGroup](QAbstractButton *button)
+  connect(mViewButtonGroup, QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
+          [this](QAbstractButton *button)
   {
-    mFileView->setCurrentIndex(viewGroup->id(button));
+    mFileView->setCurrentIndex(mViewButtonGroup->id(button));
   });
 #endif
 
@@ -198,8 +205,8 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
   connect(unstagedFiles, &TreeView::fileSelected, this, &DoubleTreeWidget::fileSelected);
   connect(unstagedFiles, &TreeView::collapseCountChanged, this, &DoubleTreeWidget::collapseCountChanged);
 
-  connect(collapseButtonStagedFiles, &StatePushButton::clicked, this, &DoubleTreeWidget::toggleCollapseStagedFiles);
-  connect(collapseButtonUnstagedFiles, &StatePushButton::clicked, this, &DoubleTreeWidget::toggleCollapseUnstagedFiles);
+  connect(mCollapseButtonStagedFiles, &StatePushButton::clicked, this, &DoubleTreeWidget::toggleCollapseStagedFiles);
+  connect(mCollapseButtonUnstagedFiles, &StatePushButton::clicked, this, &DoubleTreeWidget::toggleCollapseUnstagedFiles);
 
   connect(repo.notifier(), &git::RepositoryNotifier::indexChanged, this, [this] (const QStringList &paths) {
     mDiffTreeModel->refresh(paths);
@@ -219,6 +226,7 @@ QModelIndex DoubleTreeWidget::selectedIndex() const
   if (!indexes.isEmpty()) {
     return  proxy->mapToSource(indexes.first());
   }
+
   return QModelIndex();
 }
 
@@ -233,7 +241,8 @@ QString DoubleTreeWidget::selectedFile() const
   if (!indexes.isEmpty()) {
     return indexes.first().data(Qt::DisplayRole).toString();
   }
-  return "";
+
+  return QString();
 }
 
 /*!
@@ -246,7 +255,9 @@ void DoubleTreeWidget::setDiff(const git::Diff &diff,
                                const QString &file,
                                const QString &pathspec)
 {
-  Q_UNUSED(pathspec);
+  Q_UNUSED(file)
+  Q_UNUSED(pathspec)
+
   // Remember selection.
   storeSelection();
 
@@ -265,6 +276,10 @@ void DoubleTreeWidget::setDiff(const git::Diff &diff,
   // If statusDiff, there exist no staged/unstaged, but only
   // the commited files must be shown
   if (!diff.isValid() || diff.isStatusDiff()) {
+    mViewButtonGroup->button(kBlameIndex)->setEnabled(false);
+    mViewButtonGroup->button(kDiffIndex)->setChecked(true);
+    mFileView->setCurrentIndex(kDiffIndex);
+
     mUnstagedCommitedFiles->setText(kUnstagedFiles);
     if (diff.isValid() && diff.count() < 100)
       stagedFiles->expandAll();
@@ -273,7 +288,9 @@ void DoubleTreeWidget::setDiff(const git::Diff &diff,
 
     mStagedWidget->setVisible(true);
   } else {
-    mUnstagedCommitedFiles->setText(tr("Committed Files"));
+    mViewButtonGroup->button(kBlameIndex)->setEnabled(true);
+
+    mUnstagedCommitedFiles->setText(kCommitedFiles);
     mStagedWidget->setVisible(false);
   }
 
@@ -328,8 +345,9 @@ void DoubleTreeWidget::loadSelection()
 
 void DoubleTreeWidget::treeModelStateChanged(const QModelIndex& index, int checkState)
 {
-  Q_UNUSED(index);
-  Q_UNUSED(checkState);
+  Q_UNUSED(index)
+  Q_UNUSED(checkState)
+
   // clear editor and disable diffView when no item is selected
   QModelIndexList stagedSelections = stagedFiles->selectionModel()->selectedIndexes();
   if (stagedSelections.count())
@@ -348,9 +366,9 @@ void DoubleTreeWidget::collapseCountChanged(int count)
   TreeView* view = static_cast<TreeView*>(QObject::sender());
 
   if (view == stagedFiles)
-    collapseButtonStagedFiles->setState(count == 0);
+    mCollapseButtonStagedFiles->setState(count == 0);
   else
-    collapseButtonUnstagedFiles->setState(count == 0);
+    mCollapseButtonUnstagedFiles->setState(count == 0);
 }
 
 void DoubleTreeWidget::fileSelected(const QModelIndex &index)
@@ -410,7 +428,7 @@ void DoubleTreeWidget::loadEditorContent(const QModelIndex &index)
 
 void DoubleTreeWidget::toggleCollapseStagedFiles()
 {
-  if (collapseButtonStagedFiles->toggleState())
+  if (mCollapseButtonStagedFiles->toggleState())
     stagedFiles->expandAll();
   else
     stagedFiles->collapseAll();
@@ -418,7 +436,7 @@ void DoubleTreeWidget::toggleCollapseStagedFiles()
 
 void DoubleTreeWidget::toggleCollapseUnstagedFiles()
 {
-  if (collapseButtonUnstagedFiles->toggleState())
+  if (mCollapseButtonUnstagedFiles->toggleState())
     unstagedFiles->expandAll();
   else
     unstagedFiles->collapseAll();

--- a/src/ui/DoubleTreeWidget.h
+++ b/src/ui/DoubleTreeWidget.h
@@ -11,6 +11,7 @@
 #define DOUBLETREEWIDGET_H
 
 #include "DetailView.h" // ContentWidget
+#include <QButtonGroup>
 
 class QTreeView;
 class DiffTreeModel;
@@ -60,9 +61,11 @@ private:
   DiffTreeModel* mDiffTreeModel{nullptr};
   TreeView* stagedFiles{nullptr};
   TreeView* unstagedFiles{nullptr};
-  StatePushButton* collapseButtonStagedFiles{nullptr};
-  StatePushButton* collapseButtonUnstagedFiles{nullptr};
-  QLabel* mUnstagedCommitedFiles{nullptr};
+  StatePushButton *mCollapseButtonStagedFiles{nullptr};
+  StatePushButton *mCollapseButtonUnstagedFiles{nullptr};
+  QLabel *mUnstagedCommitedFiles{nullptr};
+
+  const QButtonGroup *mViewButtonGroup;
 
   struct SelectedFile {
     QString filename;
@@ -92,4 +95,5 @@ private:
   QStackedWidget* mFileView{nullptr};
   bool mIgnoreSelectionChange{false};
 };
+
 #endif // DOUBLETREEWIDGET_H


### PR DESCRIPTION
- Disable blame button when nothing to blame (uncommitted changes)
- Save and restore the vertical splitter position (between blame/diff and trees)
- Move "Expand all"/"Collapse all" buttons to the right

![DTV](https://user-images.githubusercontent.com/67198194/146647335-085d7650-d2f4-4601-a7b4-e711dff54e31.png)
