### PR TITLE
Remove unused but automatically started HTTP server for GitHub authentication

### DIFF
--- a/src/host/Account.h
+++ b/src/host/Account.h
@@ -15,7 +15,6 @@
 #include <QObject>
 #include <QSharedPointer>
 #include <QString>
-#include <QTcpServer>
 #include <QTimer>
 
 class AccountError;
@@ -109,7 +108,6 @@ protected:
   AccountError *mError;
   AccountProgress *mProgress;
   QNetworkAccessManager mMgr;
-  QTcpServer mRedirectServer;
 };
 
 class AccountError : public QObject {


### PR DESCRIPTION
This has been there from the first commit, but doesn't get used at all (anymore)