### PR TITLE
Fix dead links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Gittyup
 ==================================
 
 Gittyup is a graphical Git client designed to help you understand and manage your source code history. The [pre-release](https://github.com/Murmele/Gittyup/releases)
-is available either as pre-built [flatpak for Linux](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup.flatpak), [32](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup-win32-1.1.0-dev.exe) / [64](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup-win64-1.1.0-dev.exe) binary for Windows, [macOS](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup-1.1.0-dev.dmg),
+is available either as pre-built [flatpak for Linux](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup.flatpak), [32](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup-win32-1.1.1-dev.exe) / [64](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup-win64-1.1.1-dev.exe) binary for Windows, [macOS](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup-1.1.1-dev.dmg),
 or can be built from source by following the directions [below](https://github.com/Murmele/Gittyup#how-to-build).
 
 Gittyup is a continuation of the [GitAhead](https://github.com/gitahead/gitahead) client.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 Gittyup
 ==================================
 
-Gittyup is a graphical Git client designed to help you understand and manage your source code history. The [pre-release](https://github.com/Murmele/Gittyup/releases)
-is available either as pre-built [flatpak for Linux](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup.flatpak), [32](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup-win32-1.1.1-dev.exe) / [64](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup-win64-1.1.1-dev.exe) binary for Windows, [macOS](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup-1.1.1-dev.dmg),
+Gittyup is a graphical Git client designed to help you understand and manage your source code history. The [latest release](https://github.com/Murmele/Gittyup/releases/latest)
+is available either as pre-built flatpak for Linux, 32 / 64 binary for Windows, macOS,
 or can be built from source by following the directions [below](https://github.com/Murmele/Gittyup#how-to-build).
 
 Gittyup is a continuation of the [GitAhead](https://github.com/gitahead/gitahead) client.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,15 +2,15 @@
 
 Gittyup is a graphical Git client designed to help you understand and manage your source code history. Gittyup is an open source software developed by voluntiers, if you like the application please support us [![Donate Liberapay](https://liberapay.com/assets/widgets/donate.svg)](https://liberapay.com/Gittyup/donate)
 
-The release version is available for
-- [flatpak for Linux](https://github.com/Murmele/Gittyup/releases/download/stable/Gittyup.flatpak)
-- [32](https://github.com/Murmele/Gittyup/releases/download/stable/Gittyup-win32-1.1.0.exe) / [64](https://github.com/Murmele/Gittyup/releases/download/stable/Gittyup-win64-1.1.0.exe) binary for Windows
+The [stable version](https://github.com/Murmele/Gittyup/releases/stable) is available for
+- flatpak for Linux
+- 32 / 64 binary for Windows or
+- macOS X
 
-
-The [development version](https://github.com/Murmele/Gittyup/releases) is available either as pre-built for
-- [flatpak for Linux](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup.flatpak),
-- [32](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup-win32-1.1.0-dev.exe) / [64](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup-win64-1.1.0-dev.exe) binary for Windows,
-- [macOS X](https://github.com/Murmele/Gittyup/releases/download/latest/Gittyup-1.1.0-dev.dmg)
+The [latest version](https://github.com/Murmele/Gittyup/releases/latest) is available either as pre-built for
+- flatpak for Linux,
+- 32 / 64 binary for Windows,
+- macOS X
 
 or, can be built from source by following the directions in the [Gittyup Repository](https://github.com/Murmele/Gittyup#how-to-build).
 


### PR DESCRIPTION
Shouldn't the 1.1.1 stable release also be linked by the README.md ?