### PR TITLE
Allow building Gittyup without building HTML docs

### DIFF
--- a/dep/cmark/CMakeLists.txt
+++ b/dep/cmark/CMakeLists.txt
@@ -1,20 +1,15 @@
-if(PKG_CONFIG_FOUND)
-  pkg_check_modules(LIBCMARK libcmark)
-endif()
-if(NOT LIBCMARK_FOUND)
-  set(CMARK_TESTS
-      OFF
-      CACHE BOOL "" FORCE)
-  set(CMARK_SHARED
-      OFF
-      CACHE BOOL "" FORCE)
+set(CMARK_TESTS
+    OFF
+    CACHE BOOL "" FORCE)
+set(CMARK_SHARED
+    OFF
+    CACHE BOOL "" FORCE)
 
-  add_subdirectory(cmark)
-  target_include_directories(
+add_subdirectory(cmark)
+target_include_directories(
+  cmark_static
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cmark/src>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/cmark/src>)
+set(LIBCMARK_LIBRARIES
     cmark_static
-    INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cmark/src>
-              $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/cmark/src>)
-  set(LIBCMARK_LIBRARIES
-      cmark_static
-      CACHE INTERNAL "libcmark implementation" FORCE)
-endif()
+    CACHE INTERNAL "libcmark implementation" FORCE)


### PR DESCRIPTION
I couldn't build on my machine anymore, it requires `cmark_exe` instead of `cmark`

@Murmele what was the reason for using `cmark_exe`?