### PR TITLE
use deleteLater instead of delete

### DIFF
--- a/src/ui/DiffView/DiffView.cpp
+++ b/src/ui/DiffView/DiffView.cpp
@@ -289,7 +289,7 @@ void DiffView::updateFiles()
     while (mFiles.count()) {
         auto file = mFiles.takeFirst();
         mFileWidgetLayout->removeWidget(file);
-        delete file;
+		file->deleteLater();
     }
     mFiles.clear();
 


### PR DESCRIPTION
use deleteLater, otherwise it might be that a segmentation fault occurs if switching between different fileWidgets is to fast and some signals reach the deleted file in the current application loop iteration (https://forum.qt.io/topic/91180/delete-vs-deletelater/3)