### PR TITLE
Fix crash when having errors while adding a remote account

### DIFF
--- a/src/host/Account.h
+++ b/src/host/Account.h
@@ -16,6 +16,7 @@
 #include <QSharedPointer>
 #include <QString>
 #include <QTimer>
+#include <qnetworkreply.h>
 
 class AccountError;
 class AccountProgress;
@@ -59,6 +60,8 @@ public:
 
   QString repositoryPath(int index) const;
   void setRepositoryPath(int index, const QString &path);
+
+  void setErrorReply(const QNetworkReply &reply);
 
   virtual Kind kind() const = 0;
   virtual QString name() const = 0;
@@ -107,7 +110,10 @@ protected:
 
   AccountError *mError;
   AccountProgress *mProgress;
-  QNetworkAccessManager mMgr;
+  QNetworkAccessManager *mMgr;
+
+private:
+  QList<QSslError> sslErrors;
 };
 
 class AccountError : public QObject {

--- a/src/host/Beanstalk.cpp
+++ b/src/host/Beanstalk.cpp
@@ -19,7 +19,7 @@
 
 Beanstalk::Beanstalk(const QString &username) : Account(username) {
   QObject::connect(
-      &mMgr, &QNetworkAccessManager::finished, this,
+      mMgr, &QNetworkAccessManager::finished, this,
       [this](QNetworkReply *reply) {
         reply->deleteLater();
 
@@ -41,7 +41,7 @@ Beanstalk::Beanstalk(const QString &username) : Account(username) {
             repo->setUrl(Repository::Ssh, sshUrl);
           }
         } else {
-          mError->setText(tr("Connection failed"), reply->errorString());
+          setErrorReply(*reply);
         }
 
         mProgress->finish();
@@ -61,7 +61,7 @@ void Beanstalk::connect(const QString &password) {
 
   QNetworkRequest request(url() + "/api/repositories.json");
   if (setHeaders(request, password)) {
-    mMgr.get(request);
+    mMgr->get(request);
     startProgress();
   }
 }

--- a/src/host/Bitbucket.cpp
+++ b/src/host/Bitbucket.cpp
@@ -27,7 +27,7 @@ const char *kPasswordProperty = "password";
 
 Bitbucket::Bitbucket(const QString &username) : Account(username) {
   QObject::connect(
-      &mMgr, &QNetworkAccessManager::finished, this,
+      mMgr, &QNetworkAccessManager::finished, this,
       [this](QNetworkReply *reply) {
         QString password = reply->property(kPasswordProperty).toString();
         if (password.isEmpty())
@@ -36,7 +36,7 @@ Bitbucket::Bitbucket(const QString &username) : Account(username) {
         reply->deleteLater();
 
         if (reply->error() != QNetworkReply::NoError) {
-          mError->setText(tr("Connection failed"), reply->errorString());
+          setErrorReply(*reply);
           mProgress->finish();
           return;
         }
@@ -71,7 +71,7 @@ Bitbucket::Bitbucket(const QString &username) : Account(username) {
         // Request next page.
         QNetworkRequest request(next);
         if (setHeaders(request, password)) {
-          QNetworkReply *reply = mMgr.get(request);
+          QNetworkReply *reply = mMgr->get(request);
           reply->setProperty(kPasswordProperty, password);
           startProgress();
         }
@@ -93,8 +93,7 @@ void Bitbucket::connect(const QString &password) {
   request.setHeader(QNetworkRequest::ContentTypeHeader, kContentType);
 
   if (setHeaders(request, password)) {
-    mMgr.get(request);
-    QNetworkReply *reply = mMgr.get(request);
+    QNetworkReply *reply = mMgr->get(request);
     reply->setProperty(kPasswordProperty,
                        !password.isEmpty() ? password : this->password());
     startProgress();

--- a/src/host/GitLab.cpp
+++ b/src/host/GitLab.cpp
@@ -27,12 +27,12 @@ const QString kProjectsFmt = "/projects?membership=true&private_token=%1";
 
 GitLab::GitLab(const QString &username) : Account(username) {
   QObject::connect(
-      &mMgr, &QNetworkAccessManager::finished, this,
+      mMgr, &QNetworkAccessManager::finished, this,
       [this](QNetworkReply *reply) {
         reply->deleteLater();
 
         if (reply->error() != QNetworkReply::NoError) {
-          mError->setText(tr("Connection failed"), reply->errorString());
+          setErrorReply(*reply);
           mProgress->finish();
           return;
         }
@@ -75,7 +75,7 @@ GitLab::GitLab(const QString &username) : Account(username) {
         // Request next page.
         QNetworkRequest request(next);
         request.setHeader(QNetworkRequest::ContentTypeHeader, kContentType);
-        mMgr.get(request);
+        mMgr->get(request);
         startProgress();
       });
 }
@@ -100,7 +100,7 @@ void GitLab::connect(const QString &defaultPassword) {
 
   QNetworkRequest request(url() + kProjectsFmt.arg(token));
   request.setHeader(QNetworkRequest::ContentTypeHeader, kContentType);
-  mMgr.get(request);
+  mMgr->get(request);
   startProgress();
 }
 


### PR DESCRIPTION
Also improve error messages for remote account connection failures

This fixes an access to a dangling pointer when remote account authentication fails