### PR TITLE
docs: updated README (build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,16 @@ Windows:
     perl Configure VC-WIN64A
     nmake
 
-macOS:
+macOS (Intel):
 
     ./Configure darwin64-x86_64-cc no-shared
     make
+    
+macOS (Apple Silicon)
 
+    ./Configure darwin64-arm64-cc no-shared
+    make
+    
 Linux:
 
     ./config -fPIC


### PR DESCRIPTION
Updated the build instructions for compiling OpenSSL. Should be in ```darwin64-arm64-cc``` otherwise project will not link correctly on Apple Silicon.

Although it built for me, please feel free to correct me if this is not correct.

Cheers