### PR TITLE
Remove DoubleTreeWidget Arrows behind badge(s)

### DIFF
--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -111,7 +111,9 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
   treewrapperStaged->setSourceModel(mDiffTreeModel);
   stagedFiles->setModel(treewrapperStaged);
   stagedFiles->setHeaderHidden(true);
-  stagedFiles->setItemDelegateForColumn(0, new ViewDelegate());
+  ViewDelegate *stagedDelegate = new ViewDelegate();
+  stagedDelegate->setDrawArrow(false);
+  stagedFiles->setItemDelegateForColumn(0, stagedDelegate);
 
   QHBoxLayout* hBoxLayout = new QHBoxLayout();
   QLabel* label = new QLabel(kStagedFiles);
@@ -133,7 +135,9 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
   treewrapperUnstaged->setSourceModel(mDiffTreeModel);
   unstagedFiles->setModel(treewrapperUnstaged);
   unstagedFiles->setHeaderHidden(true);
-  unstagedFiles->setItemDelegateForColumn(0, new ViewDelegate());
+  ViewDelegate *unstagedDelegate = new ViewDelegate();
+  unstagedDelegate->setDrawArrow(false);
+  unstagedFiles->setItemDelegateForColumn(0, unstagedDelegate);
 
   hBoxLayout = new QHBoxLayout();
   mUnstagedCommitedFiles = new QLabel(kUnstagedFiles);

--- a/src/ui/ViewDelegate.cpp
+++ b/src/ui/ViewDelegate.cpp
@@ -14,7 +14,7 @@ void ViewDelegate::paint(
   drawBackground(painter, opt, index);
 
   // Draw >.
-  if (index.model()->hasChildren(index)) {
+  if (mDrawArrow && index.model()->hasChildren(index)) {
 	painter->save();
 	painter->setRenderHint(QPainter::Antialiasing, true);
 

--- a/src/ui/ViewDelegate.h
+++ b/src/ui/ViewDelegate.h
@@ -14,6 +14,8 @@ public:
     : QItemDelegate(parent)
   {}
 
+  void setDrawArrow(bool enable) { mDrawArrow = enable; }
+
   void paint(
     QPainter *painter,
     const QStyleOptionViewItem &option,
@@ -22,6 +24,9 @@ public:
   QSize sizeHint(
     const QStyleOptionViewItem &option,
     const QModelIndex &index) const override;
+
+private:
+  bool mDrawArrow = true;
 };
 
 #endif // VIEWDELEGATE_H


### PR DESCRIPTION
The `TreeView` is left unchanged and has arrows behind the badge(s).