### PR TITLE
Restore the default FileContextMenu in DoubleTreeWidget

### DIFF
--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -306,25 +306,6 @@ void DoubleTreeWidget::findPrevious()
   mEditor->findPrevious();
 }
 
-void DoubleTreeWidget::contextMenuEvent(QContextMenuEvent *event)
-{
-  QStringList files;
-  QModelIndexList indexes = unstagedFiles->selectionModel()->selectedIndexes();
-  foreach (const QModelIndex &index, indexes)
-    files.append(index.data(Qt::EditRole).toString());
-
-  indexes = stagedFiles->selectionModel()->selectedIndexes();
-    foreach (const QModelIndex &index, indexes)
-      files.append(index.data(Qt::EditRole).toString());
-
-  if (files.isEmpty())
-    return;
-
-  RepoView *view = RepoView::parentView(this);
-  FileContextMenu menu(view, files);
-  menu.exec(event->globalPos());
-}
-
 void DoubleTreeWidget::cancelBackgroundTasks()
 {
   mEditor->cancelBlame();

--- a/src/ui/DoubleTreeWidget.h
+++ b/src/ui/DoubleTreeWidget.h
@@ -46,9 +46,6 @@ public:
   void findNext() override;
   void findPrevious() override;
 
-protected:
-  void contextMenuEvent(QContextMenuEvent *event) override;
-
 private slots:
   void collapseCountChanged(int count);
 


### PR DESCRIPTION
Use the apps full blown `FileContextMenu` in `DoubleTreeWidget`.

Might also address issue #90 