### PR TITLE
Fix publish github page only when tagging on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -350,12 +350,12 @@ jobs:
 
       # needed otherwise the docs folder is not available     
       - name: Checkout repository
-        if: ${{ env.IS_RELEASE }}
+        if: ${{ env.IS_RELEASE == 'true'}}
         uses: actions/checkout@v1
 
       # update github pages only if it is a release 
       - name: Deploy Github pages
-        if: ${{ env.IS_RELEASE }}
+        if: ${{ env.IS_RELEASE  == 'true'}}
         uses: JamesIves/github-pages-deploy-action@v4.3.3
         with:
           branch: gh-pages # The branch the action should deploy to.


### PR DESCRIPTION
IS_RELEASE is a string, because in an environment variable only strings can be stored so compare to true must be done

fixes #163 