### PR TITLE
Fix reference view

### DIFF
--- a/src/ui/ReferenceList.cpp
+++ b/src/ui/ReferenceList.cpp
@@ -68,11 +68,8 @@ ReferenceList::ReferenceList(const git::Repository &repo,
 }
 
 git::Commit ReferenceList::target() const {
-  if (currentIndex() == -1 && mCommit.isValid())
-    return mCommit;
-
   git::Reference ref = currentReference();
-  return ref.isValid() ? ref.target() : git::Commit();
+  return ref.isValid() ? ref.target() : mCommit;
 }
 
 git::Reference ReferenceList::currentReference() const {

--- a/src/ui/ReferenceView.cpp
+++ b/src/ui/ReferenceView.cpp
@@ -153,7 +153,7 @@ public:
     for (auto &ref : mRefs) {
       if (ref.name == tr("Remotes") && ref.refs.count() > 0) {
         if (mKinds & ReferenceView::InvalidRef && ref.refs.count() > 1)
-          return createIndex(0 + 1, 0, ReferenceType::Remotes);
+          return createIndex(1, 0, ReferenceType::Remotes);
         else
           return createIndex(0, 0, ReferenceType::Remotes);
       }
@@ -166,7 +166,7 @@ public:
     for (auto &ref : mRefs) {
       if (ref.name == tr("Branches") && ref.refs.count() > 0) {
         if (mKinds & ReferenceView::InvalidRef && ref.refs.count() > 1)
-          return createIndex(0 + 1, 0, ReferenceType::Branches);
+          return createIndex(1, 0, ReferenceType::Branches);
         else
           return createIndex(0, 0, ReferenceType::Branches);
       }

--- a/src/ui/ReferenceView.cpp
+++ b/src/ui/ReferenceView.cpp
@@ -151,8 +151,12 @@ public:
   QModelIndex firstRemote() {
     // Return first remote if available, otherwise an invalid modelIndex
     for (auto &ref : mRefs) {
-      if (ref.name == tr("Remotes") && ref.refs.count() > 0)
-        return createIndex(0, 0, ReferenceType::Remotes);
+      if (ref.name == tr("Remotes") && ref.refs.count() > 0) {
+        if (mKinds & ReferenceView::InvalidRef && ref.refs.count() > 1)
+          return createIndex(0 + 1, 0, ReferenceType::Remotes);
+        else
+          return createIndex(0, 0, ReferenceType::Remotes);
+      }
     }
     return QModelIndex();
   }


### PR DESCRIPTION
## First Problem solved by first commit
1) Select commit which does not have a lokal branch, but only a remote branch
2) Try to rebase
--> Rebase button is disabled, because ref is not valid.
Solution: It must be also done like for the branch adding 1 because the first is an invalid ref.

## Second Problem solved by second commit
1) Select commit which does not have any branches/remotes/tags ...
2) try to rebase
--> Rebase button is disabled, because ref is invalid.
Solution: return the current selected commit if available