### PR TITLE
Load files and hunks depending on scrollbar position

### DIFF
--- a/src/editor/TextEditor.h
+++ b/src/editor/TextEditor.h
@@ -138,14 +138,14 @@ signals:
    * \param startPos Start line of selection
    * \param end End line of selection + 1
    */
-  void stageSelectedSignal(int startPos, int end, bool emitSignal=true);
+  void stageSelectedSignal(int startPos, int end);
   /*!
    * Emitted when in the context menu "unstage selected" is triggered
    * \brief unstageSelectedSignal
    * \param startPos Start line of selection
    * \param end End line of selection + 1
    */
-  void unstageSelectedSignal(int startPos, int end, bool emitSignal=true);
+  void unstageSelectedSignal(int startPos, int end);
   /*!
    * Emitted when in the context menu "revert selected" is triggered
    * \brief discardSelectedSignal

--- a/src/git/Patch.h
+++ b/src/git/Patch.h
@@ -166,7 +166,6 @@ public:
 
   static void clearConflictResolutions(const Repository &repo);
 
-private:
   /*!
    * Applies changes to hunk and store result in image
    * \brief Patch::apply
@@ -177,6 +176,7 @@ private:
    */
   void apply(QList<QList<QByteArray> > &image, int hidx, int start_line, int end_line) const;
 
+private:
   struct ConflictHunk
   {
     int line; // start line

--- a/src/git/Patch.h
+++ b/src/git/Patch.h
@@ -136,27 +136,11 @@ public:
                    int start_line,
                    int end_line,
                    const FilterList &filters = FilterList()) const;
-  QByteArray apply(int hidx, QByteArray& hunkData, const FilterList &filters = FilterList()) const;
-  QByteArray apply(int hidx, QByteArray& hunkData, QByteArray fileContent, const FilterList &filters = FilterList()) const;
-  /*!
-   * applies all hunk data to the patch.
-   * Important: The length of hunkData must match with the number of hunks in the patch!
-   * \brief apply
-   * \param hunkData hunk contents
-   * \param filters
-   * \return
-   */
-  QByteArray apply(QList<QByteArray>& hunkData, const FilterList &filters = FilterList()) const;
+  void apply(QList<QList<QByteArray> > &image,
+             int hidx,
+             int start_line, int end_line,
+             const QList<int> &ignore_lines = QList<int>()) const;
 
-  /*!
-   * Applies changes of a hunk. Used to revert changes
-   * Does not change the length of the List, so other changes can be applied too
-   * \brief apply
-   * \param image
-   * \param hidx
-   * \param hunkData
-   */
-  void apply(QList<QList<QByteArray>> &image, int hidx, QByteArray& hunkData) const;
   QByteArray generateResult(QList<QList<QByteArray>>& image, const FilterList &filters = FilterList()) const;
   static Patch fromBuffers(
     const QByteArray &oldBuffer,
@@ -165,16 +149,6 @@ public:
     const QString &newPath = QString());
 
   static void clearConflictResolutions(const Repository &repo);
-
-  /*!
-   * Applies changes to hunk and store result in image
-   * \brief Patch::apply
-   * \param image
-   * \param hunk_idx
-   * \param start_line
-   * \param end_line
-   */
-  void apply(QList<QList<QByteArray> > &image, int hidx, int start_line, int end_line) const;
 
 private:
   struct ConflictHunk

--- a/src/ui/DiffTreeModel.cpp
+++ b/src/ui/DiffTreeModel.cpp
@@ -264,8 +264,8 @@ bool DiffTreeModel::discard(const QModelIndex &index)
       if (QFileInfo(dir.filePath(name)).isDir()) {
         if (dir.cd(name))
           dir.removeRecursively();
-        } else {
-          dir.remove(name);
+      } else {
+        dir.remove(name);
       }
     } else {
       trackedPatches.append(patch.name());
@@ -287,7 +287,7 @@ bool DiffTreeModel::discard(const QModelIndex &index)
       filePatches.append(trackedPatch);
   }
 
