### PR TITLE
Fix rebase log

### DIFF
--- a/src/log/LogEntry.cpp
+++ b/src/log/LogEntry.cpp
@@ -71,6 +71,12 @@ LogEntry *LogEntry::insertEntry(int row, Kind kind, const QString &text,
   return entry;
 }
 
+LogEntry *LogEntry::lastEntry() const {
+  if (mEntries.isEmpty())
+    return nullptr;
+  return mEntries.last();
+}
+
 void LogEntry::setBusy(bool busy) {
   if (!busy) {
     mTimer.stop();

--- a/src/log/LogEntry.h
+++ b/src/log/LogEntry.h
@@ -48,6 +48,7 @@ public:
   void insertEntries(int row, const QList<LogEntry *> &entries);
   LogEntry *insertEntry(int row, Kind kind, const QString &text,
                         const QString &title = QString());
+  LogEntry *lastEntry() const;
 
   int progress() const { return mProgress; }
   void setBusy(bool busy);

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -1459,10 +1459,19 @@ void RepoView::rebaseCommitSuccess(const git::Rebase rebase,
                                    const git::Commit after, int currIndex) {
   QString beforeText = before.link();
   QString step = tr("%1/%2").arg(currIndex).arg(rebase.count());
-  mRebase->setText(
-      (after == before)
-          ? tr("%1 - %2 <i>already applied</i>").arg(step, beforeText)
-          : tr("%1 - %2 as %3").arg(step, beforeText, msg(after)));
+  auto *lastEntry = mRebase->lastEntry();
+  if (lastEntry) {
+    lastEntry->setText(
+        (after == before)
+            ? tr("%1 - %2 <i>already applied</i>").arg(step, beforeText)
+            : tr("%1 - %2 as %3").arg(step, beforeText, msg(after)));
+  }
+
+  // Yield to the main event loop.
+  // So the status of the rebase is shown
+  // Without it, the rebase status will be shown at the end of the
+  // rebase when the event loop will be processed
+  QCoreApplication::processEvents();
 }
 
 void RepoView::rebaseFinished(const git::Rebase rebase) {


### PR DESCRIPTION
- yield to the mainloop otherwise the user does not see any feedback during rebase, only at the end.
- fix rebase log message, because it was implemented wrongly

fixes #284 