### PR TITLE
hunks must be loaded before applying the patch

### DIFF
--- a/src/ui/DiffView/HunkWidget.cpp
+++ b/src/ui/DiffView/HunkWidget.cpp
@@ -1176,7 +1176,9 @@ QByteArray HunkWidget::hunk() const {
   return ar;
 }
 
-QByteArray HunkWidget::apply() const {
+QByteArray HunkWidget::apply() {
+
+  load(mStaged);
   QByteArray ar;
   int lineCount = mEditor->lineCount();
   for (int i = 0; i < lineCount; i++) {

--- a/src/ui/DiffView/HunkWidget.h
+++ b/src/ui/DiffView/HunkWidget.h
@@ -82,7 +82,7 @@ public:
    * \brief hunk
    * \return
    */
-  QByteArray apply() const;
+  QByteArray apply();
   /*!
    * \brief stageState
    * Calculate stage state of the hunk. Git does not provide


### PR DESCRIPTION
hunks must be loaded before applying the patch, otherwise no content is available in mEditor and therefore nothing will be processed. This leads that no content is applied (even the unchanged lines) and then the staged patch contains a lot of deleted lines. The hunkwidget will be loaded only once it will be painted and this does not happen with a lot of hunks if in the diffview it will not be scrolled to the end so that all hunks get painted at least once.

fixes #106 