### PR TITLE
use the functions of the Repoview to update submodules

### DIFF
--- a/src/ui/DiffTreeModel.cpp
+++ b/src/ui/DiffTreeModel.cpp
@@ -259,18 +259,18 @@ bool DiffTreeModel::discard(const QModelIndex &index) {
   }
 
   auto s = mRepo.submodules();
+  QList<git::Submodule> submodules;
   QStringList filePatches;
   for (auto trackedPatch : trackedPatches) {
     bool is_submodule = false;
     for (auto submodule : s) {
       if (submodule.path() == trackedPatch) {
         is_submodule = true;
-        submodule.update(nullptr, false,
-                         true); // In Repo view it is done asynchron. Maybe
-                                // changing here too!
+        submodules.append(submodule);
         break;
       }
     }
+    emit updateSubmodules(submodules, true, false, true);
 
     if (!is_submodule)
       filePatches.append(trackedPatch);

--- a/src/ui/DiffTreeModel.h
+++ b/src/ui/DiffTreeModel.h
@@ -147,6 +147,8 @@ public:
 
 signals:
   void checkStateChanged(const QModelIndex &index, int state);
+  void updateSubmodules(const QList<git::Submodule> &submodules, bool recursive,
+                        bool init, bool checkout_force);
 
 private:
   Node *node(const QModelIndex &index) const;

--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -124,6 +124,14 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
   stagedFiles->setSelectionMode(QAbstractItemView::ExtendedSelection);
   mDiffTreeModel = new DiffTreeModel(repo, this);
   mDiffView->setModel(mDiffTreeModel);
+  auto *repoView = qobject_cast<RepoView *>(parent->parent());
+  Q_ASSERT(repoView);
+  connect(mDiffTreeModel, &DiffTreeModel::updateSubmodules,
+          [repoView](const QList<git::Submodule> &submodules, bool recursive,
+                     bool init, bool force_checkout) {
+            repoView->updateSubmodules(submodules, recursive, init,
+                                       force_checkout);
+          });
   TreeProxy *treewrapperStaged = new TreeProxy(true, this);
   treewrapperStaged->setSourceModel(mDiffTreeModel);
   stagedFiles->setModel(treewrapperStaged);


### PR DESCRIPTION
Currently a nullptr as callback is given as argument. If the update fails a nullptr exception occurs. fixes #39