### PR TITLE
use bundled zlib on win64 too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,7 @@ jobs:
             qt_arch_check_only: win64_msvc2017_64
             openssl_arch: VC-WIN64A
             msvc_arch: x64
+            cmake_flags: "-DUSE_BUNDLED_ZLIB=1"
             cmake_env:
               CMAKE_RC_FLAGS: "/C 1252"
               CC: clang


### PR DESCRIPTION
use bundled zlib on win64 too, otherwise no zlib is included and the application cannot be started

fixes comment in #159 