### PR TITLE
Add options for Single Tree View and List View

### DIFF
--- a/src/ui/DiffTreeModel.h
+++ b/src/ui/DiffTreeModel.h
@@ -36,7 +36,11 @@ public:
   Node *parent() const;
   bool hasChildren() const;
   QList<Node *> children();
-  void addChild(const QStringList& pathPart, int patchIndex, int indexFirstDifferent);
+  void addChild(
+    const QStringList& pathPart,
+    int patchIndex,
+    int indexFirstDifferent,
+    bool listView);
   git::Index::StagedState stageState(const git::Index& idx, ParentStageState searchingState);
   void childFiles(QStringList &files);
   /*!
@@ -154,6 +158,8 @@ public:
 
   Qt::ItemFlags flags(const QModelIndex &index) const override;
 
+  void enableListView(bool enable) { mListView = enable; }
+
 signals:
   void checkStateChanged(const QModelIndex& index, int state);
 
@@ -165,6 +171,8 @@ private:
   git::Diff mDiff;
   Node *mRoot{nullptr};
   git::Repository mRepo;
+
+  bool mListView = false;
 };
 
 #endif /* DIFFTREEMODEL */

--- a/src/ui/DiffView/DiffView.cpp
+++ b/src/ui/DiffView/DiffView.cpp
@@ -378,7 +378,15 @@ void DiffView::fetchMore()
 
   auto dtw = dynamic_cast<DoubleTreeWidget*>(mParent);
   //QList<int> patchIndices = mDiffTreeModel->patchIndices(dtw->selectedIndex());
