### PR TITLE
Fix some links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ documentation and translations. By contributing, you agree to release
 your contributions under the terms of the license.
 
 Contribute by following the typical
-[GitHub workflow](https://guides.github.com/introduction/flow/index.html)
+[GitHub workflow](https://docs.github.com/en/get-started/quickstart/github-flow)
 for pull requests. Fork the repository and make changes on a new named
 branch. Create pull requests against the `master` branch. Follow the
 [seven guidelines](https://chris.beams.io/posts/git-commit/) to writing a

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Actions Status](https://github.com/Murmele/gitahead/workflows/GitAhead%20%28master%29/badge.svg)](https://github.com/Murmele/gitahead/actions) [![Actions Status](https://github.com/Murmele/gitahead/workflows/GitAhead%20%28stage%29/badge.svg)](https://github.com/Murmele/gitahead/actions)
-
+[![Actions Status](https://github.com/Murmele/Gittyup/actions/workflows/build.yml/badge.svg)](https://github.com/Murmele/Gittyup/actions/workflows/build.yml)
 
 Gittyup
 ==================================


### PR DESCRIPTION
This is to test if the changes in`TestEditorLineMarkers` branch works (as discussed on Matrix channel, plus to also fix some URLs in the README.