### PR TITLE
add functionality to show only branches, remotes, tags only related to the current commit

### DIFF
--- a/src/dialogs/MergeDialog.cpp
+++ b/src/dialogs/MergeDialog.cpp
@@ -30,11 +30,12 @@ const ReferenceView::Kinds kRefKinds =
 } // namespace
 
 MergeDialog::MergeDialog(RepoView::MergeFlags flags,
-                         const git::Repository &repo, QWidget *parent)
+                         const git::Repository &repo, bool filterCurrentCommit,
+                         QWidget *parent)
     : QDialog(parent), mRepo(repo) {
   setAttribute(Qt::WA_DeleteOnClose);
 
-  mRefs = new ReferenceList(repo, kRefKinds, this);
+  mRefs = new ReferenceList(repo, kRefKinds, filterCurrentCommit, this);
   connect(mRefs, &ReferenceList::referenceSelected, this, &MergeDialog::update);
 
   auto noff = RepoView::Merge | RepoView::NoFastForward;

--- a/src/dialogs/MergeDialog.h
+++ b/src/dialogs/MergeDialog.h
@@ -27,7 +27,7 @@ class MergeDialog : public QDialog {
 
 public:
   MergeDialog(RepoView::MergeFlags flags, const git::Repository &repo,
-              QWidget *parent = nullptr);
+              bool filterCurrentCommit = false, QWidget *parent = nullptr);
 
   git::Commit target() const;
   git::Reference reference() const;

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -1417,7 +1417,7 @@ void CommitList::contextMenuEvent(QContextMenuEvent *event) {
 
       menu.addAction(tr("Merge..."), [view, commit] {
         MergeDialog *dialog =
-            new MergeDialog(RepoView::Merge, view->repo(), view);
+            new MergeDialog(RepoView::Merge, view->repo(), true, view);
         connect(dialog, &QDialog::accepted, [view, dialog] {
           git::AnnotatedCommit upstream;
           git::Reference ref = dialog->reference();
@@ -1432,7 +1432,7 @@ void CommitList::contextMenuEvent(QContextMenuEvent *event) {
 
       menu.addAction(tr("Rebase..."), [view, commit] {
         MergeDialog *dialog =
-            new MergeDialog(RepoView::Rebase, view->repo(), view);
+            new MergeDialog(RepoView::Rebase, view->repo(), true, view);
         connect(dialog, &QDialog::accepted, [view, dialog] {
           git::AnnotatedCommit upstream;
           git::Reference ref = dialog->reference();
@@ -1447,7 +1447,7 @@ void CommitList::contextMenuEvent(QContextMenuEvent *event) {
 
       menu.addAction(tr("Squash..."), [view, commit] {
         MergeDialog *dialog =
-            new MergeDialog(RepoView::Squash, view->repo(), view);
+            new MergeDialog(RepoView::Squash, view->repo(), true, view);
         connect(dialog, &QDialog::accepted, [view, dialog] {
           git::AnnotatedCommit upstream;
           git::Reference ref = dialog->reference();

--- a/src/ui/ReferenceList.h
+++ b/src/ui/ReferenceList.h
@@ -21,7 +21,7 @@ class ReferenceList : public QComboBox {
 public:
   ReferenceList(const git::Repository &repo,
                 ReferenceView::Kinds kinds = ReferenceView::AllRefs,
-                QWidget *parent = nullptr);
+                bool filterCurrentCommit = false, QWidget *parent = nullptr);
 
   git::Commit target() const;
   git::Reference currentReference() const;
@@ -41,12 +41,15 @@ protected:
 
 private:
   QSize calculateSizeHint() const;
+  void initIndex();
 
   git::Repository mRepo;
   git::Reference mStoredRef;
 
   // direct commit
   git::Commit mCommit;
+
+  ReferenceView *mView;
 };
 
 #endif

--- a/src/ui/ReferenceView.h
+++ b/src/ui/ReferenceView.h
@@ -11,6 +11,7 @@
 #define REFERENCEVIEW_H
 
 #include <QTreeView>
+#include "git/Commit.h"
 
 namespace git {
 class Reference;
@@ -37,7 +38,8 @@ public:
   Q_DECLARE_FLAGS(Kinds, Kind);
 
   ReferenceView(const git::Repository &repo, Kinds kinds = AllRefs,
-                bool popup = false, QWidget *parent = nullptr);
+                bool popup = false, bool filterCurrentCommit = false,
+                QWidget *parent = nullptr);
 
   bool isPopup() const { return mPopup; }
   void resetTabIndex();
@@ -50,6 +52,8 @@ public:
   bool eventFilter(QObject *watched, QEvent *event) override;
 
   static QString kindString(const git::Reference &ref);
+
+  void setCommit(const git::Commit &commit);
 
 protected:
   void showEvent(QShowEvent *event) override;

--- a/src/ui/ReferenceWidget.cpp
+++ b/src/ui/ReferenceWidget.cpp
@@ -129,7 +129,7 @@ ReferenceWidget::ReferenceWidget(const git::Repository &repo,
   header->addWidget(mLabel);
   header->addWidget(button);
 
-  mView = new ReferenceView(repo, kinds, false, this);
+  mView = new ReferenceView(repo, kinds, false, false, this);
   mView->setSelectionModel(new SelectionModel(mView->model(), repo));
 
   QVBoxLayout *layout = new QVBoxLayout(this);


### PR DESCRIPTION
So when clicking in the commit list and merging, only the related branches are shown. When executing from menubar, all branches, remotes and tags are visible

fixes #228 