### PR TITLE
Sore and restore splitter positions

### DIFF
--- a/src/ui/BlameEditor.cpp
+++ b/src/ui/BlameEditor.cpp
@@ -31,6 +31,8 @@
 
 namespace {
 
+const QString kSplitterKey = QString("blamesplitter");
+
 class BlameCallbacks : public git::Blame::Callbacks
 {
 public:
@@ -79,14 +81,18 @@ BlameEditor::BlameEditor(const git::Repository &repo, QWidget *parent)
   splitter->addWidget(mEditor);
   splitter->addWidget(mMargin);
   splitter->setStretchFactor(0, 1);
+  connect(splitter, &QSplitter::splitterMoved, this, [splitter] {
+    QSettings().setValue(kSplitterKey, splitter->saveState());
+  });
+
+  // Restore splitter state.
+  splitter->restoreState(QSettings().value(kSplitterKey).toByteArray());
 
   QVBoxLayout *layout = new QVBoxLayout(this);
   layout->setContentsMargins(0,0,0,0);
   layout->setSpacing(0);
   layout->addWidget(mFind);
   layout->addWidget(splitter, 1);
-
-  // FIXME: Remember splitter position?
 
   // Handle asynchronous blame termination.
   connect(&mBlame, &QFutureWatcher<git::Blame>::finished, [this] {

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -66,7 +66,7 @@
 
 namespace {
 
-const QString kSplitterKey = "splitter";
+const QString kSplitterKey = "reposplitter";
 const QString kMsgFmt = "%1 - <span style='color: gray'>%2</span>";
 
 QString msg(const git::Commit &commit)

--- a/src/ui/TreeWidget.cpp
+++ b/src/ui/TreeWidget.cpp
@@ -23,10 +23,13 @@
 #include <QAction>
 #include <QContextMenuEvent>
 #include <QMenu>
+#include <QSettings>
 #include <QSplitter>
 #include <QVBoxLayout>
 
 namespace {
+
+const QString kSplitterKey = QString("treesplitter");
 
 const QItemSelectionModel::SelectionFlags kSelectionFlags =
   QItemSelectionModel::Clear |
@@ -53,6 +56,12 @@ TreeWidget::TreeWidget(const git::Repository &repo, QWidget *parent)
   splitter->addWidget(mView);
   splitter->addWidget(mEditor);
   splitter->setStretchFactor(1, 1);
+  connect(splitter, &QSplitter::splitterMoved, this, [splitter] {
+    QSettings().setValue(kSplitterKey, splitter->saveState());
+  });
+
+  // Restore splitter state.
+  splitter->restoreState(QSettings().value(kSplitterKey).toByteArray());
 
   QVBoxLayout *layout = new QVBoxLayout(this);
   layout->setContentsMargins(0,0,0,0);


### PR DESCRIPTION
The splitter posititon between staged and unstaged files is not stored / restored (dynamic content, a fixed splitter position might be annoying)