### PR TITLE
Fix updater not closing all main windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ endif()
 set(BUILD_SHARED_LIBS OFF)
 
 option(FLATPAK "Building for flatpak" OFF)
+option(DEBUG_FLATPAK "Building but using flatpak urls for testing" OFF)
 
 # Require C++17.
 set(CMAKE_CXX_STANDARD 17)
@@ -77,6 +78,10 @@ if(FLATPAK)
     COMPONENTS XcbQpa
     REQUIRED)
   add_compile_definitions(FLATPAK)
+endif()
+
+if(DEBUG_FLATPAK)
+  add_compile_definitions(DEBUG_FLATPAK)
 endif()
 
 set(QT_TRANSLATIONS_DIR "${Qt5_DIR}/../../../translations")

--- a/src/update/CMakeLists.txt
+++ b/src/update/CMakeLists.txt
@@ -8,8 +8,14 @@ endif()
 add_library(update DownloadDialog.cpp UpdateDialog.cpp Updater.cpp
                    UpToDateDialog.cpp ${UPDATER_IMPL_FILE})
 
-target_link_libraries(update conf ${LIBCMARK_LIBRARIES} Qt5::Network
-                      Qt5::Widgets ${UPDATER_IMPL_LIBS})
+target_link_libraries(
+  update
+  conf
+  ${LIBCMARK_LIBRARIES}
+  git
+  Qt5::Network
+  Qt5::Widgets
+  ${UPDATER_IMPL_LIBS})
 
 set_target_properties(update PROPERTIES AUTOMOC ON)
 

--- a/src/update/CMakeLists.txt
+++ b/src/update/CMakeLists.txt
@@ -32,8 +32,16 @@ if(APPLE)
 elseif(UNIX)
   set_target_properties(relauncher PROPERTIES INSTALL_RPATH "$ORIGIN")
 
-  install(
-    TARGETS relauncher
-    DESTINATION .
-    COMPONENT ${GITTYUP_NAME})
+  if(FLATPAK)
+    # Install application.
+    install(
+      TARGETS relauncher
+      DESTINATION ./bin # otherwise the executable will not be found by flatpak
+      COMPONENT ${GITTYUP_NAME})
+  else()
+    install(
+      TARGETS relauncher
+      DESTINATION .
+      COMPONENT ${GITTYUP_NAME})
+  endif()
 endif()

--- a/src/update/UpdateDialog.cpp
+++ b/src/update/UpdateDialog.cpp
@@ -57,7 +57,7 @@ UpdateDialog::UpdateDialog(const QString &platform, const QString &version,
                      "Would you like to download it now?</p>"
                      "<b>Release Notes:</b>")
                       .arg(appName, version, appVersion);
-#elif defined(FLATPAK)
+#elif defined(FLATPAK) || defined(DEBUG_FLATPAK)
   QString label =
       tr("<h3>A new version of %1 is available!</h3>"
          "<p>%1 %2 is now available - you have %3.</p>"
@@ -82,7 +82,7 @@ UpdateDialog::UpdateDialog(const QString &platform, const QString &version,
   browser->document()->setDefaultStyleSheet(kStyleSheet);
   browser->setHtml(changelog);
 
-#if !defined(Q_OS_LINUX) || defined(FLATPAK)
+#if !defined(Q_OS_LINUX) || defined(FLATPAK) || defined(DEBUG_FLATPAK)
   QCheckBox *download =
       new QCheckBox(tr("Automatically download and install updates"), this);
   download->setChecked(Settings::instance()->value("update/download").toBool());
@@ -92,7 +92,7 @@ UpdateDialog::UpdateDialog(const QString &platform, const QString &version,
 #endif
 
   QDialogButtonBox *buttons = new QDialogButtonBox(this);
-#if !defined(Q_OS_LINUX) || defined(FLATPAK)
+#if !defined(Q_OS_LINUX) || defined(FLATPAK) || defined(DEBUG_FLATPAK)
   buttons->addButton(tr("Install Update"), QDialogButtonBox::AcceptRole);
   buttons->addButton(tr("Remind Me Later"), QDialogButtonBox::RejectRole);
   connect(buttons, &QDialogButtonBox::accepted, this, &UpdateDialog::accept);
@@ -120,7 +120,7 @@ UpdateDialog::UpdateDialog(const QString &platform, const QString &version,
       new QPushButton(QIcon(":/liberapay_icon_130890.png"), tr("Donate"), this);
   QSpacerItem *spacer =
       new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Minimum);
-#if !defined(Q_OS_LINUX) || defined(FLATPAK)
+#if !defined(Q_OS_LINUX) || defined(FLATPAK) || defined(DEBUG_FLATPAK)
   l->addWidget(download);
 #endif
   l->addItem(spacer);

--- a/src/update/Updater.cpp
+++ b/src/update/Updater.cpp
@@ -76,19 +76,18 @@ Updater::Updater(QObject *parent) : QObject(parent) {
             QVersionNumber appVersion = QVersionNumber::fromString(
                 QCoreApplication::applicationVersion());
             QVersionNumber newVersion = QVersionNumber::fromString(version);
-            if (newVersion.majorVersion() > appVersion.majorVersion() ||
-                !Settings::instance()->value("update/download").toBool()) {
+
+            if (Settings::instance()->value("update/download").toBool()) {
+              // Skip the update dialog and just start downloading.
+              if (Updater::DownloadRef download = this->download(link)) {
+                DownloadDialog *dialog = new DownloadDialog(download);
+                dialog->show();
+              }
+            } else {
               UpdateDialog *dialog =
                   new UpdateDialog(platform, version, log, link);
               connect(dialog, &UpdateDialog::rejected, this,
                       &Updater::updateCanceled);
-              dialog->show();
-              return;
-            }
-
-            // Skip the update dialog and just start downloading.
-            if (Updater::DownloadRef download = this->download(link)) {
-              DownloadDialog *dialog = new DownloadDialog(download);
               dialog->show();
             }
           });

--- a/src/update/Updater.cpp
+++ b/src/update/Updater.cpp
@@ -13,6 +13,7 @@
 #include "UpdateDialog.h"
 #include "UpToDateDialog.h"
 #include "conf/Settings.h"
+#include "ui/MainWindow.h"
 #include <QApplication>
 #include <QCloseEvent>
 #include <QDialog>
@@ -225,12 +226,20 @@ Updater::DownloadRef Updater::download(const QString &link) {
 
 void Updater::install(const DownloadRef &download) {
   // First try to close all windows. Disable quit on close.
-  QCloseEvent event;
-  QString errorText = tr("Unable to install update");
   bool quitOnClose = QGuiApplication::quitOnLastWindowClosed();
   QGuiApplication::setQuitOnLastWindowClosed(false);
-  bool rejected = (!qApp->notify(qApp, &event) || !event.isAccepted());
+
+  bool rejected = false;
+  for (MainWindow *window : MainWindow::windows()) {
+    rejected = !window->close();
+    if (rejected) {
+      break;
+    }
+  }
+
   QGuiApplication::setQuitOnLastWindowClosed(quitOnClose);
+
+  QString errorText = tr("Unable to install update");
   if (rejected) {
     emit updateError(errorText,
                      tr("Some windows failed to close. You can "


### PR DESCRIPTION
For some reason, using QCoreApplication::notify() with a QCloseEvent never reaches any MainWindow, so now they get closed explicitly