-  if (filePatches.count()) {
+  if (!filePatches.isEmpty()) {
     int strategy = GIT_CHECKOUT_FORCE;
     auto repo = mDiff.patch(list[0]).repo(); // does not matter which index is used all are in the same repo
     if (!repo.checkout(git::Commit(), nullptr, trackedPatches, strategy))

--- a/src/ui/DiffTreeModel.cpp
+++ b/src/ui/DiffTreeModel.cpp
@@ -249,12 +249,12 @@ bool DiffTreeModel::setData(const QModelIndex &index,
       Node *node = this->node(index);
       git::Index::StagedState state = static_cast<git::Index::StagedState>(value.toInt());
 
-      if (state != git::Index::StagedState::PartiallyStaged) {
+      if (state != git::Index::PartiallyStaged) {
         node->childFiles(files);
 
-        if (state == git::Index::StagedState::Staged)
+        if (state == git::Index::Staged)
           mDiff.index().setStaged(files, true);
-        else if (state == git::Index::StagedState::Unstaged)
+        else if (state == git::Index::Unstaged)
           mDiff.index().setStaged(files, false);
       }
 
@@ -415,9 +415,9 @@ git::Index::StagedState Node::stageState(const git::Index& idx, ParentStageState
     for (auto child: mChildren) {
 
         childState = child->stageState(idx, searchingState);
-        if ((childState == git::Index::StagedState::Staged && searchingState == ParentStageState::Unstaged) ||
-            (childState == git::Index::StagedState::Unstaged && searchingState == ParentStageState::Staged) ||
-            childState == git::Index::PartiallyStaged)
+        if ((childState == git::Index::Staged && searchingState == ParentStageState::Unstaged) ||
+            (childState == git::Index::Unstaged && searchingState == ParentStageState::Staged) ||
+             childState == git::Index::PartiallyStaged)
             return git::Index::PartiallyStaged;
 
         if (searchingState == ParentStageState::Any) {

--- a/src/ui/DiffTreeModel.h
+++ b/src/ui/DiffTreeModel.h
@@ -134,22 +134,6 @@ public:
    * \return
    */
   bool discard(const QModelIndex &index);
-  /*!
-   * Setting the data to the item
-   * \brief setData
-   * \param index
-   * \param value
-   * \param role
-   * \param ignoreIndexChanges If index changes should be ignored or not.
-   * In normal case it is desired that the index is changed when checking an item,
-   * but when the data was changed outside of the model (like in the DiffView) the
-   * index must not be updated anymore because it is done already.
-   * \return
-   */
-  bool setData(
-    const QModelIndex &index,
-    const QVariant &value,
-    int role, bool ignoreIndexChanges);
 
   Qt::ItemFlags flags(const QModelIndex &index) const override;
 

--- a/src/ui/DiffView/DiffView.h
+++ b/src/ui/DiffView/DiffView.h
@@ -21,11 +21,9 @@
 #include "app/Theme.h"
 #include <QMap>
 #include <QScrollArea>
+#include <QVBoxLayout>
 
-class QCheckBox;
-class QVBoxLayout;
 class FileWidget;
-class DiffTreeModel;
 
 namespace DiffViewStyle {
     const int kIndent = 2;
@@ -86,7 +84,7 @@ public:
   QWidget *file(int index);
 
   void setDiff(const git::Diff &diff);
-  void setFilter(const QList<int> &indexes);
+  void setFilter(const QStringList &paths);
 
   const QList<PluginRef> &plugins() const { return mPlugins; }
   const Account::CommitComments &comments() const { return mComments; }

--- a/src/ui/DiffView/DiffView.h
+++ b/src/ui/DiffView/DiffView.h
@@ -94,7 +94,6 @@ public:
 
 signals:
   void diagnosticAdded(TextEditor::DiagnosticKind kind);
-  void stageStateChanged(const QString &name, git::Index::StagedState state);
   void discarded(const QString &name);
 
 protected:

--- a/src/ui/DiffView/DiffView.h
+++ b/src/ui/DiffView/DiffView.h
@@ -125,7 +125,7 @@ protected:
 
 private:
   bool canFetchMore();
-  void fetchMore();
+  void fetchMore(int count = 4);
   void fetchAll(int index = -1);
   void indexChanged(const QStringList& paths);
 

--- a/src/ui/DiffView/DiffView.h
+++ b/src/ui/DiffView/DiffView.h
@@ -88,27 +88,13 @@ public:
   void setDiff(const git::Diff &diff);
 
   bool scrollToFile(int index);
-
-  /*!
-   * \brief updateFiles
-   * Call this function to update the visible diff files.
-   * It fetches the files then from the diffTreeModel and the selection model
-   */
-  void updateFiles();
+  void setFilter(const QList<int> &indexes);
 
   const QList<PluginRef> &plugins() const { return mPlugins; }
   const Account::CommitComments &comments() const { return mComments; }
 
   QList<TextEditor *> editors() override;
   void ensureVisible(TextEditor *editor, int pos) override;
-  /*!
-   * Enables/disables showing diffs
-   * \brief enable
-   * \param enable
-   */
-  void enable(bool enable);
-  void setModel(DiffTreeModel *model);
-  void diffTreeModelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles);
 
 signals:
   void diagnosticAdded(TextEditor::DiagnosticKind kind);
@@ -138,10 +124,9 @@ private:
   QList<PluginRef> mPlugins;
   Account::CommitComments mComments;
 
-  bool mEnabled{true};
-  DiffTreeModel* mDiffTreeModel{nullptr};
-  QWidget* mParent{nullptr};
   QVBoxLayout* mFileWidgetLayout{nullptr};
+
+  QList<int> mIndexes;
 };
 
 #endif

--- a/src/ui/DiffView/DiffView.h
+++ b/src/ui/DiffView/DiffView.h
@@ -86,8 +86,6 @@ public:
   QWidget *file(int index);
 
   void setDiff(const git::Diff &diff);
-
-  bool scrollToFile(int index);
   void setFilter(const QList<int> &indexes);
 
   const QList<PluginRef> &plugins() const { return mPlugins; }
@@ -98,12 +96,8 @@ public:
 
 signals:
   void diagnosticAdded(TextEditor::DiagnosticKind kind);
-  /*!
-   * Emitted when in one of the FileWidgets the stageState was changed
-   * \brief fileStageStateChanged
-   * \param state
-   */
-  void fileStageStateChanged(git::Index::StagedState state);
+  void stageStateChanged(const QString &name, git::Index::StagedState state);
+  void discarded(const QString &name);
 
 protected:
   void dropEvent(QDropEvent *event) override;
@@ -113,7 +107,6 @@ private:
   bool canFetchMore();
   void fetchMore(int count = 4);
   void fetchAll(int index = -1);
-  void indexChanged(const QStringList& paths);
 
   git::Diff mDiff;
   QMap<QString,git::Patch> mStagedPatches;

--- a/src/ui/DiffView/FileWidget.cpp
+++ b/src/ui/DiffView/FileWidget.cpp
@@ -228,11 +228,10 @@ void _FileWidget::Header::updateCheckState()
 FileWidget::FileWidget(DiffView *view,
   const git::Diff &diff,
   const git::Patch &patch,
-  const git::Patch &staged, const QModelIndex modelIndex,
+  const git::Patch &staged,
   QWidget *parent)
-  : QWidget(parent), mView(view), mDiff(diff), mPatch(patch), mModelIndex(modelIndex)
+  : QWidget(parent), mView(view), mDiff(diff), mPatch(patch)
 {
-  auto stageState = static_cast<git::Index::StagedState>(mModelIndex.data(Qt::CheckStateRole).toInt());
   setObjectName("FileWidget");
   QVBoxLayout *layout = new QVBoxLayout(this);
   layout->setContentsMargins(0,0,0,0);
@@ -256,7 +255,11 @@ FileWidget::FileWidget(DiffView *view,
 
   bool lfs = patch.isLfsPointer();
   mHeader = new _FileWidget::Header(diff, patch, binary, lfs, submodule, parent);
-  mHeader->setStageState(stageState);
+
+  //SK TODO: get the CheckStateRole. emit dataChange could do the job
+  //auto stageState = static_cast<git::Index::StagedState>(mModelIndex.data(Qt::CheckStateRole).toInt());
+  //mHeader->setStageState(stageState);
+
   connect(mHeader, &_FileWidget::Header::stageStateChanged, this, &FileWidget::headerCheckStateChanged);
   connect(mHeader, &_FileWidget::Header::discard, this, &FileWidget::discard);
   layout->addWidget(mHeader);
@@ -354,11 +357,6 @@ void FileWidget::setStageState(git::Index::StagedState state)
 
     for (auto hunk: mHunks)
         hunk->setStageState(state);
-}
-
-QModelIndex FileWidget::modelIndex()
-{
-    return mModelIndex;
 }
 
 void FileWidget::updatePatch(const git::Patch &patch, const git::Patch &staged) {
@@ -485,7 +483,9 @@ HunkWidget *FileWidget::addHunk(
 
 void FileWidget::stageHunks(const HunkWidget* hunk, git::Index::StagedState stageState, bool completeFile, bool completeFileStaged)
 {
-	// Might be a problem if not all hunks are loaded
+  // Might be a problem if not all hunks are loaded
+  fetchAll(-1);
+
   if (mSupressStaging)
       return;
 
@@ -508,25 +508,25 @@ void FileWidget::stageHunks(const HunkWidget* hunk, git::Index::StagedState stag
   }
   // TODO: check all not loaded hunks!
 
-  mSuppressUpdate = true;
+//SK TODO: no more mModelIndex
+//  mSuppressUpdate = true;
 
-  if ((staged == mHunks.size() && mHunks.size() > 0) || (completeFile && completeFileStaged)) {
-    // if the file does not contain hunks, it should be always staged!
-    emit stageStateChanged(mModelIndex, git::Index::Staged);
-    mSuppressUpdate = false;
-    return;
-  } else if (completeFile && !completeFileStaged) {
-      emit stageStateChanged(mModelIndex, git::Index::Unstaged);
-      mSuppressUpdate = false;
-      return;
-  }
+//  if ((staged == mHunks.size() && mHunks.size() > 0) || (completeFile && completeFileStaged)) {
+//    // if the file does not contain hunks, it should be always staged!
+//    emit stageStateChanged(mModelIndex, git::Index::Staged);
+//    mSuppressUpdate = false;
+//    return;
+//  } else if (completeFile && !completeFileStaged) {
+//      emit stageStateChanged(mModelIndex, git::Index::Unstaged);
+//      mSuppressUpdate = false;
+//      return;
+//  }
 
-  if (unstaged == mHunks.size()) {
-    emit stageStateChanged(mModelIndex, git::Index::Unstaged);
-    mSuppressUpdate = false;
-    return;
-  }
-
+//  if (unstaged == mHunks.size()) {
+//    emit stageStateChanged(mModelIndex, git::Index::Unstaged);
+//    mSuppressUpdate = false;
+//    return;
+//  }
 
   // when changing a line in a file,
   // two lines are visible, the old one and the new one.
@@ -560,7 +560,9 @@ void FileWidget::stageHunks(const HunkWidget* hunk, git::Index::StagedState stag
   mSuppressUpdate = false;
 
   // TODO: index.add should notify the model directly!
-  emit stageStateChanged(mModelIndex, git::Index::PartiallyStaged);
+
+  //SK TODO: no more mModelIndex
+  //emit stageStateChanged(mModelIndex, git::Index::PartiallyStaged);
 }
 
 void FileWidget::discardHunk() {
@@ -623,9 +625,11 @@ void FileWidget::discard() {
       untracked ? FileWidget::tr("Remove %1").arg(arg) : FileWidget::tr("Discard Changes");
     QPushButton *discard =
       dialog->addButton(button, QMessageBox::AcceptRole);
-    connect(discard, &QPushButton::clicked, [this] {
-      emit discarded(mModelIndex);
-    });
+
+//SK TODO: no more mModelIndex
+//    connect(discard, &QPushButton::clicked, [this] {
+//      emit discarded(mModelIndex);
+//    });
 
     dialog->exec();
 }
@@ -634,8 +638,9 @@ void FileWidget::headerCheckStateChanged(int state)
 {
     assert(state != Qt::PartiallyChecked); // makes no sense, that the user can select partially selected
 
-    if (state == Qt::Checked)
-        emit stageStateChanged(mModelIndex, git::Index::Staged);
-    else
-        emit stageStateChanged(mModelIndex, git::Index::Unstaged);
+//SK TODO: no more mModelIndex
+//    if (state == Qt::Checked)
+//        emit stageStateChanged(mModelIndex, git::Index::Staged);
+//    else
+//        emit stageStateChanged(mModelIndex, git::Index::Unstaged);
 }

--- a/src/ui/DiffView/FileWidget.h
+++ b/src/ui/DiffView/FileWidget.h
@@ -123,8 +123,7 @@ public slots:
    * \brief stageHunks
    */
   void stageHunks(HunkWidget *hunk,
-                  git::Index::StagedState stageState,
-                  bool completeHunk);
+                  git::Index::StagedState stageState);
   /*!
    * Discard specific hunk
    * Emitted by the hunk it self

--- a/src/ui/DiffView/FileWidget.h
+++ b/src/ui/DiffView/FileWidget.h
@@ -5,7 +5,6 @@
 
 #include <QWidget>
 #include <QFrame>
-#include <QModelIndex>
 
 #include "git/Diff.h"
 #include "git/Patch.h"
@@ -84,7 +83,6 @@ public:
     const git::Diff &diff,
     const git::Patch &patch,
     const git::Patch &staged,
-    const QModelIndex modelIndex,
     QWidget *parent = nullptr);
   bool isEmpty();
   void updatePatch(const git::Patch &patch, const git::Patch &staged);
@@ -110,7 +108,6 @@ public:
     bool lfs,
     bool submodule);
     void setStageState(git::Index::StagedState state);
-    QModelIndex modelIndex();
 
     // Fetching new hunks
     bool canFetchMore();
@@ -140,19 +137,15 @@ public slots:
 
 signals:
   void diagnosticAdded(TextEditor::DiagnosticKind kind);
-  void stageStateChanged(const QModelIndex& idx, git::Index::StagedState state);
-  void discarded(const QModelIndex& idx);
 
 private:
   void discard();
-
 
   DiffView *mView{nullptr};
 
   git::Diff mDiff;
   git::Patch mPatch;
   git::Patch mStaged;
-  QModelIndex mModelIndex;
 
   _FileWidget::Header *mHeader{nullptr};
   QList<QWidget *> mImages;
@@ -163,4 +156,3 @@ private:
 };
 
 #endif // FILEWIDGET_H
-

--- a/src/ui/DiffView/FileWidget.h
+++ b/src/ui/DiffView/FileWidget.h
@@ -116,11 +116,12 @@ public:
     bool canFetchMore();
     /*!
      * \brief DiffView::fetchMore
-     * Fetch maxNewFiles more patches
+     * Fetch count more patches
      * use a while loop with canFetchMore() to get all
      */
-    int fetchMore();
-    void fetchAll(int index);
+    void fetchMore(int count = 4);
+    void fetchAll(int index = -1);
+
 public slots:
   void headerCheckStateChanged(int state);
   /*!

--- a/src/ui/DiffView/FileWidget.h
+++ b/src/ui/DiffView/FileWidget.h
@@ -44,8 +44,8 @@ public:
   void setStageState(git::Index::StagedState state);
 
 signals:
-  void stageStateChanged(int stageState);
   void discard();
+
 protected:
   void mouseDoubleClickEvent(QMouseEvent *event) override;
   void contextMenuEvent(QContextMenuEvent *event) override;
@@ -86,11 +86,7 @@ public:
     QWidget *parent = nullptr);
   bool isEmpty();
   void updatePatch(const git::Patch &patch, const git::Patch &staged);
-  /*!
-   * Update hunks after index change and emits the current stage state of the hunks
-   * \brief updateHunks
-   */
-  void updateHunks(git::Patch stagedPatch);
+
   _FileWidget::Header *header() const;
 
   QString name() const { return mPatch.name(); }
@@ -120,14 +116,15 @@ public:
     void fetchAll(int index = -1);
 
 public slots:
-  void headerCheckStateChanged(int state);
   /*!
    * Stages the changes of the hunk
    * emits signal "stageStateChanged" with the
    * current state of the hunk as parameter
    * \brief stageHunks
    */
-  void stageHunks(const HunkWidget *hunk, git::Index::StagedState stageState, bool completeFile=false, bool completeFileStaged=false);
+  void stageHunks(HunkWidget *hunk,
+                  git::Index::StagedState stageState,
+                  bool completeHunk);
   /*!
    * Discard specific hunk
    * Emitted by the hunk it self
@@ -137,7 +134,6 @@ public slots:
 
 signals:
   void diagnosticAdded(TextEditor::DiagnosticKind kind);
-  void stageStateChanged(const QString &name, git::Index::StagedState state);
   void discarded(const QString &name);
 
 private:
@@ -153,8 +149,6 @@ private:
   QList<QWidget *> mImages;
   QList<HunkWidget *> mHunks;
   QVBoxLayout* mHunkLayout{nullptr};
-  bool mSuppressUpdate{false};
-  bool mSupressStaging{false};
 };
 
 #endif // FILEWIDGET_H

--- a/src/ui/DiffView/FileWidget.h
+++ b/src/ui/DiffView/FileWidget.h
@@ -107,7 +107,7 @@ public:
     int index,
     bool lfs,
     bool submodule);
-    void setStageState(git::Index::StagedState state);
+    void updateStageState();
 
     // Fetching new hunks
     bool canFetchMore();

--- a/src/ui/DiffView/FileWidget.h
+++ b/src/ui/DiffView/FileWidget.h
@@ -92,9 +92,9 @@ public:
    */
   void updateHunks(git::Patch stagedPatch);
   _FileWidget::Header *header() const;
-  QString name() const;
 
-  QList<HunkWidget *> hunks() const;
+  QString name() const { return mPatch.name(); }
+  QList<HunkWidget *> hunks() const { return mHunks; }
 
   QWidget *addImage(
     DisclosureButton *button,
@@ -137,6 +137,8 @@ public slots:
 
 signals:
   void diagnosticAdded(TextEditor::DiagnosticKind kind);
+  void stageStateChanged(const QString &name, git::Index::StagedState state);
+  void discarded(const QString &name);
 
 private:
   void discard();

--- a/src/ui/DiffView/HunkWidget.cpp
+++ b/src/ui/DiffView/HunkWidget.cpp
@@ -244,10 +244,10 @@ HunkWidget::HunkWidget(
 
   // Respond to check changes
   connect(mHeader->check(), &QCheckBox::clicked, this, [this](bool checked) {
-    git::Index::StagedState stageState = checked ? git::Index::StagedState::Staged :
-                                                   git::Index::StagedState::Unstaged;
-    setStageState(stageState);
-    emit stageStateChanged(stageState, true);
+    git::Index::StagedState stageState = checked ? git::Index::Staged :
+                                                   git::Index::Unstaged;
+    updateStageState(stageState);
+    emit stageStateChanged(stageState);
   });
 
   // Respond to discard signal
@@ -487,29 +487,42 @@ void HunkWidget::paintEvent(QPaintEvent *event)
   QFrame::paintEvent(event);
 }
 
-void HunkWidget::stageSelected(int startLine, int end, bool emitSignal)
+void HunkWidget::stageSelected(int startLine, int end)
 {
   for (int i = startLine; i < end; i++) {
     int mask = mEditor->markers(i);
-    if (mask & (1 << TextEditor::Marker::Addition | (1 << TextEditor::Marker::Deletion)))
-      mEditor->markerAdd(i, TextEditor::StagedMarker);
+    if (mask & (1 << TextEditor::Marker::Addition | 1 << TextEditor::Marker::Deletion)) {
+      if (!(mask & (1 << TextEditor::StagedMarker))) {
+        mEditor->markerAdd(i, TextEditor::StagedMarker);
+        if (mask & (1 << TextEditor::Marker::Addition))
+          mStagedAdditions++;
+        else
+          mStagedDeletions++;
+      }
+    }
   }
 
-  mStagedStateLoaded = false;
-  if (!mLoading && emitSignal)
-    emit stageStateChanged(stageState(), false);
+  // Change index
+  emit stageStateChanged(stageState());
 }
 
-void HunkWidget::unstageSelected(int startLine, int end, bool emitSignal) {
+void HunkWidget::unstageSelected(int startLine, int end)
+{
   for (int i = startLine; i < end; i++) {
     int mask = mEditor->markers(i);
-    if (mask & (1 << TextEditor::Marker::Addition | 1 << TextEditor::Marker::Deletion))
-      mEditor->markerDelete(i, TextEditor::StagedMarker);
+    if (mask & (1 << TextEditor::Marker::Addition | 1 << TextEditor::Marker::Deletion)) {
+      if (mask & (1 << TextEditor::StagedMarker)) {
+        mEditor->markerDelete(i, TextEditor::StagedMarker);
+        if (mask & (1 << TextEditor::Marker::Addition))
+          mStagedAdditions--;
+        else
+          mStagedDeletions--;
+      }
+    }
   }
 
-  mStagedStateLoaded = false;
-  if (!mLoading && emitSignal)
-    emit stageStateChanged(stageState(), false);
+  // Change index
+  emit stageStateChanged(stageState());
 }
 
 void HunkWidget::discardDialog(int startLine, int end) {
@@ -586,59 +599,72 @@ void HunkWidget::discardSelected(int startLine, int end)
   emit discard();
 }
 
-void HunkWidget::setStageState(git::Index::StagedState stageState)
+void HunkWidget::updatePatch(const git::Patch &patch,
+                             const git::Patch &staged)
 {
-  if (stageState == git::Index::StagedState::Staged ||
-      stageState == git::Index::StagedState::Unstaged)
-  {
-    mHeader->setStageState(stageState);
-
-    // Update the line markers
-    bool staged = stageState == git::Index::StagedState::Staged ? true : false;
-    for (int i = 0; i < mEditor->lineCount(); i++) {
-      int mask = mEditor->markers(i);
-
-      // If a line was not added or deleted, it cannot be staged so ignore all of them
-      if (mask & (1 << TextEditor::Marker::Addition | 1 << TextEditor::Marker::Deletion))
-        setStaged(i, staged, false);
-    }
-    mStagedStage = stageState;
+  // Update patch of unloaded hunk
+  if (!mLoaded) {
+    mPatch = patch;
+    mStaged = staged;
   }
 }
 
-void HunkWidget::setStaged(int lidx, bool staged, bool emitSignal)
+void HunkWidget::updateStageState(git::Index::StagedState stageState)
 {
+  if (!mLoaded)
+    return;
+
+  // Update stage state of loaded hunk
+  if (stageState == git::Index::Staged ||
+      stageState == git::Index::Unstaged)
+  {
+    mHeader->setStageState(stageState);
+
+    // Update line markers
+    bool staged = stageState == git::Index::Staged ? true : false;
+    for (int i = 0; i < mEditor->lineCount(); i++) {
+      int mask = mEditor->markers(i);
+      if (mask & (1 << TextEditor::Marker::Addition | 1 << TextEditor::Marker::Deletion)) {
+        if (staged) {
+          if (!(mask & (1 << TextEditor::StagedMarker))) {
+            mEditor->markerAdd(i, TextEditor::StagedMarker);
+            if (mask & (1 << TextEditor::Marker::Addition))
+              mStagedAdditions++;
+            else
+              mStagedDeletions++;
+          }
+        } else {
+          if (mask & (1 << TextEditor::StagedMarker)) {
+            mEditor->markerDelete(i, TextEditor::StagedMarker);
+            if (mask & (1 << TextEditor::Marker::Addition))
+              mStagedAdditions--;
+            else
+              mStagedDeletions--;
+          }
+        }
+      }
+    }
+  }
+}
+
+void HunkWidget::marginClicked(int pos, int modifier, int margin)
+{
+  Q_UNUSED(modifier)
+
+  if (margin != TextEditor::Margin::Staged)
+    return;
+
+  int lidx = mEditor->lineFromPosition(pos);
   int markers = mEditor->markers(lidx);
   if (!(markers & (1 << TextEditor::Marker::Addition | 1 << TextEditor::Marker::Deletion)))
     return;
 
-  if (staged == (markers & (1 << TextEditor::Marker::StagedMarker)) > 0)
-    return;
-
-  if (staged)
-    stageSelected(lidx, lidx + 1, emitSignal);
+  // Toggle staged line
+  if (markers & (1 << TextEditor::Marker::StagedMarker))
+    unstageSelected(lidx, lidx + 1);
   else
-    unstageSelected(lidx, lidx + 1, emitSignal);
-
-  mLoaded = true;
+    stageSelected(lidx, lidx + 1);
 }
-
- void HunkWidget::marginClicked(int pos, int modifier, int margin) {
-     if (margin != TextEditor::Margin::Staged)
-         return;
-
-     int lidx = mEditor->lineFromPosition(pos);
-
-     int markers = mEditor->markers(lidx);
-
-     if (!(markers & (1 << TextEditor::Marker::Addition | 1 << TextEditor::Marker::Deletion)))
-         return;
-
-     if (markers & (1 << TextEditor::Marker::StagedMarker))
-       setStaged(lidx, false);
-     else
-       setStaged(lidx, true);
- }
 
 int HunkWidget::tokenEndPosition(int pos) const
 {
@@ -695,9 +721,6 @@ void HunkWidget::load(git::Patch &staged, bool force)
     return;
 
   mLoaded = true;
-  mLoading = true;
-  mStagedStateLoaded = false;
-
   mStaged = staged;
 
   mEditor->markerDeleteAll(-1); // delete all markers on each line
@@ -724,18 +747,8 @@ void HunkWidget::load(git::Patch &staged, bool force)
   }
 
   if (mLfs) {
-      // TODO: show pdfs, if it is a pdf!
-      return;
-  }
-
-  qDebug() << "Diff Header:";
-  for (int i = 0; i < mPatch.count(); i++) {
-    qDebug() << mPatch.header(i);
-  }
-
-  qDebug() << "Staged Header:";
-  for (int i = 0; i < mStaged.count(); i++) {
-    qDebug() << mStaged.header(i);
+    // TODO: show pdfs, if it is a pdf!
+    return;
   }
 
   // Load hunk.
@@ -765,15 +778,10 @@ void HunkWidget::load(git::Patch &staged, bool force)
   }
 
   // Trim final line end.
-  // Don't do that because then the editor line
-  // does not match anymore the blob line.
-  // this is a problem when copying the hunk
-  // back into the blob as done in the discardHunk()
-  // method in FileWidget
-  //  if (content.endsWith('\n'))
-  //    content.chop(1);
-  //  if (content.endsWith('\r'))
-  //    content.chop(1);
+  if (content.endsWith('\n'))
+     content.chop(1);
+  if (content.endsWith('\r'))
+     content.chop(1);
 
   // Add text.
   mEditor->setText(repo.decode(content));
@@ -826,33 +834,12 @@ void HunkWidget::load(git::Patch &staged, bool force)
 
   mEditor->updateGeometry();
 
-  mLoading = false;
-
   // Update stage state after everything is loaded
   mHeader->setStageState(stageState());
 }
 
 void HunkWidget::setEditorLineInfos(QList<Line>& lines, Account::FileComments& comments, int width)
 {
-  //SK TODO: this is not working properly.
-  // if the first line is NOT staged, the linestaging is NOT evaluated PROPERLY
-  //SK TODO
-    qDebug() << "Patch lines:" << lines.count();
-	for (int i=0; i < lines.count(); i++) {
-		qDebug() << i << ") " << lines[i].print();
-    }
-
-	qDebug() << "Staged linesStaged:" << mStaged.count();
-	for (int i=0; i < mStaged.count(); i++) {qDebug() << "Staged patch No. " << i;
-		for (int lidx=0; lidx < mStaged.lineCount(i); lidx++) {
-			auto origin = mStaged.lineOrigin(i, lidx);
-			int oldLineStaged = mStaged.lineNumber(i, lidx, git::Diff::OldFile);
-			int newLineStaged = mStaged.lineNumber(i, lidx, git::Diff::NewFile);
-			auto line = Line(origin, oldLineStaged, newLineStaged);
-			qDebug() << lidx << ") " << line.print();
-		}
-	}
-
 //	New file line number change for different line origins
 //	| diff HEAD         | diff –cached |   |
 //	|-------------------|--------------|---|
@@ -871,187 +858,175 @@ void HunkWidget::setEditorLineInfos(QList<Line>& lines, Account::FileComments& c
 //	| unstaged deletion | +            | / |
 //	| staged deletion   | +            | + |
 
-    int count = lines.size();
-    int marker = -1;
+  // Staged line numbers
+  const git_diff_hunk *unstageHeader = mPatch.header_struct(mIndex);
+
+  QMap<int, QString> stagedAddLines;
+  QMap<int, QString> stagedDelLines;
+  if (!mPatch.isConflicted()) {
+    for (int i = 0; i < mStaged.count(); i++) {
+
+      // Find staged patch within patch
+      const git_diff_hunk *stageHeader = mStaged.header_struct(i);
+      int old_start = stageHeader->old_start - unstageHeader->old_start;
+      int stageDiff = stageHeader->old_start - stageHeader->new_start;
+      int unstageDiff = unstageHeader->old_start - unstageHeader->new_start;
+      if ((old_start >= 0 && old_start <= unstageHeader->old_lines) &&
+          (stageHeader->old_lines <= unstageHeader->old_lines)) {
+
+        for (int lidx = 0; lidx < mStaged.lineCount(i); lidx++) {
+          char origin = mStaged.lineOrigin(i, lidx);
+          if (origin == '-')
+            stagedDelLines.insert(mStaged.lineNumber(i, lidx, git::Diff::OldFile),
+                                  mStaged.lineContent(i, lidx));
+
+          if (origin == '+')
+            stagedAddLines.insert(mStaged.lineNumber(i, lidx, git::Diff::NewFile)
+                                  + stageDiff - unstageDiff,
+                                  mStaged.lineContent(i, lidx));
+        }
+      }
+    }
+  }
+
+  // Reset statistics
+  mAdditions = 0, mDeletions = 0;
+  mStagedAdditions = 0, mStagedDeletions = 0;
+
+  // Set all editor markers, like green background for adding, red background for deletion
+  // Blue background for OURS or magenta background for Theirs
+  // Setting also the staged symbol
+  int count = lines.size();
+  for (int lidx = 0; lidx < count; ++lidx) {
     int additions = 0, deletions = 0;
-	int additions_tot = 0, deletions_tot = 0;
-    int stagedAdditions = 0, stagedDeletions = 0;
+    int marker = -1;
     bool staged = false;
-	int current_staged_index = -1;
-	int current_staged_line_idx = 0;
-	int diff_patch_old_new_file = -1;
-	int diff_staged_patch_old_new_file = -1;
 
-	// Find the first staged hunk which is within this patch
-	if (!mPatch.isConflicted()) {
-		auto patch_header_struct = mPatch.header_struct(mIndex);
-		for (int i = 0; i < mStaged.count(); i++) {
-			if (patch_header_struct->old_start > mStaged.header_struct(i)->old_start + mStaged.header_struct(i)->old_lines)
-				continue;
-			else {
-				current_staged_index = i;
-				break;
-			}
-		}
-	}
+    const Line& line = lines.at(lidx);
+    createMarkersAndLineNumbers(line, lidx, comments, width);
 
-	// Set all editor markers, like green background for adding, red background for deletion
-	// Blue background for OURS or magenta background for Theirs
-	// Setting also the staged symbol
-	bool first_staged_patch_match = false;
-	 for (int lidx = 0; lidx < count; ++lidx) {
-		marker = -1;
-		staged = false;
+    switch (lines[lidx].origin()) {
+      case GIT_DIFF_LINE_CONTEXT:
+        marker = TextEditor::Context;
+        additions = 0;
+        deletions = 0;
+        break;
 
-		const Line& line = lines.at(lidx);
-		createMarkersAndLineNumbers(line, lidx, comments, width);
-
-		if (!mPatch.isConflicted() && current_staged_index >= 0) {
-			auto staged_header_struct_next = mStaged.header_struct(current_staged_index + 1);
-			if (!first_staged_patch_match) {
-				if (mPatch.lineNumber(mIndex, lidx, git::Diff::OldFile) == mStaged.header_struct(current_staged_index)->old_start) {
-					first_staged_patch_match = true;
-					diff_patch_old_new_file = mPatch.lineNumber(mIndex, lidx, git::Diff::NewFile) - mPatch.lineNumber(mIndex, lidx, git::Diff::OldFile);
-					diff_staged_patch_old_new_file = mStaged.lineNumber(current_staged_index, 0, git::Diff::NewFile) - mStaged.lineNumber(current_staged_index, 0, git::Diff::OldFile);
-				}
-				current_staged_line_idx = 0;
-			} else if(staged_header_struct_next && mPatch.lineNumber(mIndex, lidx, git::Diff::OldFile) == staged_header_struct_next->old_start) {
-				// Align staged patch with total patch
-				current_staged_index ++;
-				assert(mPatch.lineContent(mIndex, lidx) == mStaged.lineContent(current_staged_index, 0));
-				current_staged_line_idx = 0;
-			}
-		}
-
-        switch (lines[lidx].origin()) {
-          case GIT_DIFF_LINE_CONTEXT:
-            marker = TextEditor::Context;
-            additions = 0;
-            deletions = 0;
-			current_staged_line_idx++;
-            break;
-
-          case GIT_DIFF_LINE_ADDITION: {
-            marker = TextEditor::Addition;
-            additions++;
-            // Find matching lines
-            if (lidx + 1 >= count ||
-                mPatch.lineOrigin(mIndex, lidx + 1) != GIT_DIFF_LINE_ADDITION) { // end of file, or the last addition line
-              // The heuristic is that matching blocks have
-              // the same number of additions as deletions.
-              if (additions == deletions) {
-                for (int i = 0; i < additions; ++i) {
-                  int current = lidx - i;
-                  int match = current - additions;
-                  lines[current].setMatchingLine(match);
-                  lines[match].setMatchingLine(current);
-                }
-              }
-              // Only for performance reason, because the above loop
-              // iterates over all additions
-              additions = 0;
-              deletions = 0;
+      case GIT_DIFF_LINE_ADDITION: {
+        marker = TextEditor::Addition;
+        additions++;
+        // Find matching lines
+        if (lidx + 1 >= count ||
+            mPatch.lineOrigin(mIndex, lidx + 1) != GIT_DIFF_LINE_ADDITION) { // end of file, or the last addition line
+          // The heuristic is that matching blocks have
+          // the same number of additions as deletions.
+          if (additions == deletions) {
+            for (int i = 0; i < additions; ++i) {
+              int current = lidx - i;
+              int match = current - additions;
+              lines[current].setMatchingLine(match);
+              lines[match].setMatchingLine(current);
             }
-            // Check if staged
-
-			if (!mPatch.isConflicted() && mStaged.count() > 0 && current_staged_index >= 0 && current_staged_line_idx < mStaged.lineCount(current_staged_index)) {
-				auto line_origin = mStaged.lineOrigin(current_staged_index, current_staged_line_idx);
-				auto staged_file = mStaged.lineNumber(current_staged_index, current_staged_line_idx, git::Diff::NewFile) - diff_staged_patch_old_new_file;
-				auto patch_file = mPatch.lineNumber(mIndex, lidx, git::Diff::NewFile) - (additions_tot - stagedAdditions) + (deletions_tot - stagedDeletions) - diff_patch_old_new_file; // - offset_patch_old_new;
-				if (line_origin == '+' && staged_file == patch_file && mStaged.lineContent(current_staged_index, current_staged_line_idx) == mPatch.lineContent(mIndex, lidx)) {
-				  stagedAdditions++;
-				  current_staged_line_idx++;
-				  staged = true;
-				}
-			}
-			additions_tot++;
-            break;
-
-          } case GIT_DIFF_LINE_DELETION: {
-            marker = TextEditor::Deletion;
-            deletions++;
-			deletions_tot++;
-
-            // Check if staged
-			if (!mPatch.isConflicted() && mStaged.count() > 0 && current_staged_index >= 0 && current_staged_line_idx < mStaged.lineCount(current_staged_index)) {
-				auto line_origin = mStaged.lineOrigin(current_staged_index, current_staged_line_idx);
-				auto staged_old_file = mStaged.lineNumber(current_staged_index, current_staged_line_idx, git::Diff::OldFile);
-				auto patch_old_file = mPatch.lineNumber(mIndex, lidx, git::Diff::OldFile);
-				if (line_origin == '-' && staged_old_file == patch_old_file) {
-				  assert(mStaged.lineContent(current_staged_index, current_staged_line_idx) == mPatch.lineContent(mIndex, lidx));
-				  stagedDeletions++;
-				  staged = true;
-				}
-			}
-			current_staged_line_idx++; // must be in staged and in the unstaged case
-            break;
-
-          } case 'O':
-            marker = TextEditor::Ours;
-            break;
-
-          case 'T':
-            marker = TextEditor::Theirs;
-            break;
+          }
+          // Only for performance reason, because the above loop
+          // iterates over all additions
+          additions = 0;
+          deletions = 0;
         }
 
-        // Add marker.
-        if (marker >= 0)
-            mEditor->markerAdd(lidx, marker);
-		 if (staged)
-          setStaged(lidx, true);
+        // Check if staged
+        int patchLinenumber = mPatch.lineNumber(mIndex, lidx, git::Diff::NewFile) - (mAdditions - mStagedAdditions) + (mDeletions - mStagedDeletions);
+        if (stagedAddLines.contains(patchLinenumber)) {
+          if (stagedAddLines.value(patchLinenumber) == mPatch.lineContent(mIndex, lidx)) {
+            mStagedAdditions++;
+            staged = true;
+          }
+        }
+
+        mAdditions++;
+        break;
+      }
+
+      case GIT_DIFF_LINE_DELETION: {
+        marker = TextEditor::Deletion;
+        deletions++;
+        mDeletions++;
+
+        // Check if staged
+        int patchLinenumber = mPatch.lineNumber(mIndex, lidx, git::Diff::OldFile);
+        if (stagedDelLines.contains(patchLinenumber)) {
+          if (stagedDelLines.value(patchLinenumber) == mPatch.lineContent(mIndex, lidx)) {
+            mStagedDeletions++;
+            staged = true;
+          }
+        }
+        break;
+      }
+
+      case 'O':
+        marker = TextEditor::Ours;
+        break;
+
+      case 'T':
+        marker = TextEditor::Theirs;
+        break;
     }
 
+    // Add marker.
+    if (marker >= 0)
+      mEditor->markerAdd(lidx, marker);
+    if (staged)
+      mEditor->markerAdd(lidx, TextEditor::StagedMarker);
+  }
 
+  // Diff matching lines. Highlight changes within the line!
+  for (int lidx = 0; lidx < count; ++lidx) {
+    const Line &line = lines.at(lidx);
+    int matchingLine = line.matchingLine();
+    if (line.origin() == GIT_DIFF_LINE_DELETION && matchingLine >= 0) {
+    // Split lines into tokens and diff corresponding tokens.
+    QList<Token> oldTokens = tokens(lidx);
+    QList<Token> newTokens = tokens(matchingLine);
+    QByteArray oldBuffer = tokenBuffer(oldTokens);
+    QByteArray newBuffer = tokenBuffer(newTokens);
+    git::Patch patch = git::Patch::fromBuffers(oldBuffer, newBuffer);
+    for (int pidx = 0; pidx < patch.count(); ++pidx) {
+      // Find the boundary between additions and deletions.
+      int index;
+      int count = patch.lineCount(pidx);
+      for (index = 0; index < count; ++index) {
+        if (patch.lineOrigin(pidx, index) == GIT_DIFF_LINE_ADDITION)
+          break;
+      }
 
-	 // Diff matching lines. Highlight changes within the line!
-	for (int lidx = 0; lidx < count; ++lidx) {
-	  const Line &line = lines.at(lidx);
-	  int matchingLine = line.matchingLine();
-	  if (line.origin() == GIT_DIFF_LINE_DELETION && matchingLine >= 0) {
-		// Split lines into tokens and diff corresponding tokens.
-		QList<Token> oldTokens = tokens(lidx);
-		QList<Token> newTokens = tokens(matchingLine);
-		QByteArray oldBuffer = tokenBuffer(oldTokens);
-		QByteArray newBuffer = tokenBuffer(newTokens);
-		git::Patch patch = git::Patch::fromBuffers(oldBuffer, newBuffer);
-		for (int pidx = 0; pidx < patch.count(); ++pidx) {
-		  // Find the boundary between additions and deletions.
-		  int index;
-		  int count = patch.lineCount(pidx);
-		  for (index = 0; index < count; ++index) {
-			if (patch.lineOrigin(pidx, index) == GIT_DIFF_LINE_ADDITION)
-			  break;
-		  }
+      // Map differences onto the deletion line.
+      if (index > 0) {
+        int first = patch.lineNumber(pidx, 0, git::Diff::OldFile) - 1;
+        int last = patch.lineNumber(pidx, index - 1, git::Diff::OldFile);
 
-		  // Map differences onto the deletion line.
-		  if (index > 0) {
-			int first = patch.lineNumber(pidx, 0, git::Diff::OldFile) - 1;
-			int last = patch.lineNumber(pidx, index - 1, git::Diff::OldFile);
+        int size = oldTokens.size();
+        if (first >= 0 && first < size && last >= 0 && last < size) {
+          int pos = oldTokens.at(first).pos;
+          mEditor->setIndicatorCurrent(TextEditor::WordDeletion);
+          mEditor->indicatorFillRange(pos, oldTokens.at(last).pos - pos);
+        }
+      }
 
-			int size = oldTokens.size();
-			if (first >= 0 && first < size && last >= 0 && last < size) {
-			  int pos = oldTokens.at(first).pos;
-			  mEditor->setIndicatorCurrent(TextEditor::WordDeletion);
-			  mEditor->indicatorFillRange(pos, oldTokens.at(last).pos - pos);
-			}
-		  }
+      // Map differences onto the addition line.
+      if (index < count) {
+        int first = patch.lineNumber(pidx, index, git::Diff::NewFile) - 1;
+        int last = patch.lineNumber(pidx, count - 1, git::Diff::NewFile);
 
-		  // Map differences onto the addition line.
-		  if (index < count) {
-			int first = patch.lineNumber(pidx, index, git::Diff::NewFile) - 1;
-			int last = patch.lineNumber(pidx, count - 1, git::Diff::NewFile);
-
-			int size = newTokens.size();
-			if (first >= 0 && first < size && last >= 0 && last < size) {
-			  int pos = newTokens.at(first).pos;
-			  mEditor->setIndicatorCurrent(TextEditor::WordAddition);
-			  mEditor->indicatorFillRange(pos, newTokens.at(last).pos - pos);
-			}
-		  }
-		}
-	  }
-	}
+        int size = newTokens.size();
+          if (first >= 0 && first < size && last >= 0 && last < size) {
+            int pos = newTokens.at(first).pos;
+            mEditor->setIndicatorCurrent(TextEditor::WordAddition);
+            mEditor->indicatorFillRange(pos, newTokens.at(last).pos - pos);
+          }
+        }
+      }
+    }
+  }
 }
 
 void HunkWidget::createMarkersAndLineNumbers(const Line& line, int lidx, Account::FileComments& comments, int width) const
@@ -1138,18 +1113,30 @@ void HunkWidget::createMarkersAndLineNumbers(const Line& line, int lidx, Account
     }
 }
 
-QList<int> HunkWidget::ignoreLines() const
+QList<int> HunkWidget::unstagedLines() const
 {
   QList<int> list;
   for (int i = 0; i < mEditor->lineCount(); i++) {
     int mask = mEditor->markers(i);
-    if (mask & (1 << TextEditor::Marker::Addition)) {
+    if (mask & (1 << TextEditor::Marker::Context))
+      continue;
+    if (mask & (1 << TextEditor::Marker::Addition | 1 << TextEditor::Marker::Deletion))
       if (!(mask & (1 << TextEditor::Marker::StagedMarker)))
         list.append(i);
-    } else if (mask & (1 << TextEditor::Marker::Deletion)) {
-      if (!(mask & (1 << TextEditor::Marker::StagedMarker)))
-        list.append(i);
-    }
+  }
+
+  return list;
+}
+
+QList<int> HunkWidget::discardedLines() const
+{
+  QList<int> list;
+  for (int i = 0; i < mEditor->lineCount(); i++) {
+    int mask = mEditor->markers(i);
+    if (mask & (1 << TextEditor::Marker::Context))
+      continue;
+    if (mask & (1 << TextEditor::Marker::DiscardMarker))
+      list.append(i);
   }
 
   return list;
@@ -1157,35 +1144,12 @@ QList<int> HunkWidget::ignoreLines() const
 
 git::Index::StagedState HunkWidget::stageState()
 {
-  if (mStagedStateLoaded)
-      return mStagedStage;
+  if ((mStagedAdditions + mStagedDeletions) == 0)
+    return git::Index::Unstaged;
+  else if ((mStagedAdditions + mStagedDeletions) == (mAdditions + mDeletions))
+    return git::Index::Staged;
 
-  int lineCount = mEditor->lineCount();
-  int staged = 0;
-  int diffLines = 0;
-  for (int i = 0; i < lineCount; i++) {
-      int mask = mEditor->markers(i);
-      if (!(mask & (1 << TextEditor::Marker::Addition | 1 << TextEditor::Marker::Deletion)))
-          continue;
-
-      diffLines++;
-	  if (mask & 1 << TextEditor::Marker::StagedMarker) {
-          staged++;
-		  if (staged < diffLines)
-			  break; // No need to check more, because it is already clear that it is partially staged
-	  }
-  }
-
-  if (!staged)
-      mStagedStage = git::Index::Unstaged;
-  else if (staged == diffLines)
-      mStagedStage = git::Index::Staged;
-  else
-      mStagedStage = git::Index::PartiallyStaged;
-
-  mStagedStateLoaded = true;
-
-  return mStagedStage;
+  return git::Index::PartiallyStaged;
 }
 
 void HunkWidget::chooseLines(TextEditor::Marker kind)

--- a/src/ui/DiffView/HunkWidget.h
+++ b/src/ui/DiffView/HunkWidget.h
@@ -79,7 +79,8 @@ public:
   TextEditor *editor(bool ensureLoaded = true);
   void invalidate();
 
-  QList<int> ignoreLines() const;
+  QList<int> unstagedLines() const;
+  QList<int> discardedLines() const;
   /*!
    * \brief stageState
    * Calculate stage state of the hunk. Git does not provide
@@ -89,7 +90,9 @@ public:
    */
   git::Index::StagedState stageState();
 
-  void setStageState(git::Index::StagedState stageState);
+  void updatePatch(const git::Patch &patch,
+                   const git::Patch &staged);
+  void updateStageState(git::Index::StagedState stageState);
   /*!
    * update hunk content
    * \brief load
@@ -105,16 +108,15 @@ signals:
    * \brief stageStateChanged
    * \param stageState
    */
-  void stageStateChanged(git::Index::StagedState stageState,
-                         bool completeHunk);
+  void stageStateChanged(git::Index::StagedState stageState);
   void discard();
 
 protected:
   void paintEvent(QPaintEvent *event);
 
 private slots:
-  void stageSelected(int startLine, int end, bool emitSignal = true);
-  void unstageSelected(int startLine, int end, bool emitSignal = true);
+  void stageSelected(int startLine, int end);
+  void unstageSelected(int startLine, int end);
   void discardSelected(int startLine, int end);
   /*!
    * Shows dialog if the changes should be discarded
@@ -123,13 +125,7 @@ private slots:
    * \param end
    */
   void discardDialog(int startLine, int end);
-  /*!
-   * Stage/Unstage line with index lidx
-   * \brief setStaged
-   * \param lidx Line index
-   * \param staged Staged if true, else unstaged
-   */
-  void setStaged(int lidx, bool staged, bool emitSignal=true);
+
   void marginClicked(int pos, int modifier, int margin);
 
 private:
@@ -161,10 +157,12 @@ private:
 
   _HunkWidget::Header *mHeader;
   TextEditor *mEditor;
-  bool mLoaded{false};
-  bool mLoading{false}; // during execution of the load() method
-  bool mStagedStateLoaded{false};
-  git::Index::StagedState mStagedStage;
+
+  bool mLoaded = false;
+  int mAdditions = 0;
+  int mDeletions = 0;
+  int mStagedAdditions = 0;
+  int mStagedDeletions = 0;
 };
 
 #endif // HUNKWIDGET_H

--- a/src/ui/DiffView/HunkWidget.h
+++ b/src/ui/DiffView/HunkWidget.h
@@ -78,22 +78,8 @@ public:
   _HunkWidget::Header *header() const;
   TextEditor *editor(bool ensureLoaded = true);
   void invalidate();
-  /*!
-   * Return hunk retrieved from the editor with removed discard lines
-   * Idea is to store the changes only in the texteditor
-   * and provide the data to the patch if needed
-   * \brief hunk
-   * \return
-   */
-  QByteArray hunk() const;
-  /*!
-   * Return hunk retrieved from the editor to apply patch
-   * Idea is to store the changes only in the texteditor
-   * and provide the data to the patch if needed
-   * \brief hunk
-   * \return
-   */
-  QByteArray apply() const;
+
+  QList<int> ignoreLines() const;
   /*!
    * \brief stageState
    * Calculate stage state of the hunk. Git does not provide
@@ -102,12 +88,7 @@ public:
    * \return
    */
   git::Index::StagedState stageState();
-  /*!
-   * Stage/Unstage all
-   * \brief setStaged
-   * \param staged
-   */
-  void setStaged(bool staged);
+
   void setStageState(git::Index::StagedState stageState);
   /*!
    * update hunk content
@@ -132,8 +113,8 @@ protected:
   void paintEvent(QPaintEvent *event);
 
 private slots:
-  void stageSelected(int startLine, int end, bool emitSignal=true);
-  void unstageSelected(int startLine, int end, bool emitSignal=true);
+  void stageSelected(int startLine, int end, bool emitSignal = true);
+  void unstageSelected(int startLine, int end, bool emitSignal = true);
   void discardSelected(int startLine, int end);
   /*!
    * Shows dialog if the changes should be discarded

--- a/src/ui/DiffView/HunkWidget.h
+++ b/src/ui/DiffView/HunkWidget.h
@@ -3,8 +3,9 @@
 
 #include <QFrame>
 #include <QCheckBox>
-#include <QWidget>
 #include <QLabel>
+#include <QToolButton>
+#include <QWidget>
 
 #include "../../editor/TextEditor.h"
 #include "../../git/Patch.h"
@@ -13,8 +14,6 @@
 #include "git/Diff.h"
 
 class DiffView;
-class Header;
-class QToolButton;
 class DisclosureButton;
 class Line;
 

--- a/src/ui/DiffView/HunkWidget.h
+++ b/src/ui/DiffView/HunkWidget.h
@@ -39,13 +39,12 @@ namespace _HunkWidget {
       QToolButton *theirsButton() const;
 
     public slots:
-      void setCheckState(git::Index::StagedState state);
+      void setStageState(git::Index::StagedState state);
 
     protected:
       void mouseDoubleClickEvent(QMouseEvent *event) override;
 
     signals:
-      void stageStateChanged(int stageState);
       void discard();
 
     private:
@@ -109,13 +108,7 @@ public:
    * \param staged
    */
   void setStaged(bool staged);
-  void setStageState(git::Index::StagedState state);
-  /*!
-   * Called by the hunk header
-   * \brief discard
-   */
-  void discard();
-  void load();
+  void setStageState(git::Index::StagedState stageState);
   /*!
    * update hunk content
    * \brief load
@@ -131,8 +124,9 @@ signals:
    * \brief stageStateChanged
    * \param stageState
    */
-  void stageStateChanged(git::Index::StagedState state);
-  void discardSignal();
+  void stageStateChanged(git::Index::StagedState stageState,
+                         bool completeHunk);
+  void discard();
 
 protected:
   void paintEvent(QPaintEvent *event);
@@ -148,7 +142,6 @@ private slots:
    * \param end
    */
   void discardDialog(int startLine, int end);
-  void headerCheckStateChanged(int state);
   /*!
    * Stage/Unstage line with index lidx
    * \brief setStaged

--- a/src/ui/DiffWidget.cpp
+++ b/src/ui/DiffWidget.cpp
@@ -67,7 +67,7 @@ DiffWidget::DiffWidget(const git::Repository &repo, QWidget *parent)
     QModelIndexList indexes = mFiles->selectionModel()->selectedIndexes();
     foreach (const QModelIndex &index, indexes)
       paths.append(index.data().toString());
-    mDiffView->updateFiles();
+    //TODO: mDiffView->updateFiles(); is OBSOLETE, use mDiffView->setFilter();
   });
 
   connect(mDiffView->verticalScrollBar(), &QScrollBar::valueChanged,

--- a/src/ui/DiffWidget.cpp
+++ b/src/ui/DiffWidget.cpp
@@ -149,7 +149,7 @@ void DiffWidget::selectFile(const QString &file)
   // FIXME: Look up the old name from the blame?
   if (!indexes.isEmpty()) {
     QModelIndex index = indexes.first();
-    if (mDiffView->scrollToFile(index.row()))
+    //OBSOLETE if (mDiffView->scrollToFile(index.row()))
       mFiles->selectionModel()->select(index, kSelectionFlags);
   }
 }

--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -231,7 +231,7 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
       QModelIndex index = mDiffTreeModel->index(path);
 
       // PartiallyStaged is a dummy signal for update only
-      git::Index::StagedState state = git::Index::StagedState::PartiallyStaged;
+      git::Index::StagedState state = git::Index::PartiallyStaged;
       mDiffTreeModel->setData(index, state, Qt::CheckStateRole);
     }
   });

--- a/src/ui/DoubleTreeWidget.h
+++ b/src/ui/DoubleTreeWidget.h
@@ -91,7 +91,5 @@ private:
    */
   QStackedWidget* mFileView{nullptr};
   bool mIgnoreSelectionChange{false};
-
-  git::Diff mDiff;
 };
 #endif // DOUBLETREEWIDGET_H

--- a/src/ui/DoubleTreeWidget.h
+++ b/src/ui/DoubleTreeWidget.h
@@ -40,9 +40,6 @@ public:
     const QString &file = QString(),
     const QString &pathspec = QString()) override;
 
-public slots:
-  void updateTreeModel(git::Index::StagedState state);
-
 private slots:
   void collapseCountChanged(int count);
 

--- a/src/ui/DoubleTreeWidget.h
+++ b/src/ui/DoubleTreeWidget.h
@@ -94,5 +94,7 @@ private:
    */
   QStackedWidget* mFileView{nullptr};
   bool mIgnoreSelectionChange{false};
+
+  git::Diff mDiff;
 };
 #endif // DOUBLETREEWIDGET_H

--- a/src/ui/TreeProxy.cpp
+++ b/src/ui/TreeProxy.cpp
@@ -8,57 +8,25 @@
 //
 
 #include "TreeProxy.h"
-#include "DiffTreeModel.h"
-#include "conf/Settings.h"
-#include "git/Blob.h"
-#include "git/Diff.h"
-#include "git/RevWalk.h"
-#include "git/Submodule.h"
-#include <QStringBuilder>
-#include <QUrl>
 
-namespace {
-
-const QString kLinkFmt = "<a href='%1'>%2</a>";
-
-} // anon. namespace
-
-TreeProxy::TreeProxy(bool staged, QObject *parent):
-	mStaged(staged),
-	QSortFilterProxyModel(parent)
-{
-}
+TreeProxy::TreeProxy(bool staged, QObject *parent)
+  : QSortFilterProxyModel(parent), mStaged(staged)
+{}
 
 TreeProxy::~TreeProxy()
-{
-}
-
-bool TreeProxy::setData(const QModelIndex &index, const QVariant &value, int role, bool ignoreIndexChanges)
-{
-    QModelIndex sourceIndex = mapToSource(index);
-    if (index.isValid() && !sourceIndex.isValid())
-        return false;
-
-    return static_cast<DiffTreeModel*>(sourceModel())->setData(sourceIndex, value, role, ignoreIndexChanges);
-}
+{}
 
 bool TreeProxy::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const
 {
-	QModelIndex index = sourceModel()->index(source_row, 0, source_parent);
-	if (!index.isValid())
-		return false;
+  QModelIndex index = sourceModel()->index(source_row, 0, source_parent);
+  if (!index.isValid())
+    return false;
 
-    // This is anymore needed, because only the diff tree is checked and so every file is modified or was added
-//    QString status = sourceModel()->data(index, DiffTreeModel::StatusRole).toString();
-//	QRegExp regexp(".*[AM?].*");
-//	if (!status.contains(regexp))
-//		return false; // if the file/folder was not modified/added ... don't show it in the tree view
+  Qt::CheckState state = static_cast<Qt::CheckState>(sourceModel()->data(index, Qt::CheckStateRole).toInt());
+  if (mStaged && state == Qt::CheckState::Unchecked)
+    return false;
+  else if (!mStaged && state == Qt::CheckState::Checked)
+    return false;
 
-	Qt::CheckState state = static_cast<Qt::CheckState>(sourceModel()->data(index, Qt::CheckStateRole).toInt());
-	if (mStaged && state == Qt::CheckState::Unchecked)
-		return false;
-	else if (!mStaged && state == Qt::CheckState::Checked)
-		return false;
-
-	return true;
+  return true;
 }

--- a/src/ui/TreeProxy.h
+++ b/src/ui/TreeProxy.h
@@ -9,14 +9,7 @@
 #ifndef TREEPROXY_H
 #define TREEPROXY_H
 
-#include "git/Diff.h"
-#include "git/Index.h"
-#include "git/Tree.h"
-#include "git/Repository.h"
 #include <QSortFilterProxyModel>
-#include <QFileIconProvider>
-
-class TreeModel;
 
 class TreeProxy : public QSortFilterProxyModel
 {
@@ -25,11 +18,10 @@ class TreeProxy : public QSortFilterProxyModel
 public:
   TreeProxy(bool staged, QObject *parent = nullptr);
   virtual ~TreeProxy();
-  bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole, bool ignoreIndexChanges = false);
-  bool staged() {return mStaged;}
+
 private:
   bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
-  bool mStaged{true}; // indicates, if only staged or only unstages files should be shown
+  bool mStaged = true; // indicates, if only staged or only unstages files should be shown
 };
 
 #endif // TREEPROXY_H


### PR DESCRIPTION
FileWidget:
When fetchMore() is called without parameter up to 4 more hunks are loaded (see header file). fetchMore(-1) will fetch all available hunks.

DiffView:
The verticalScrollBar determines if more hunks are loaded (FileWidget) or more files are loaded. fetchMore(-1) will fetch 4 more files.

When fetching a huge added file (which only has 1 hunk) the app still freezes while loading the editor. You can see a spiking cpu utilization but if the file is loaded everything is back on track. I have no file with a hung amount of hunks, please do a performance test for that case.

(This is almost the same behavior as the CommitList scrollbar and that is what I wanted to achieve)