### PR TITLE
Fix new branch dialog showing the wrong starting point

### DIFF
--- a/src/dialogs/NewBranchDialog.cpp
+++ b/src/dialogs/NewBranchDialog.cpp
@@ -28,9 +28,9 @@ NewBranchDialog::NewBranchDialog(const git::Repository &repo,
   mName = new QLineEdit(this);
 
   auto kinds = ReferenceView::InvalidRef | ReferenceView::RemoteBranches;
-  mUpstream = new ReferenceList(repo, kinds, this);
+  mUpstream = new ReferenceList(repo, kinds, false, this);
 
-  mRefs = new ReferenceList(repo, ReferenceView::AllRefs, this);
+  mRefs = new ReferenceList(repo, ReferenceView::AllRefs, true, this);
   mRefs->select(repo.head());
   mRefs->setCommit(commit);
 

--- a/src/ui/ReferenceView.cpp
+++ b/src/ui/ReferenceView.cpp
@@ -81,8 +81,12 @@ public:
     git::Reference detachedHead;
     if (mKinds & ReferenceView::DetachedHead) {
       git::Reference head = mRepo.head();
-      if (head.isValid() && !head.isBranch())
-        detachedHead = head;
+      if (head.isValid() && !head.isBranch()) {
+        if (!mFilterCurrentCommit ||
+            head.annotatedCommit().commit() == mCommit) {
+          detachedHead = head;
+        }
+      }
     }
 
     // Add local branches.


### PR DESCRIPTION
When currently on a detached head, the detached head is visible and automatically chosen as the starting point even if another commit has been selected from the commit graph