### PR TITLE
Improve Terminal detection on macOS

### DIFF
--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -2577,9 +2577,9 @@ void RepoView::openTerminal() {
 
       for (const char **candidate = candidates; *candidate; ++candidate) {
         int res = QProcess::execute(
-            "osascript",
-            {"-e", QString("tell application \"Finder\" to get application file id \"%1\"")
-                       .arg(*candidate)});
+            "osascript", {"-e", QString("tell application \"Finder\" to get "
+                                        "application file id \"%1\"")
+                                    .arg(*candidate)});
 
         if (res == 0) {
           detectedTerminal = QString("open -b %1").arg(*candidate) + " .";

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -2578,11 +2578,11 @@ void RepoView::openTerminal() {
       for (const char **candidate = candidates; *candidate; ++candidate) {
         int res = QProcess::execute(
             "osascript",
-            {"-e", QString("tell Finder to get application file id \"%1\"")
+            {"-e", QString("tell application \"Finder\" to get application file id \"%1\"")
                        .arg(*candidate)});
 
         if (res == 0) {
-          detectedTerminal = QString("open -b %1").arg(*candidate) + " %1";
+          detectedTerminal = QString("open -b %1").arg(*candidate) + " .";
           break;
         }
       }


### PR DESCRIPTION
This PR implements the fixes already described in issue #258 in RepoView.cpp, namely aligning the syntax of the `osascript` call with that in ShowTool.cpp, and using `.` instead of `%1` for the Git working directory.

This is confirmed to work when compiled on macOS Monterey (v12.6) with an Apple M1 chip, with Qt 5.15.5_3.

Note that the native security controls trigger the dialog
```
“Gittyup.app“ wants access to control “Finder.app“. Allowing control will provide access to documents and data in “Finder.app“, and to perform actions within that app.
```
the first time the "open terminal" button is pressed, but pressing "OK" gives persistent permission. This happens as well for the native Terminal app the first time the equivalent `osascript` call is used there, so is probably unavoidable with this approach.

Closes #267.