### PR TITLE
fix edit tool and file browser for flatpak. 

### DIFF
--- a/src/tools/EditTool.cpp
+++ b/src/tools/EditTool.cpp
@@ -85,7 +85,14 @@ bool EditTool::start()
   auto signal = QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished);
   QObject::connect(process, signal, this, &ExternalTool::deleteLater);
 
-  process->start(editor, args);
+#if defined(FLATPAK)
+    args.prepend(editor);
+    args.prepend("--host");
+    process->start("flatpak-spawn", args);
+#else
+    process->start(editor, args);
+#endif
+
   if (!process->waitForStarted())
     return false;
 

--- a/src/tools/ShowTool.cpp
+++ b/src/tools/ShowTool.cpp
@@ -84,8 +84,14 @@ bool ShowTool::openFileManager(QString path)
   for(QString &part : cmdParts)
     part = part.arg(path);
 
+#if defined(FLATPAK)
+  QStringList arguments;
+  arguments << "--host" << cmdParts;
+  return QProcess::startDetached("flatpak-spawn", arguments);
+#else
   QString program = cmdParts.takeFirst();
   return QProcess::startDetached(program, cmdParts);
+#endif
 }
 
 ShowTool::ShowTool(const QString &file, QObject *parent)


### PR DESCRIPTION
So not flatpak-spawn must not be pretended.
- Tested terminal opening
- Tested editor opening
- Tested filer browser opening

@stefanknotzer @exactly-one-kas can you have a check?