-  QList<QModelIndex> indices = mDiffTreeModel->modelIndices(dtw->selectedIndex());
+  QList<QModelIndex> indexList = dtw->selectedIndices();
+  QList<QModelIndex> indices;
+  for (auto index : indexList) {
+    QList<QModelIndex> addList = mDiffTreeModel->modelIndices(index);
+    for (auto add : addList) {
+      if (!indices.contains(add))
+        indices.append(add);
+    }
+  }
   int count = indices.count();
 
   for (int i = mFiles.count(); i < count && addedFiles < maxNewFiles; ++i) {

--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -7,6 +7,7 @@
 // Author: Martin Marmsoler
 //
 
+#include "ContextMenuButton.h"
 #include "DoubleTreeWidget.h"
 #include "BlameEditor.h"
 #include "DiffTreeModel.h"
@@ -15,6 +16,7 @@
 #include "TreeProxy.h"
 #include "TreeView.h"
 #include "ViewDelegate.h"
+#include "conf/Settings.h"
 #include "DiffView/DiffView.h"
 
 #include <QVBoxLayout>
@@ -33,6 +35,7 @@ const QString kCollapseAll = QString(QObject::tr("Collapse all"));
 const QString kStagedFiles = QString(QObject::tr("Staged Files"));
 const QString kUnstagedFiles = QString(QObject::tr("Unstaged Files"));
 const QString kCommitedFiles = QString(QObject::tr("Committed Files"));
+const QString kAllFiles = QString(QObject::tr("Workdir Files"));
 
 class SegmentedButton : public QWidget
 {
@@ -80,10 +83,33 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
   QPushButton* diffView = new QPushButton(tr("Diff"), this);
   segmentedButton->addButton(diffView, tr("Show Diff View"), true);
 
+  // Context button.
+  ContextMenuButton *contextButton = new ContextMenuButton(this);
+  QMenu *contextMenu = new QMenu(this);
+  contextButton->setMenu(contextMenu);
+  QAction *singleTree = new QAction(tr("Single Tree View"));
+  singleTree->setCheckable(true);
+  singleTree->setChecked(
+    Settings::instance()->value("doubletreeview/single", false).toBool());
+  connect(singleTree, &QAction::triggered, this, [this](bool checked) {
+    Settings::instance()->setValue("doubletreeview/single", checked);
+    RepoView::parentView(this)->refresh();
+  });
+  QAction *listView = new QAction(tr("List View"));
+  listView->setCheckable(true);
+  listView->setChecked(
+    Settings::instance()->value("doubletreeview/listview", false).toBool());
+  connect(listView, &QAction::triggered, this, [this](bool checked) {
+    Settings::instance()->setValue("doubletreeview/listview", checked);
+    RepoView::parentView(this)->refresh();
+  });
+  contextMenu->addAction(singleTree);
+  contextMenu->addAction(listView);
   QHBoxLayout *buttonLayout = new QHBoxLayout();
   buttonLayout->addStretch();
   buttonLayout->addWidget(segmentedButton);
   buttonLayout->addStretch();
+  buttonLayout->addWidget(contextButton);
 
   // bottom (Stacked widget with Blame editor and DiffView)
   QVBoxLayout* fileViewLayout = new QVBoxLayout();
@@ -105,6 +131,7 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
   QVBoxLayout* vBoxLayout = new QVBoxLayout();
   stagedFiles = new TreeView(this, "Staged");
   stagedFiles->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
+  stagedFiles->setSelectionMode(QAbstractItemView::ExtendedSelection);
   mDiffTreeModel = new DiffTreeModel(repo, this);
   mDiffView->setModel(mDiffTreeModel);
   TreeProxy* treewrapperStaged = new TreeProxy(true, this);
@@ -129,6 +156,7 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
   vBoxLayout = new QVBoxLayout();
   unstagedFiles = new TreeView(this, "Unstaged");
   unstagedFiles->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
+  unstagedFiles->setSelectionMode(QAbstractItemView::ExtendedSelection);
   TreeProxy* treewrapperUnstaged = new TreeProxy(false, this);
   treewrapperUnstaged->setSourceModel(mDiffTreeModel);
   unstagedFiles->setModel(treewrapperUnstaged);
@@ -177,23 +205,43 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
 
   const QButtonGroup* viewGroup = segmentedButton->buttonGroup();
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
-  connect(viewGroup, QOverload<int>::of(&QButtonGroup::idClicked), this, [this] (int id) {
+  connect(viewGroup, QOverload<int>::of(&QButtonGroup::idClicked), this,
+    [this] (int id) {
     mFileView->setCurrentIndex(id);
+    // Change selection mode.
+    if (id == Blame) {
+      stagedFiles->setSelectionMode(QAbstractItemView::SingleSelection);
+      unstagedFiles->setSelectionMode(QAbstractItemView::SingleSelection);
+    } else {
+      stagedFiles->setSelectionMode(QAbstractItemView::ExtendedSelection);
+      unstagedFiles->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    }
   });
 #else
-  connect(viewGroup, QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
-          [this, viewGroup](QAbstractButton *button)
+  connect(
+    viewGroup, QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
+    [this, viewGroup](QAbstractButton *button)
   {
     mFileView->setCurrentIndex(viewGroup->id(button));
+    // Change selection mode.
+    if (viewGroup->id(button) == Blame) {
+      stagedFiles->setSelectionMode(QAbstractItemView::SingleSelection);
+      unstagedFiles->setSelectionMode(QAbstractItemView::SingleSelection);
+    } else {
+      stagedFiles->setSelectionMode(QAbstractItemView::ExtendedSelection);
+      unstagedFiles->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    }
   });
 #endif
 
   connect(mDiffTreeModel, &DiffTreeModel::checkStateChanged, this, &DoubleTreeWidget::treeModelStateChanged);
 
-  connect(stagedFiles, &TreeView::fileSelected, this, &DoubleTreeWidget::fileSelected);
+  connect(stagedFiles, &TreeView::filesSelected,
+          this, &DoubleTreeWidget::filesSelected);
   connect(stagedFiles, &TreeView::collapseCountChanged, this, &DoubleTreeWidget::collapseCountChanged);
 
-  connect(unstagedFiles, &TreeView::fileSelected, this, &DoubleTreeWidget::fileSelected);
+  connect(unstagedFiles, &TreeView::filesSelected,
+          this, &DoubleTreeWidget::filesSelected);
   connect(unstagedFiles, &TreeView::collapseCountChanged, this, &DoubleTreeWidget::collapseCountChanged);
 
   connect(collapseButtonStagedFiles, &StatePushButton::clicked, this, &DoubleTreeWidget::toggleCollapseStagedFiles);
@@ -221,6 +269,23 @@ QModelIndex DoubleTreeWidget::selectedIndex() const
     return  proxy->mapToSource(indexes.first());
   }
   return QModelIndex();
+}
+
+QList<QModelIndex> DoubleTreeWidget::selectedIndices() const
+{
+  QList<QModelIndex> list;
+
+  TreeProxy* proxy = static_cast<TreeProxy *>(stagedFiles->model());
+  QModelIndexList indexes = stagedFiles->selectionModel()->selectedIndexes();
+  for (auto index : indexes)
+    list.append(proxy->mapToSource(index));
+
+  proxy = static_cast<TreeProxy *>(unstagedFiles->model());
+  indexes = unstagedFiles->selectionModel()->selectedIndexes();
+  for (auto index : indexes)
+    list.append(proxy->mapToSource(index));
+
+  return list;
 }
 
 QString DoubleTreeWidget::selectedFile() const
@@ -267,16 +332,31 @@ void DoubleTreeWidget::setDiff(const git::Diff &diff,
   else
     unstagedFiles->collapseAll();
 
+// Single tree & list view.
+  bool singleTree =
+    Settings::instance()->value("doubletreeview/single", false).toBool();
+  bool listView =
+    Settings::instance()->value("doubletreeview/listview", false).toBool();
+
+  // Widget modifications.
+  model->enableListView(listView);
+  stagedFiles->setRootIsDecorated(!listView);
+  unstagedFiles->setRootIsDecorated(!listView);
+  //mUnstagedCommitedFiles->setVisible(!singleTree);
+  collapseButtonStagedFiles->setVisible(!listView);
+  collapseButtonUnstagedFiles->setVisible(!listView);
+
   // If statusDiff, there exist no staged/unstaged, but only
   // the commited files must be shown
   if (!diff.isValid() || diff.isStatusDiff()) {
-    mUnstagedCommitedFiles->setText(kUnstagedFiles);
+    mUnstagedCommitedFiles->setText(singleTree ? kAllFiles : kUnstagedFiles);
     if (diff.isValid() && diff.count() < 100)
       stagedFiles->expandAll();
     else
       stagedFiles->collapseAll();
 
-    mStagedWidget->setVisible(true);
+    proxy->enableFilter(!singleTree);
+    mStagedWidget->setVisible(!singleTree);
   } else {
     mUnstagedCommitedFiles->setText(kCommitedFiles);
     mStagedWidget->setVisible(false);
@@ -398,9 +478,9 @@ void DoubleTreeWidget::collapseCountChanged(int count)
     collapseButtonUnstagedFiles->setState(count == 0);
 }
 
-void DoubleTreeWidget::fileSelected(const QModelIndex &index)
+void DoubleTreeWidget::filesSelected(const QModelIndexList &indexes)
 {
-  if (!index.isValid())
+  if (indexes.isEmpty())
     return;
 
   QObject* obj = QObject::sender();
@@ -414,18 +494,23 @@ void DoubleTreeWidget::fileSelected(const QModelIndex &index)
       unstagedFiles->setFocus();
     }
   }
-  loadEditorContent(index);
+  loadEditorContent(indexes);
 }
 
-void DoubleTreeWidget::loadEditorContent(const QModelIndex &index)
+void DoubleTreeWidget::loadEditorContent(const QModelIndexList &indexes)
 {
-  QString name = index.data(Qt::EditRole).toString();
-  QList<git::Commit> commits = RepoView::parentView(this)->commits();
-  git::Commit commit = !commits.isEmpty() ? commits.first() : git::Commit();
-  RepoView *view = RepoView::parentView(this);
-  int idx = mDiff.isValid() ? mDiff.indexOf(name) : -1;
-  git::Blob blob = idx < 0 ? git::Blob() :
-                             view->repo().lookupBlob(mDiff.id(idx, git::Diff::NewFile));
+  QString name;
+  git::Blob blob;
+  git::Commit commit;
+
+  if (indexes.count() == 1) {
+    RepoView *view = RepoView::parentView(this);
+    name = indexes.first().data(Qt::EditRole).toString();
+    QList<git::Commit> commits = view->commits();
+    commit = !commits.isEmpty() ? commits.first() : git::Commit();
+    int idx = mDiff.isValid() ? mDiff.indexOf(name) : -1;
+    blob = idx < 0 ? git::Blob() : view->repo().lookupBlob(mDiff.id(idx, git::Diff::NewFile));
+  }
 
   mEditor->load(name, blob, commit);
 

--- a/src/ui/DoubleTreeWidget.h
+++ b/src/ui/DoubleTreeWidget.h
@@ -10,10 +10,11 @@
 #ifndef DOUBLETREEWIDGET_H
 #define DOUBLETREEWIDGET_H
 
-#include "DetailView.h" // ContentWidget
+#include "DiffTreeModel.h"
+#include "DetailView.h"
+#include <QModelIndexList>
 
 class QTreeView;
-class DiffTreeModel;
 class TreeView;
 class BlameEditor;
 class StatePushButton;
@@ -33,6 +34,7 @@ class DoubleTreeWidget : public ContentWidget
 public:
   DoubleTreeWidget(const git::Repository &repo, QWidget *parent = nullptr);
   QModelIndex selectedIndex() const override;
+  QList<QModelIndex> selectedIndices() const;
   QString selectedFile() const override;
 
   void setDiff(
@@ -61,8 +63,8 @@ private:
   void treeModelStateChanged(const QModelIndex& index, int checkState);
   void storeSelection();
   void loadSelection();
-  void fileSelected(const QModelIndex &index);
-  void loadEditorContent(const QModelIndex &index);
+  void filesSelected(const QModelIndexList &indexes);
+  void loadEditorContent(const QModelIndexList &indexes);
   void toggleCollapseStagedFiles();
   void toggleCollapseUnstagedFiles();
 

--- a/src/ui/TreeProxy.cpp
+++ b/src/ui/TreeProxy.cpp
@@ -48,6 +48,9 @@ bool TreeProxy::filterAcceptsRow(int source_row, const QModelIndex &source_paren
 	if (!index.isValid())
 		return false;
 
+  if (!mFilter)
+    return true;
+
     // This is anymore needed, because only the diff tree is checked and so every file is modified or was added
 //    QString status = sourceModel()->data(index, DiffTreeModel::StatusRole).toString();
 //	QRegExp regexp(".*[AM?].*");

--- a/src/ui/TreeProxy.h
+++ b/src/ui/TreeProxy.h
@@ -27,9 +27,12 @@ public:
   virtual ~TreeProxy();
   bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole, bool ignoreIndexChanges = false);
   bool staged() {return mStaged;}
+
+  void enableFilter(bool enable) { mFilter = enable; }
 private:
   bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
   bool mStaged{true}; // indicates, if only staged or only unstages files should be shown
+  bool mFilter = true;
 };
 
 #endif // TREEPROXY_H

--- a/src/ui/TreeView.cpp
+++ b/src/ui/TreeView.cpp
@@ -158,12 +158,12 @@ void TreeView::handleSelectionChange(
   const QItemSelection &selected,
   const QItemSelection &deselected)
 {
+  Q_UNUSED(selected)
+
   // FIXME: The argument sent by Qt doesn't contain the whole selection.
   QModelIndexList indexes = selectionModel()->selectedIndexes();
-  if (indexes.length() > 0) {
-	  QModelIndex index = (indexes.size() == 1) ? indexes.first() : QModelIndex();
-	  emit fileSelected(index);
-  }
+  if (indexes.count() > 0)
+    emit filesSelected(indexes);
 
   // ignore deselection handling, because when selecting an item in the second
   // TreeView (staged/unstaged files), the root should not be set selected. Anything

--- a/src/ui/TreeView.h
+++ b/src/ui/TreeView.h
@@ -67,7 +67,7 @@ public slots:
 
 signals:
   void linkActivated(const QString &link);
-  void fileSelected(const QModelIndex &index);
+  void filesSelected(const QModelIndexList &indexes);
   void collapseCountChanged(int count);
 
 private:


### PR DESCRIPTION
Context menu button added next to Blame/Diff buttons:
new settings to toggle between the default double tree view and a single tree view
new setting to toggle between Tree View and List View
In diff view mode multiple selections are possible (in both tree and list view).

Addresses issue #90 