### PR TITLE
Fix Segmentation fault if file is removed and symlink created

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
         if: github.ref_type != 'tag'
         uses: allenevans/set-env@c4f231179ef63887be707202a295d9cb1c687eb9
         with:
-          CMAKE_FLAGS: "-DDEV_BUILD=${{ github.ref_name }}"
+          CMAKE_FLAGS: '-DDEV_BUILD="${{ github.ref_name }}"'
 
       - name: Checkout repository
         uses: actions/checkout@v1

--- a/src/git/Commit.cpp
+++ b/src/git/Commit.cpp
@@ -153,6 +153,7 @@ Diff Commit::diff(
 
   git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
   opts.context_lines = contextLines;
+  opts.flags |=  GIT_DIFF_INCLUDE_TYPECHANGE;
   if (ignoreWhitespace)
     opts.flags |= GIT_DIFF_IGNORE_WHITESPACE;
 

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -349,7 +349,7 @@ Diff Repository::diffTreeToIndex(
   bool ignoreWhitespace) const
 {
   git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
-  opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED | GIT_DIFF_RECURSE_UNTRACKED_DIRS;
+  opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED | GIT_DIFF_RECURSE_UNTRACKED_DIRS | GIT_DIFF_INCLUDE_TYPECHANGE;
   if (ignoreWhitespace)
     opts.flags |= GIT_DIFF_IGNORE_WHITESPACE;
 
@@ -364,7 +364,7 @@ Diff Repository::diffIndexToWorkdir(
   bool ignoreWhitespace) const
 {
   git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
-  opts.flags |= (GIT_DIFF_INCLUDE_UNTRACKED | GIT_DIFF_RECURSE_UNTRACKED_DIRS | GIT_DIFF_DISABLE_MMAP);
+  opts.flags |= (GIT_DIFF_INCLUDE_UNTRACKED | GIT_DIFF_RECURSE_UNTRACKED_DIRS | GIT_DIFF_DISABLE_MMAP | GIT_DIFF_INCLUDE_TYPECHANGE);
   if (ignoreWhitespace)
     opts.flags |= GIT_DIFF_IGNORE_WHITESPACE;
 

--- a/src/ui/DiffTreeModel.cpp
+++ b/src/ui/DiffTreeModel.cpp
@@ -415,7 +415,7 @@ void Node::addChild(
   int indexFirstDifferent,
   bool listView)
 {
-  Node* node;
+  Node* node = nullptr;
 
   if (listView) {
     // Add child with full path in list view.
@@ -432,10 +432,11 @@ void Node::addChild(
       // Folders cannot have a patch Index!
       node = new Node(pathPart[indexFirstDifferent], -1, this);
       node->addChild(pathPart, patchIndex, indexFirstDifferent + 1, false);
-    } else
+	} else if (indexFirstDifferent < pathPart.length())
       node = new Node(pathPart[indexFirstDifferent], patchIndex, this);
   }
-  mChildren.append(node);
+  if (node)
+	mChildren.append(node);
 }
 
 git::Index::StagedState Node::stageState(const git::Index& idx, ParentStageState searchingState)


### PR DESCRIPTION
It does not crash anymore and typechanges are now visible

fixes #114 

1) Create new git repo
2) Add file "test.txt" and commit
3) move file outside of the repository
4) create symlink: ln -s <path_to_test.txt>/test.txt test.txt
5) Open Repository with Gittyup