### PR TITLE
trigger also on tag pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
     - master
+    tags:
+    - 'gittyup_v*'
   pull_request:
   page_build:
   workflow_dispatch:


### PR DESCRIPTION
The creation of tag gittyup_v1.1.1 did not trigger the build, because we allow only triggers for specific branches. Therefore the publish of the new version did not work