### PR TITLE
Show branchname or tag in merge commit message by default

### DIFF
--- a/src/ui/ReferenceList.cpp
+++ b/src/ui/ReferenceList.cpp
@@ -48,14 +48,14 @@ ReferenceList::ReferenceList(const git::Repository &repo,
   // Select index. Priority: Branch --> Tag --> Remote --> Commit ID
   QModelIndex idx;
   if ((idx = view->firstBranch()).isValid())
-		setRootModelIndex(model->index(0, 0));
+    setRootModelIndex(model->index(0, 0));
   else if ((idx = view->firstTag()).isValid())
-      setRootModelIndex(model->index(2, 0));
+    setRootModelIndex(model->index(2, 0));
   else if ((idx = view->firstRemote()).isValid())
-      setRootModelIndex(model->index(1, 0));
+    setRootModelIndex(model->index(1, 0));
   else {
-      setRootModelIndex(model->index(0, 0));
-      idx = model->index(0, 0);
+    setRootModelIndex(model->index(0, 0));
+    idx = model->index(0, 0);
   }
   setCurrentIndex(idx.row());
 
@@ -90,9 +90,7 @@ git::Reference ReferenceList::currentReference() const {
   return currentData(Qt::UserRole).value<git::Reference>();
 }
 
-void ReferenceList::setCommit(const git::Commit &commit) {
-  mCommit = commit;
-}
+void ReferenceList::setCommit(const git::Commit &commit) { mCommit = commit; }
 
 void ReferenceList::select(const git::Reference &ref, bool spontaneous) {
   if (!ref.isValid()) {

--- a/src/ui/ReferenceList.cpp
+++ b/src/ui/ReferenceList.cpp
@@ -45,12 +45,12 @@ ReferenceList::ReferenceList(const git::Repository &repo,
   setModel(model);
   setView(view);
 
-  // Select index. Priority: Tag --> Branch --> Remote --> First index
+  // Select index. Priority: Branch --> Tag --> Remote --> Commit ID
   QModelIndex idx;
-  if ((idx = view->firstTag()).isValid())
+  if ((idx = view->firstBranch()).isValid())
+		setRootModelIndex(model->index(0, 0));
+  else if ((idx = view->firstTag()).isValid())
       setRootModelIndex(model->index(2, 0));
-  else if ((idx = view->firstBranch()).isValid())
-      setRootModelIndex(model->index(0, 0));
   else if ((idx = view->firstRemote()).isValid())
       setRootModelIndex(model->index(1, 0));
   else {

--- a/src/ui/ReferenceList.cpp
+++ b/src/ui/ReferenceList.cpp
@@ -45,9 +45,19 @@ ReferenceList::ReferenceList(const git::Repository &repo,
   setModel(model);
   setView(view);
 
-  // Select the first valid index.
-  setRootModelIndex(model->index(0, 0));
-  setCurrentIndex(0);
+  // Select index. Priority: Tag --> Branch --> Remote --> First index
+  QModelIndex idx;
+  if ((idx = view->firstTag()).isValid())
+      setRootModelIndex(model->index(2, 0));
+  else if ((idx = view->firstBranch()).isValid())
+      setRootModelIndex(model->index(0, 0));
+  else if ((idx = view->firstRemote()).isValid())
+      setRootModelIndex(model->index(1, 0));
+  else {
+      setRootModelIndex(model->index(0, 0));
+      idx = model->index(0, 0);
+  }
+  setCurrentIndex(idx.row());
 
   connect(this, QOverload<int>::of(&QComboBox::currentIndexChanged),
           [this](int index) {
@@ -82,8 +92,9 @@ git::Reference ReferenceList::currentReference() const {
 
 void ReferenceList::setCommit(const git::Commit &commit) {
   mCommit = commit;
-  if (commit.isValid())
-    setCurrentIndex(-1);
+// If this is on, by default the commit id is shown and used in the merge commit message
+//  if (commit.isValid())
+//    setCurrentIndex(-1);
 }
 
 void ReferenceList::select(const git::Reference &ref, bool spontaneous) {

--- a/src/ui/ReferenceList.cpp
+++ b/src/ui/ReferenceList.cpp
@@ -92,9 +92,6 @@ git::Reference ReferenceList::currentReference() const {
 
 void ReferenceList::setCommit(const git::Commit &commit) {
   mCommit = commit;
-// If this is on, by default the commit id is shown and used in the merge commit message
-//  if (commit.isValid())
-//    setCurrentIndex(-1);
 }
 
 void ReferenceList::select(const git::Reference &ref, bool spontaneous) {

--- a/src/ui/ReferenceView.cpp
+++ b/src/ui/ReferenceView.cpp
@@ -43,11 +43,7 @@ bool refComparator(const git::Reference &lhs, const git::Reference &rhs) {
           lhsCommit.committer().date() > rhsCommit.committer().date());
 }
 
-enum ReferenceType {
-    Branches = 0,
-    Remotes = 1,
-    Tags = 2
-};
+enum ReferenceType { Branches = 0, Remotes = 1, Tags = 2 };
 
 class ReferenceModel : public QAbstractItemModel {
   Q_OBJECT
@@ -137,33 +133,33 @@ public:
   }
 
   QModelIndex firstRemote() {
-      // Return first remote if available, otherwise an invalid modelIndex
-      for (auto& ref: mRefs) {
-          if (ref.name == tr("Remotes") && ref.refs.count() > 0)
-              return createIndex(0, 0, ReferenceType::Remotes);
-      }
-      return QModelIndex();
+    // Return first remote if available, otherwise an invalid modelIndex
+    for (auto &ref : mRefs) {
+      if (ref.name == tr("Remotes") && ref.refs.count() > 0)
+        return createIndex(0, 0, ReferenceType::Remotes);
+    }
+    return QModelIndex();
   }
 
   QModelIndex firstBranch() {
-      // Return first branch if available, otherwise an invalid modelIndex
-      for (auto& ref: mRefs) {
-          if (ref.name == tr("Branches") && ref.refs.count() > 0) {
-              if (mKinds & ReferenceView::InvalidRef && ref.refs.count() > 1)
-                return createIndex(0 + 1, 0, ReferenceType::Branches);
-              else
-                return createIndex(0, 0, ReferenceType::Branches);
-          }
+    // Return first branch if available, otherwise an invalid modelIndex
+    for (auto &ref : mRefs) {
+      if (ref.name == tr("Branches") && ref.refs.count() > 0) {
+        if (mKinds & ReferenceView::InvalidRef && ref.refs.count() > 1)
+          return createIndex(0 + 1, 0, ReferenceType::Branches);
+        else
+          return createIndex(0, 0, ReferenceType::Branches);
       }
-      return QModelIndex();
+    }
+    return QModelIndex();
   }
 
   QModelIndex firstTag() {
     // Return first tag if available, otherwise an invalid modelIndex
 
-    for (auto& ref: mRefs) {
-        if (ref.name == tr("Tags") && ref.refs.count() > 0)
-            return createIndex(0, 0, ReferenceType::Tags);
+    for (auto &ref : mRefs) {
+      if (ref.name == tr("Tags") && ref.refs.count() > 0)
+        return createIndex(0, 0, ReferenceType::Tags);
     }
     return QModelIndex();
   }
@@ -182,11 +178,12 @@ public:
     if (!index.isValid())
       return QModelIndex();
 
-    // The sections (Branches, Remotes, Tags) (Elements of mRefs) do not have an internalId()
-    // Those sections don't have any parents, only the refs in each mRefs element
+    // The sections (Branches, Remotes, Tags) (Elements of mRefs) do not have an
+    // internalId() Those sections don't have any parents, only the refs in each
+    // mRefs element
     quintptr id = index.internalId();
     if (!id)
-        return QModelIndex();
+      return QModelIndex();
     auto refType = static_cast<ReferenceType>(id - 1);
     return createIndex(refType, 0);
   }
@@ -428,7 +425,7 @@ ReferenceView::ReferenceView(const git::Repository &repo, Kinds kinds,
   setFocusProxy(field);
 
   // Update model last.
-  static_cast<ReferenceModel*>(mSource)->update();
+  static_cast<ReferenceModel *>(mSource)->update();
 }
 
 void ReferenceView::resetTabIndex() {
@@ -440,27 +437,27 @@ void ReferenceView::resetTabIndex() {
 }
 
 QModelIndex ReferenceView::firstBranch() {
-    auto index = static_cast<ReferenceModel*>(mSource)->firstBranch();
-    index = static_cast<FilterProxyModel*>(model())->mapFromSource(index);
-    if (!index.isValid())
-        return QModelIndex();
-    return index;
+  auto index = static_cast<ReferenceModel *>(mSource)->firstBranch();
+  index = static_cast<FilterProxyModel *>(model())->mapFromSource(index);
+  if (!index.isValid())
+    return QModelIndex();
+  return index;
 }
 
 QModelIndex ReferenceView::firstTag() {
-    auto index = static_cast<ReferenceModel*>(mSource)->firstTag();
-    index = static_cast<FilterProxyModel*>(model())->mapFromSource(index);
-    if (!index.isValid())
-        return QModelIndex();
-    return index;
+  auto index = static_cast<ReferenceModel *>(mSource)->firstTag();
+  index = static_cast<FilterProxyModel *>(model())->mapFromSource(index);
+  if (!index.isValid())
+    return QModelIndex();
+  return index;
 }
 
 QModelIndex ReferenceView::firstRemote() {
-    auto index = static_cast<ReferenceModel*>(mSource)->firstRemote();
-    index = static_cast<FilterProxyModel*>(model())->mapFromSource(index);
-    if (!index.isValid())
-        return QModelIndex();
-    return index;
+  auto index = static_cast<ReferenceModel *>(mSource)->firstRemote();
+  index = static_cast<FilterProxyModel *>(model())->mapFromSource(index);
+  if (!index.isValid())
+    return QModelIndex();
+  return index;
 }
 
 git::Reference ReferenceView::currentReference() const {

--- a/src/ui/ReferenceView.cpp
+++ b/src/ui/ReferenceView.cpp
@@ -43,6 +43,12 @@ bool refComparator(const git::Reference &lhs, const git::Reference &rhs) {
           lhsCommit.committer().date() > rhsCommit.committer().date());
 }
 
+enum ReferenceType {
+    Branches = 0,
+    Remotes = 1,
+    Tags = 2
+};
+
 class ReferenceModel : public QAbstractItemModel {
   Q_OBJECT
 
@@ -99,7 +105,7 @@ public:
           branches.append(stash);
       }
 
-      mRefs.append({tr("Branches"), branches});
+      mRefs.append({tr("Branches"), branches}); // First element in mRefs
     }
 
     // Add remote branches.
@@ -114,7 +120,7 @@ public:
       std::sort(remotes.begin(), remotes.end(), refComparator);
       if (mKinds & ReferenceView::InvalidRef)
         remotes.prepend(git::Reference());
-      mRefs.append({tr("Remotes"), remotes});
+      mRefs.append({tr("Remotes"), remotes}); // Second element in mRefs
     }
 
     // Add tags.
@@ -124,10 +130,42 @@ public:
         tags.append(tag);
 
       std::sort(tags.begin(), tags.end(), refComparator);
-      mRefs.append({tr("Tags"), tags});
+      mRefs.append({tr("Tags"), tags}); // Third element in mRefs
     }
 
     endResetModel();
+  }
+
+  QModelIndex firstRemote() {
+      // Return first remote if available, otherwise an invalid modelIndex
+      for (auto& ref: mRefs) {
+          if (ref.name == tr("Remotes") && ref.refs.count() > 0)
+              return createIndex(0, 0, ReferenceType::Remotes);
+      }
+      return QModelIndex();
+  }
+
+  QModelIndex firstBranch() {
+      // Return first branch if available, otherwise an invalid modelIndex
+      for (auto& ref: mRefs) {
+          if (ref.name == tr("Branches") && ref.refs.count() > 0) {
+              if (mKinds & ReferenceView::InvalidRef && ref.refs.count() > 1)
+                return createIndex(0 + 1, 0, ReferenceType::Branches);
+              else
+                return createIndex(0, 0, ReferenceType::Branches);
+          }
+      }
+      return QModelIndex();
+  }
+
+  QModelIndex firstTag() {
+    // Return first tag if available, otherwise an invalid modelIndex
+
+    for (auto& ref: mRefs) {
+        if (ref.name == tr("Tags") && ref.refs.count() > 0)
+            return createIndex(0, 0, ReferenceType::Tags);
+    }
+    return QModelIndex();
   }
 
   QModelIndex index(int row, int column,
@@ -135,6 +173,7 @@ public:
     if (!hasIndex(row, column, parent))
       return QModelIndex();
 
+    // only true for ref elements, not for elements of mRefs
     bool id = (!parent.isValid() || parent.internalId());
     return createIndex(row, column, !id ? parent.row() + 1 : 0);
   }
@@ -143,8 +182,13 @@ public:
     if (!index.isValid())
       return QModelIndex();
 
+    // The sections (Branches, Remotes, Tags) (Elements of mRefs) do not have an internalId()
+    // Those sections don't have any parents, only the refs in each mRefs element
     quintptr id = index.internalId();
-    return !id ? QModelIndex() : createIndex(id - 1, 0);
+    if (!id)
+        return QModelIndex();
+    auto refType = static_cast<ReferenceType>(id - 1);
+    return createIndex(refType, 0);
   }
 
   int rowCount(const QModelIndex &parent = QModelIndex()) const override {
@@ -169,8 +213,10 @@ public:
     if (!id)
       return (role == Qt::DisplayRole) ? mRefs.at(row).name : QVariant();
 
+    auto refType = static_cast<ReferenceType>(id - 1);
+
     // refs
-    git::Reference ref = mRefs.at(id - 1).refs.at(row);
+    git::Reference ref = mRefs.at(refType).refs.at(row);
     switch (role) {
       case Qt::DisplayRole:
         return ref.isValid() ? ref.name() : QString();
@@ -343,8 +389,8 @@ ReferenceView::ReferenceView(const git::Repository &repo, Kinds kinds,
 
   // Set model.
   FilterProxyModel *model = new FilterProxyModel(this);
-  ReferenceModel *source = new ReferenceModel(repo, kinds, this);
-  model->setSourceModel(source);
+  mSource = new ReferenceModel(repo, kinds, this);
+  model->setSourceModel(mSource);
   setModel(model);
 
   connect(field, &QLineEdit::textChanged, [this, model](const QString &text) {
@@ -382,7 +428,7 @@ ReferenceView::ReferenceView(const git::Repository &repo, Kinds kinds,
   setFocusProxy(field);
 
   // Update model last.
-  source->update();
+  static_cast<ReferenceModel*>(mSource)->update();
 }
 
 void ReferenceView::resetTabIndex() {
@@ -391,6 +437,30 @@ void ReferenceView::resetTabIndex() {
     root = root.parent();
 
   static_cast<Header *>(header())->tabs()->setCurrentIndex(root.row());
+}
+
+QModelIndex ReferenceView::firstBranch() {
+    auto index = static_cast<ReferenceModel*>(mSource)->firstBranch();
+    index = static_cast<FilterProxyModel*>(model())->mapFromSource(index);
+    if (!index.isValid())
+        return QModelIndex();
+    return index;
+}
+
+QModelIndex ReferenceView::firstTag() {
+    auto index = static_cast<ReferenceModel*>(mSource)->firstTag();
+    index = static_cast<FilterProxyModel*>(model())->mapFromSource(index);
+    if (!index.isValid())
+        return QModelIndex();
+    return index;
+}
+
+QModelIndex ReferenceView::firstRemote() {
+    auto index = static_cast<ReferenceModel*>(mSource)->firstRemote();
+    index = static_cast<FilterProxyModel*>(model())->mapFromSource(index);
+    if (!index.isValid())
+        return QModelIndex();
+    return index;
 }
 
 git::Reference ReferenceView::currentReference() const {

--- a/src/ui/ReferenceView.h
+++ b/src/ui/ReferenceView.h
@@ -17,6 +17,8 @@ class Reference;
 class Repository;
 } // namespace git
 
+class QAbstractItemModel;
+
 class ReferenceView : public QTreeView {
   Q_OBJECT
 
@@ -41,6 +43,9 @@ public:
   void resetTabIndex();
 
   git::Reference currentReference() const;
+  QModelIndex firstBranch();
+  QModelIndex firstTag();
+  QModelIndex firstRemote();
 
   bool eventFilter(QObject *watched, QEvent *event) override;
 
@@ -52,6 +57,7 @@ protected:
 
 private:
   bool mPopup;
+  QAbstractItemModel* mSource;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(ReferenceView::Kinds);

--- a/src/ui/ReferenceView.h
+++ b/src/ui/ReferenceView.h
@@ -57,7 +57,7 @@ protected:
 
 private:
   bool mPopup;
-  QAbstractItemModel* mSource;
+  QAbstractItemModel *mSource;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(ReferenceView::Kinds);


### PR DESCRIPTION
Currently when starting a merge operation, per default the commit id is shown in the merge commit message. It would be preferable to show the tagname or the branch name as default because then the merge commits are more clear

![grafik](https://user-images.githubusercontent.com/10099533/180200064-7d1974ee-0a8c-4cc5-a86d-fc5ea5d6db6f.png)
