### PR TITLE
Ability to change dates in amend

### DIFF
--- a/src/dialogs/AmendDialog.cpp
+++ b/src/dialogs/AmendDialog.cpp
@@ -8,6 +8,7 @@
 #include <QCheckBox>
 #include <QHBoxLayout>
 #include <QDateTime>
+#include <QDateTimeEdit>
 
 enum Row {
   AuthorName = 0,
@@ -39,8 +40,7 @@ AmendDialog::AmendDialog(const git::Signature &author,
   auto *lAuthorEmail = new QLabel(tr("Author email:"), this);
   m_authorEmail = new QLineEdit(author.email(), this);
   auto *lAuthorCommitDate = new QLabel(tr("Author commit date:"), this);
-  auto d = author.date().toString(Qt::RFC2822Date);
-  m_authorCommitDate = new QLineEdit(d, this);
+  m_authorCommitDate = new QDateTimeEdit(author.date(), this);
   m_editAuthorCommitDate = new QCheckBox(tr("Manually set author commit date?"), this);
   l->addWidget(lAuthor, Row::AuthorName, 0);
   l->addWidget(m_authorName, Row::AuthorName, 1);
@@ -55,8 +55,7 @@ AmendDialog::AmendDialog(const git::Signature &author,
   auto *lCommitterEmail = new QLabel(tr("Committer email:"), this);
   m_committerEmail = new QLineEdit(committer.email(), this);
   auto *lCommitterCommitDate = new QLabel(tr("Committer commit date:"), this);
-  d = committer.date().toString(Qt::RFC2822Date);
-  m_committerCommitDate = new QLineEdit(d, this);
+  m_committerCommitDate = new QDateTimeEdit(committer.date(), this);
   m_editCommitterCommitDate = new QCheckBox(tr("Manually set committer commit date?"), this);
   l->addWidget(lCommitterName, Row::CommitterName, 0);
   l->addWidget(m_committerName, Row::CommitterName, 1);
@@ -78,7 +77,7 @@ AmendDialog::AmendDialog(const git::Signature &author,
   connect(ok, &QPushButton::clicked, this, &QDialog::accept);
   connect(cancel, &QPushButton::clicked, this, &QDialog::reject);
 
-  auto chbStateChangedHandler = [](QCheckBox* chb, QLineEdit* l){
+  auto chbStateChangedHandler = [](QCheckBox* chb, QWidget* l){
     auto enable = chb->checkState() == Qt::Checked;
     l->setEnabled(enable);
   };
@@ -107,7 +106,7 @@ QString AmendDialog::authorName() const { return m_authorName->text(); }
 
 QString AmendDialog::authorEmail() const { return m_authorEmail->text(); }
 
-QString AmendDialog::authorCommitDate() const { return m_authorCommitDate->text(); }
+QDateTime AmendDialog::authorCommitDate() const { return m_authorCommitDate->dateTime(); }
 
 bool AmendDialog::editAuthorCommitDate() const { return m_editAuthorCommitDate->checkState() == Qt::Checked; }
 
@@ -115,7 +114,7 @@ QString AmendDialog::committerName() const { return m_committerName->text(); }
 
 QString AmendDialog::committerEmail() const { return m_committerEmail->text(); }
 
-QString AmendDialog::committerCommitDate() const { return m_committerCommitDate->text(); }
+QDateTime AmendDialog::committerCommitDate() const { return m_committerCommitDate->dateTime(); }
 
 bool AmendDialog::editCommitterCommitDate() const { return m_editAuthorCommitDate->checkState() == Qt::Checked; }
 

--- a/src/dialogs/AmendDialog.cpp
+++ b/src/dialogs/AmendDialog.cpp
@@ -40,7 +40,7 @@ AmendDialog::AmendDialog(const git::Signature &author,
   auto *lAuthorEmail = new QLabel(tr("Author email:"), this);
   m_authorEmail = new QLineEdit(author.email(), this);
   auto *lAuthorCommitDate = new QLabel(tr("Author commit date:"), this);
-  m_authorCommitDate = new QDateTimeEdit(author.date(), this);
+  m_authorCommitDate = new QDateTimeEdit(author.date().toLocalTime(), this);
   m_editAuthorCommitDate =
       new QCheckBox(tr("Manually set author commit date?"), this);
   l->addWidget(lAuthor, Row::AuthorName, 0);
@@ -56,7 +56,8 @@ AmendDialog::AmendDialog(const git::Signature &author,
   auto *lCommitterEmail = new QLabel(tr("Committer email:"), this);
   m_committerEmail = new QLineEdit(committer.email(), this);
   auto *lCommitterCommitDate = new QLabel(tr("Committer commit date:"), this);
-  m_committerCommitDate = new QDateTimeEdit(committer.date(), this);
+  m_committerCommitDate =
+      new QDateTimeEdit(committer.date().toLocalTime(), this);
   m_editCommitterCommitDate =
       new QCheckBox(tr("Manually set committer commit date?"), this);
   l->addWidget(lCommitterName, Row::CommitterName, 0);
@@ -127,7 +128,7 @@ QDateTime AmendDialog::committerCommitDate() const {
 }
 
 bool AmendDialog::editCommitterCommitDate() const {
-  return m_editAuthorCommitDate->checkState() == Qt::Checked;
+  return m_editCommitterCommitDate->checkState() == Qt::Checked;
 }
 
 QString AmendDialog::commitMessage() const {

--- a/src/dialogs/AmendDialog.cpp
+++ b/src/dialogs/AmendDialog.cpp
@@ -5,13 +5,19 @@
 #include <QLineEdit>
 #include <QTextEdit>
 #include <QPushButton>
+#include <QCheckBox>
 #include <QHBoxLayout>
+#include <QDateTime>
 
 enum Row {
   AuthorName = 0,
   AuthorEmail,
+  EditAuthorCommitDate,
+  AuthorCommitDate,
   CommitterName,
   CommitterEmail,
+  EditCommitterCommitDate,
+  CommitterCommitDate,
   CommitMessage,
 
   Buttons
@@ -24,27 +30,42 @@ AmendDialog::AmendDialog(const git::Signature &author,
 
   auto *l = new QGridLayout();
 
-  // committer
   // author
+  // committer
   // message
 
   auto *lAuthor = new QLabel(tr("Author name:"), this);
   m_authorName = new QLineEdit(author.name(), this);
   auto *lAuthorEmail = new QLabel(tr("Author email:"), this);
   m_authorEmail = new QLineEdit(author.email(), this);
+  auto *lAuthorCommitDate = new QLabel(tr("Author commit date:"), this);
+  auto d = author.date().toString(Qt::RFC2822Date);
+  m_authorCommitDate = new QLineEdit(d, this);
+  m_editAuthorCommitDate = new QCheckBox(tr("Manually set author commit date?"), this);
   l->addWidget(lAuthor, Row::AuthorName, 0);
   l->addWidget(m_authorName, Row::AuthorName, 1);
   l->addWidget(lAuthorEmail, Row::AuthorEmail, 0);
   l->addWidget(m_authorEmail, Row::AuthorEmail, 1);
+  l->addWidget(m_editAuthorCommitDate, Row::EditAuthorCommitDate, 0);
+  l->addWidget(lAuthorCommitDate, Row::AuthorCommitDate, 0);
+  l->addWidget(m_authorCommitDate, Row::AuthorCommitDate, 1);
 
   auto *lCommitterName = new QLabel(tr("Committer name:"), this);
   m_committerName = new QLineEdit(committer.name(), this);
   auto *lCommitterEmail = new QLabel(tr("Committer email:"), this);
   m_committerEmail = new QLineEdit(committer.email(), this);
+  auto *lCommitterCommitDate = new QLabel(tr("Committer commit date:"), this);
+  d = committer.date().toString(Qt::RFC2822Date);
+  m_committerCommitDate = new QLineEdit(d, this);
+  m_editCommitterCommitDate = new QCheckBox(tr("Manually set committer commit date?"), this);
   l->addWidget(lCommitterName, Row::CommitterName, 0);
   l->addWidget(m_committerName, Row::CommitterName, 1);
   l->addWidget(lCommitterEmail, Row::CommitterEmail, 0);
   l->addWidget(m_committerEmail, Row::CommitterEmail, 1);
+  l->addWidget(m_editCommitterCommitDate, Row::EditCommitterCommitDate, 0);
+  l->addWidget(lCommitterCommitDate, Row::CommitterCommitDate, 0);
+  l->addWidget(m_committerCommitDate, Row::CommitterCommitDate, 1);
+
 
   auto *lMessage = new QLabel(tr("Message:"), this);
   m_commitMessage = new QTextEdit(commitMessage, this);
@@ -56,6 +77,22 @@ AmendDialog::AmendDialog(const git::Signature &author,
 
   connect(ok, &QPushButton::clicked, this, &QDialog::accept);
   connect(cancel, &QPushButton::clicked, this, &QDialog::reject);
+
+  auto chbStateChangedHandler = [](QCheckBox* chb, QLineEdit* l){
+    auto enable = chb->checkState() == Qt::Checked;
+    l->setEnabled(enable);
+  };
+  
+  connect(m_editAuthorCommitDate, &QCheckBox::stateChanged, this, [&, chbStateChangedHandler](){
+    chbStateChangedHandler(m_editAuthorCommitDate, m_authorCommitDate);
+  });
+
+  connect(m_editCommitterCommitDate, &QCheckBox::stateChanged, this, [&, chbStateChangedHandler](){
+    chbStateChangedHandler(m_editCommitterCommitDate, m_committerCommitDate);
+  });
+
+  chbStateChangedHandler(m_editAuthorCommitDate, m_authorCommitDate);
+  chbStateChangedHandler(m_editCommitterCommitDate, m_committerCommitDate);
 
   auto *hl = new QHBoxLayout();
   hl->addWidget(cancel);
@@ -70,9 +107,17 @@ QString AmendDialog::authorName() const { return m_authorName->text(); }
 
 QString AmendDialog::authorEmail() const { return m_authorEmail->text(); }
 
+QString AmendDialog::authorCommitDate() const { return m_authorCommitDate->text(); }
+
+bool AmendDialog::editAuthorCommitDate() const { return m_editAuthorCommitDate->checkState() == Qt::Checked; }
+
 QString AmendDialog::committerName() const { return m_committerName->text(); }
 
 QString AmendDialog::committerEmail() const { return m_committerEmail->text(); }
+
+QString AmendDialog::committerCommitDate() const { return m_committerCommitDate->text(); }
+
+bool AmendDialog::editCommitterCommitDate() const { return m_editAuthorCommitDate->checkState() == Qt::Checked; }
 
 QString AmendDialog::commitMessage() const {
   return m_commitMessage->toPlainText();

--- a/src/dialogs/AmendDialog.cpp
+++ b/src/dialogs/AmendDialog.cpp
@@ -29,11 +29,11 @@ public:
     current->setChecked(true);
 
     connect(current, &QRadioButton::clicked,
-            [this]() { emit this->typeChanged(this->type()); });
+            [this]() { emit typeChanged(type()); });
     connect(manual, &QRadioButton::clicked,
-            [this]() { emit this->typeChanged(this->type()); });
+            [this]() { emit typeChanged(type()); });
     connect(original, &QRadioButton::clicked,
-            [this]() { emit this->typeChanged(this->type()); });
+            [this]() { emit typeChanged(type()); });
 
     l->addWidget(current);
     l->addWidget(manual);

--- a/src/dialogs/AmendDialog.cpp
+++ b/src/dialogs/AmendDialog.cpp
@@ -41,7 +41,8 @@ AmendDialog::AmendDialog(const git::Signature &author,
   m_authorEmail = new QLineEdit(author.email(), this);
   auto *lAuthorCommitDate = new QLabel(tr("Author commit date:"), this);
   m_authorCommitDate = new QDateTimeEdit(author.date(), this);
-  m_editAuthorCommitDate = new QCheckBox(tr("Manually set author commit date?"), this);
+  m_editAuthorCommitDate =
+      new QCheckBox(tr("Manually set author commit date?"), this);
   l->addWidget(lAuthor, Row::AuthorName, 0);
   l->addWidget(m_authorName, Row::AuthorName, 1);
   l->addWidget(lAuthorEmail, Row::AuthorEmail, 0);
@@ -56,7 +57,8 @@ AmendDialog::AmendDialog(const git::Signature &author,
   m_committerEmail = new QLineEdit(committer.email(), this);
   auto *lCommitterCommitDate = new QLabel(tr("Committer commit date:"), this);
   m_committerCommitDate = new QDateTimeEdit(committer.date(), this);
-  m_editCommitterCommitDate = new QCheckBox(tr("Manually set committer commit date?"), this);
+  m_editCommitterCommitDate =
+      new QCheckBox(tr("Manually set committer commit date?"), this);
   l->addWidget(lCommitterName, Row::CommitterName, 0);
   l->addWidget(m_committerName, Row::CommitterName, 1);
   l->addWidget(lCommitterEmail, Row::CommitterEmail, 0);
@@ -64,7 +66,6 @@ AmendDialog::AmendDialog(const git::Signature &author,
   l->addWidget(m_editCommitterCommitDate, Row::EditCommitterCommitDate, 0);
   l->addWidget(lCommitterCommitDate, Row::CommitterCommitDate, 0);
   l->addWidget(m_committerCommitDate, Row::CommitterCommitDate, 1);
-
 
   auto *lMessage = new QLabel(tr("Message:"), this);
   m_commitMessage = new QTextEdit(commitMessage, this);
@@ -77,18 +78,21 @@ AmendDialog::AmendDialog(const git::Signature &author,
   connect(ok, &QPushButton::clicked, this, &QDialog::accept);
   connect(cancel, &QPushButton::clicked, this, &QDialog::reject);
 
-  auto chbStateChangedHandler = [](QCheckBox* chb, QWidget* l){
+  auto chbStateChangedHandler = [](QCheckBox *chb, QWidget *l) {
     auto enable = chb->checkState() == Qt::Checked;
     l->setEnabled(enable);
   };
-  
-  connect(m_editAuthorCommitDate, &QCheckBox::stateChanged, this, [&, chbStateChangedHandler](){
-    chbStateChangedHandler(m_editAuthorCommitDate, m_authorCommitDate);
-  });
 
-  connect(m_editCommitterCommitDate, &QCheckBox::stateChanged, this, [&, chbStateChangedHandler](){
-    chbStateChangedHandler(m_editCommitterCommitDate, m_committerCommitDate);
-  });
+  connect(m_editAuthorCommitDate, &QCheckBox::stateChanged, this,
+          [&, chbStateChangedHandler]() {
+            chbStateChangedHandler(m_editAuthorCommitDate, m_authorCommitDate);
+          });
+
+  connect(m_editCommitterCommitDate, &QCheckBox::stateChanged, this,
+          [&, chbStateChangedHandler]() {
+            chbStateChangedHandler(m_editCommitterCommitDate,
+                                   m_committerCommitDate);
+          });
 
   chbStateChangedHandler(m_editAuthorCommitDate, m_authorCommitDate);
   chbStateChangedHandler(m_editCommitterCommitDate, m_committerCommitDate);
@@ -106,17 +110,25 @@ QString AmendDialog::authorName() const { return m_authorName->text(); }
 
 QString AmendDialog::authorEmail() const { return m_authorEmail->text(); }
 
-QDateTime AmendDialog::authorCommitDate() const { return m_authorCommitDate->dateTime(); }
+QDateTime AmendDialog::authorCommitDate() const {
+  return m_authorCommitDate->dateTime();
+}
 
-bool AmendDialog::editAuthorCommitDate() const { return m_editAuthorCommitDate->checkState() == Qt::Checked; }
+bool AmendDialog::editAuthorCommitDate() const {
+  return m_editAuthorCommitDate->checkState() == Qt::Checked;
+}
 
 QString AmendDialog::committerName() const { return m_committerName->text(); }
 
 QString AmendDialog::committerEmail() const { return m_committerEmail->text(); }
 
-QDateTime AmendDialog::committerCommitDate() const { return m_committerCommitDate->dateTime(); }
+QDateTime AmendDialog::committerCommitDate() const {
+  return m_committerCommitDate->dateTime();
+}
 
-bool AmendDialog::editCommitterCommitDate() const { return m_editAuthorCommitDate->checkState() == Qt::Checked; }
+bool AmendDialog::editCommitterCommitDate() const {
+  return m_editAuthorCommitDate->checkState() == Qt::Checked;
+}
 
 QString AmendDialog::commitMessage() const {
   return m_commitMessage->toPlainText();

--- a/src/dialogs/AmendDialog.cpp
+++ b/src/dialogs/AmendDialog.cpp
@@ -92,7 +92,7 @@ AmendDialog::AmendDialog(const git::Signature &author,
   m_authorCommitDateType->setObjectName("AuthorCommitDateType");
   m_authorCommitDate = new QDateTimeEdit(author.date().toLocalTime(), this);
   m_authorCommitDate->setObjectName("authorCommitDate");
-  m_authorCommitDate->setEnabled(m_authorCommitDateType->type() ==
+  m_authorCommitDate->setVisible(m_authorCommitDateType->type() ==
                                  SelectedDateTimeType::Manual);
   l->addWidget(lAuthor, Row::AuthorName, 0);
   l->addWidget(m_authorName, Row::AuthorName, 1);
@@ -112,7 +112,7 @@ AmendDialog::AmendDialog(const git::Signature &author,
   m_committerCommitDate =
       new QDateTimeEdit(committer.date().toLocalTime(), this);
   m_committerCommitDate->setObjectName("committerCommitDate");
-  m_committerCommitDate->setEnabled(m_committerCommitDateType->type() ==
+  m_committerCommitDate->setVisible(m_committerCommitDateType->type() ==
                                     SelectedDateTimeType::Manual);
   l->addWidget(lCommitterName, Row::CommitterName, 0);
   l->addWidget(m_committerName, Row::CommitterName, 1);
@@ -138,15 +138,15 @@ AmendDialog::AmendDialog(const git::Signature &author,
           [this](AmendDialog::SelectedDateTimeType type) {
             const auto enabled =
                 type == AmendDialog::SelectedDateTimeType::Manual;
-            this->m_lAuthorCommitDate->setEnabled(enabled);
-            this->m_authorCommitDate->setEnabled(enabled);
+            this->m_lAuthorCommitDate->setVisible(enabled);
+            this->m_authorCommitDate->setVisible(enabled);
           });
   connect(m_committerCommitDateType, &DateSelectionGroupWidget::typeChanged,
           [this](AmendDialog::SelectedDateTimeType type) {
             const auto enabled =
                 type == AmendDialog::SelectedDateTimeType::Manual;
-            this->m_lCommitterCommitDate->setEnabled(enabled);
-            this->m_committerCommitDate->setEnabled(enabled);
+            this->m_lCommitterCommitDate->setVisible(enabled);
+            this->m_committerCommitDate->setVisible(enabled);
           });
 
   auto *hl = new QHBoxLayout();

--- a/src/dialogs/AmendDialog.cpp
+++ b/src/dialogs/AmendDialog.cpp
@@ -9,15 +9,63 @@
 #include <QHBoxLayout>
 #include <QDateTime>
 #include <QDateTimeEdit>
+#include <QRadioButton>
+#include <QGroupBox>
+
+class DateSelectionGroupWidget : public QGroupBox {
+  Q_OBJECT
+public:
+  DateSelectionGroupWidget(QWidget *parent = nullptr)
+      : QGroupBox(tr("Datetime source"), parent) {
+    QHBoxLayout *l = new QHBoxLayout();
+
+    current = new QRadioButton(tr("Current"), this);
+    current->setObjectName("Current");
+    manual = new QRadioButton(tr("Manual"), this);
+    manual->setObjectName("Manual");
+    original = new QRadioButton(tr("Original"), this);
+    original->setObjectName("Original");
+
+    current->setChecked(true);
+
+    connect(current, &QRadioButton::clicked,
+            [this]() { emit this->typeChanged(this->type()); });
+    connect(manual, &QRadioButton::clicked,
+            [this]() { emit this->typeChanged(this->type()); });
+    connect(original, &QRadioButton::clicked,
+            [this]() { emit this->typeChanged(this->type()); });
+
+    l->addWidget(current);
+    l->addWidget(manual);
+    l->addWidget(original);
+    setLayout(l);
+  }
+  AmendDialog::SelectedDateTimeType type() {
+    if (original->isChecked()) {
+      return AmendDialog::SelectedDateTimeType::Original;
+    } else if (manual->isChecked()) {
+      return AmendDialog::SelectedDateTimeType::Manual;
+    }
+    return AmendDialog::SelectedDateTimeType::Current;
+  }
+
+signals:
+  void typeChanged(AmendDialog::SelectedDateTimeType);
+
+private:
+  QRadioButton *current;
+  QRadioButton *manual;
+  QRadioButton *original;
+};
 
 enum Row {
   AuthorName = 0,
   AuthorEmail,
-  EditAuthorCommitDate,
+  AuthorCommitDateType,
   AuthorCommitDate,
   CommitterName,
   CommitterEmail,
-  EditCommitterCommitDate,
+  CommitterCommitDateType,
   CommitterCommitDate,
   CommitMessage,
 
@@ -27,7 +75,7 @@ enum Row {
 AmendDialog::AmendDialog(const git::Signature &author,
                          const git::Signature &committer,
                          const QString &commitMessage, QWidget *parent)
-    : QDialog(parent) {
+    : QDialog(parent), m_author(author), m_committer(committer) {
 
   auto *l = new QGridLayout();
 
@@ -39,33 +87,40 @@ AmendDialog::AmendDialog(const git::Signature &author,
   m_authorName = new QLineEdit(author.name(), this);
   auto *lAuthorEmail = new QLabel(tr("Author email:"), this);
   m_authorEmail = new QLineEdit(author.email(), this);
-  auto *lAuthorCommitDate = new QLabel(tr("Author commit date:"), this);
+  m_lAuthorCommitDate = new QLabel(tr("Author commit date:"), this);
+  m_authorCommitDateType = new DateSelectionGroupWidget(this);
+  m_authorCommitDateType->setObjectName("AuthorCommitDateType");
   m_authorCommitDate = new QDateTimeEdit(author.date().toLocalTime(), this);
-  m_editAuthorCommitDate =
-      new QCheckBox(tr("Manually set author commit date?"), this);
+  m_authorCommitDate->setObjectName("authorCommitDate");
+  m_authorCommitDate->setEnabled(m_authorCommitDateType->type() ==
+                                 SelectedDateTimeType::Manual);
   l->addWidget(lAuthor, Row::AuthorName, 0);
   l->addWidget(m_authorName, Row::AuthorName, 1);
   l->addWidget(lAuthorEmail, Row::AuthorEmail, 0);
   l->addWidget(m_authorEmail, Row::AuthorEmail, 1);
-  l->addWidget(m_editAuthorCommitDate, Row::EditAuthorCommitDate, 0);
-  l->addWidget(lAuthorCommitDate, Row::AuthorCommitDate, 0);
+  l->addWidget(m_authorCommitDateType, Row::AuthorCommitDateType, 0, 1, 2);
+  l->addWidget(m_lAuthorCommitDate, Row::AuthorCommitDate, 0);
   l->addWidget(m_authorCommitDate, Row::AuthorCommitDate, 1);
 
   auto *lCommitterName = new QLabel(tr("Committer name:"), this);
   m_committerName = new QLineEdit(committer.name(), this);
   auto *lCommitterEmail = new QLabel(tr("Committer email:"), this);
   m_committerEmail = new QLineEdit(committer.email(), this);
-  auto *lCommitterCommitDate = new QLabel(tr("Committer commit date:"), this);
+  m_lCommitterCommitDate = new QLabel(tr("Committer commit date:"), this);
+  m_committerCommitDateType = new DateSelectionGroupWidget(this);
+  m_committerCommitDateType->setObjectName("CommitterCommitDateType");
   m_committerCommitDate =
       new QDateTimeEdit(committer.date().toLocalTime(), this);
-  m_editCommitterCommitDate =
-      new QCheckBox(tr("Manually set committer commit date?"), this);
+  m_committerCommitDate->setObjectName("committerCommitDate");
+  m_committerCommitDate->setEnabled(m_committerCommitDateType->type() ==
+                                    SelectedDateTimeType::Manual);
   l->addWidget(lCommitterName, Row::CommitterName, 0);
   l->addWidget(m_committerName, Row::CommitterName, 1);
   l->addWidget(lCommitterEmail, Row::CommitterEmail, 0);
   l->addWidget(m_committerEmail, Row::CommitterEmail, 1);
-  l->addWidget(m_editCommitterCommitDate, Row::EditCommitterCommitDate, 0);
-  l->addWidget(lCommitterCommitDate, Row::CommitterCommitDate, 0);
+  l->addWidget(m_committerCommitDateType, Row::CommitterCommitDateType, 0, 1,
+               2);
+  l->addWidget(m_lCommitterCommitDate, Row::CommitterCommitDate, 0);
   l->addWidget(m_committerCommitDate, Row::CommitterCommitDate, 1);
 
   auto *lMessage = new QLabel(tr("Message:"), this);
@@ -79,24 +134,20 @@ AmendDialog::AmendDialog(const git::Signature &author,
   connect(ok, &QPushButton::clicked, this, &QDialog::accept);
   connect(cancel, &QPushButton::clicked, this, &QDialog::reject);
 
-  auto chbStateChangedHandler = [](QCheckBox *chb, QWidget *l) {
-    auto enable = chb->checkState() == Qt::Checked;
-    l->setEnabled(enable);
-  };
-
-  connect(m_editAuthorCommitDate, &QCheckBox::stateChanged, this,
-          [&, chbStateChangedHandler]() {
-            chbStateChangedHandler(m_editAuthorCommitDate, m_authorCommitDate);
+  connect(m_authorCommitDateType, &DateSelectionGroupWidget::typeChanged,
+          [this](AmendDialog::SelectedDateTimeType type) {
+            const auto enabled =
+                type == AmendDialog::SelectedDateTimeType::Manual;
+            this->m_lAuthorCommitDate->setEnabled(enabled);
+            this->m_authorCommitDate->setEnabled(enabled);
           });
-
-  connect(m_editCommitterCommitDate, &QCheckBox::stateChanged, this,
-          [&, chbStateChangedHandler]() {
-            chbStateChangedHandler(m_editCommitterCommitDate,
-                                   m_committerCommitDate);
+  connect(m_committerCommitDateType, &DateSelectionGroupWidget::typeChanged,
+          [this](AmendDialog::SelectedDateTimeType type) {
+            const auto enabled =
+                type == AmendDialog::SelectedDateTimeType::Manual;
+            this->m_lCommitterCommitDate->setEnabled(enabled);
+            this->m_committerCommitDate->setEnabled(enabled);
           });
-
-  chbStateChangedHandler(m_editAuthorCommitDate, m_authorCommitDate);
-  chbStateChangedHandler(m_editCommitterCommitDate, m_committerCommitDate);
 
   auto *hl = new QHBoxLayout();
   hl->addWidget(cancel);
@@ -112,11 +163,15 @@ QString AmendDialog::authorName() const { return m_authorName->text(); }
 QString AmendDialog::authorEmail() const { return m_authorEmail->text(); }
 
 QDateTime AmendDialog::authorCommitDate() const {
-  return m_authorCommitDate->dateTime();
+  if (authorCommitDateType() == SelectedDateTimeType::Original) {
+    return m_author.date().toLocalTime();
+  } else {
+    return m_authorCommitDate->dateTime();
+  }
 }
 
-bool AmendDialog::editAuthorCommitDate() const {
-  return m_editAuthorCommitDate->checkState() == Qt::Checked;
+AmendDialog::SelectedDateTimeType AmendDialog::authorCommitDateType() const {
+  return m_authorCommitDateType->type();
 }
 
 QString AmendDialog::committerName() const { return m_committerName->text(); }
@@ -124,13 +179,19 @@ QString AmendDialog::committerName() const { return m_committerName->text(); }
 QString AmendDialog::committerEmail() const { return m_committerEmail->text(); }
 
 QDateTime AmendDialog::committerCommitDate() const {
-  return m_committerCommitDate->dateTime();
+  if (committerCommitDateType() == SelectedDateTimeType::Original) {
+    return m_committer.date().toLocalTime();
+  } else {
+    return m_committerCommitDate->dateTime();
+  }
 }
 
-bool AmendDialog::editCommitterCommitDate() const {
-  return m_editCommitterCommitDate->checkState() == Qt::Checked;
+AmendDialog::SelectedDateTimeType AmendDialog::committerCommitDateType() const {
+  return m_committerCommitDateType->type();
 }
 
 QString AmendDialog::commitMessage() const {
   return m_commitMessage->toPlainText();
 }
+
+#include "AmendDialog.moc"

--- a/src/dialogs/AmendDialog.cpp
+++ b/src/dialogs/AmendDialog.cpp
@@ -61,11 +61,11 @@ private:
 enum Row {
   AuthorName = 0,
   AuthorEmail,
-  AuthorCommitDateType,
+  AuthorDateType,
   AuthorCommitDate,
   CommitterName,
   CommitterEmail,
-  CommitterCommitDateType,
+  CommitterDateType,
   CommitterCommitDate,
   CommitMessage,
 
@@ -92,13 +92,12 @@ AmendDialog::AmendDialog(const git::Signature &author,
   m_authorCommitDateType->setObjectName("AuthorCommitDateType");
   m_authorCommitDate = new QDateTimeEdit(author.date().toLocalTime(), this);
   m_authorCommitDate->setObjectName("authorCommitDate");
-  m_authorCommitDate->setVisible(m_authorCommitDateType->type() ==
-                                 SelectedDateTimeType::Manual);
+  authorDateTimeTypeChanged(m_authorCommitDateType->type());
   l->addWidget(lAuthor, Row::AuthorName, 0);
   l->addWidget(m_authorName, Row::AuthorName, 1);
   l->addWidget(lAuthorEmail, Row::AuthorEmail, 0);
   l->addWidget(m_authorEmail, Row::AuthorEmail, 1);
-  l->addWidget(m_authorCommitDateType, Row::AuthorCommitDateType, 0, 1, 2);
+  l->addWidget(m_authorCommitDateType, Row::AuthorDateType, 0, 1, 2);
   l->addWidget(m_lAuthorCommitDate, Row::AuthorCommitDate, 0);
   l->addWidget(m_authorCommitDate, Row::AuthorCommitDate, 1);
 
@@ -112,14 +111,12 @@ AmendDialog::AmendDialog(const git::Signature &author,
   m_committerCommitDate =
       new QDateTimeEdit(committer.date().toLocalTime(), this);
   m_committerCommitDate->setObjectName("committerCommitDate");
-  m_committerCommitDate->setVisible(m_committerCommitDateType->type() ==
-                                    SelectedDateTimeType::Manual);
+  committerDateTimeTypeChanged(m_committerCommitDateType->type());
   l->addWidget(lCommitterName, Row::CommitterName, 0);
   l->addWidget(m_committerName, Row::CommitterName, 1);
   l->addWidget(lCommitterEmail, Row::CommitterEmail, 0);
   l->addWidget(m_committerEmail, Row::CommitterEmail, 1);
-  l->addWidget(m_committerCommitDateType, Row::CommitterCommitDateType, 0, 1,
-               2);
+  l->addWidget(m_committerCommitDateType, Row::CommitterDateType, 0, 1, 2);
   l->addWidget(m_lCommitterCommitDate, Row::CommitterCommitDate, 0);
   l->addWidget(m_committerCommitDate, Row::CommitterCommitDate, 1);
 
@@ -134,20 +131,10 @@ AmendDialog::AmendDialog(const git::Signature &author,
   connect(ok, &QPushButton::clicked, this, &QDialog::accept);
   connect(cancel, &QPushButton::clicked, this, &QDialog::reject);
 
-  connect(m_authorCommitDateType, &DateSelectionGroupWidget::typeChanged,
-          [this](AmendDialog::SelectedDateTimeType type) {
-            const auto enabled =
-                type == AmendDialog::SelectedDateTimeType::Manual;
-            this->m_lAuthorCommitDate->setVisible(enabled);
-            this->m_authorCommitDate->setVisible(enabled);
-          });
+  connect(m_authorCommitDateType, &DateSelectionGroupWidget::typeChanged, this,
+          &AmendDialog::authorDateTimeTypeChanged);
   connect(m_committerCommitDateType, &DateSelectionGroupWidget::typeChanged,
-          [this](AmendDialog::SelectedDateTimeType type) {
-            const auto enabled =
-                type == AmendDialog::SelectedDateTimeType::Manual;
-            this->m_lCommitterCommitDate->setVisible(enabled);
-            this->m_committerCommitDate->setVisible(enabled);
-          });
+          this, &AmendDialog::committerDateTimeTypeChanged);
 
   auto *hl = new QHBoxLayout();
   hl->addWidget(cancel);
@@ -156,6 +143,19 @@ AmendDialog::AmendDialog(const git::Signature &author,
   l->addLayout(hl, Buttons, 1);
 
   setLayout(l);
+}
+
+void AmendDialog::authorDateTimeTypeChanged(const SelectedDateTimeType type) {
+  const auto enabled = type == AmendDialog::SelectedDateTimeType::Manual;
+  this->m_lAuthorCommitDate->setVisible(enabled);
+  this->m_authorCommitDate->setVisible(enabled);
+}
+
+void AmendDialog::committerDateTimeTypeChanged(
+    const SelectedDateTimeType type) {
+  const auto enabled = type == AmendDialog::SelectedDateTimeType::Manual;
+  this->m_lCommitterCommitDate->setVisible(enabled);
+  this->m_committerCommitDate->setVisible(enabled);
 }
 
 QString AmendDialog::authorName() const { return m_authorName->text(); }

--- a/src/dialogs/AmendDialog.cpp
+++ b/src/dialogs/AmendDialog.cpp
@@ -7,6 +7,7 @@
 #include <QPushButton>
 #include <QCheckBox>
 #include <QHBoxLayout>
+#include <QVBoxLayout>
 #include <QDateTimeEdit>
 #include <QRadioButton>
 #include <QGroupBox>
@@ -66,33 +67,41 @@ public:
 
   InfoBox(const QString &title, const git::Signature &signature,
           QWidget *parent = nullptr)
-      : QGroupBox(title, parent), m_signature(signature) {
+      : QGroupBox(title + ":", parent), m_signature(signature) {
 
-    auto *l = new QGridLayout();
+    auto *l = new QVBoxLayout();
 
     auto *lName = new QLabel(tr("Name:"), this);
     m_name = new QLineEdit(signature.name(), this);
+    auto *hName = new QHBoxLayout();
+    hName->addWidget(lName);
+    hName->addWidget(m_name);
 
     auto *lEmail = new QLabel(tr("Email:"), this);
     m_email = new QLineEdit(signature.email(), this);
+    auto *hEmail = new QHBoxLayout();
+    hEmail->addWidget(lEmail);
+    hEmail->addWidget(m_email);
 
     m_commitDateType = new DateSelectionGroupWidget(this);
-    m_commitDateType->setObjectName("CommitDateType");
+    m_commitDateType->setObjectName(title + "CommitDateType");
     m_lCommitDate = new QLabel(tr("Commit date:"), this);
     m_commitDate = new QDateTimeEdit(signature.date().toLocalTime(), this);
-    m_commitDate->setObjectName("CommitDate");
+    m_commitDate->setObjectName(title + "CommitDate");
+    QSizePolicy sp(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    m_commitDate->setSizePolicy(sp);
+    auto *hDate = new QHBoxLayout();
+    hDate->addWidget(m_lCommitDate);
+    hDate->addWidget(m_commitDate);
 
-    dateTimeTypeChanged(m_commitDateType->type());
-
-    l->addWidget(lName, LocalRow::Name, 0);
-    l->addWidget(m_name, LocalRow::Name, 1);
-    l->addWidget(lEmail, LocalRow::Email, 0);
-    l->addWidget(m_email, LocalRow::Email, 1);
-    l->addWidget(m_commitDateType, LocalRow::DateType, 0, 1, 2);
-    l->addWidget(m_lCommitDate, LocalRow::CommitDate, 0);
-    l->addWidget(m_commitDate, LocalRow::CommitDate, 1);
+    l->addLayout(hName);
+    l->addLayout(hEmail);
+    l->addWidget(m_commitDateType);
+    l->addLayout(hDate);
 
     setLayout(l);
+
+    dateTimeTypeChanged(m_commitDateType->type());
 
     connect(m_commitDateType, &DateSelectionGroupWidget::typeChanged, this,
             &InfoBox::dateTimeTypeChanged);
@@ -111,8 +120,8 @@ public:
 private slots:
   void dateTimeTypeChanged(const ContributorInfo::SelectedDateTimeType type) {
     const auto enabled = type == ContributorInfo::SelectedDateTimeType::Manual;
-    this->m_lCommitDate->setVisible(enabled);
-    this->m_commitDate->setVisible(enabled);
+    m_lCommitDate->setVisible(enabled);
+    m_commitDate->setVisible(enabled);
   }
 
 private:
@@ -152,10 +161,10 @@ AmendDialog::AmendDialog(const git::Signature &author,
   // committer
   // message
 
-  m_authorInfo = new InfoBox(tr("Author:"), author, this);
+  m_authorInfo = new InfoBox(tr("Author"), author, this);
   l->addWidget(m_authorInfo, Row::Author, 0, 1, 2);
 
-  m_committerInfo = new InfoBox(tr("Committer:"), committer, this);
+  m_committerInfo = new InfoBox(tr("Committer"), committer, this);
   l->addWidget(m_committerInfo, Row::Committer, 0, 1, 2);
 
   auto *lMessage = new QLabel(tr("Commit Message:"), this);

--- a/src/dialogs/AmendDialog.cpp
+++ b/src/dialogs/AmendDialog.cpp
@@ -69,16 +69,20 @@ public:
           QWidget *parent = nullptr)
       : QGroupBox(title + ":", parent), m_signature(signature) {
 
+    setObjectName(title);
+
     auto *l = new QVBoxLayout();
 
     auto *lName = new QLabel(tr("Name:"), this);
     m_name = new QLineEdit(signature.name(), this);
+    m_name->setObjectName("Name");
     auto *hName = new QHBoxLayout();
     hName->addWidget(lName);
     hName->addWidget(m_name);
 
     auto *lEmail = new QLabel(tr("Email:"), this);
     m_email = new QLineEdit(signature.email(), this);
+    m_email->setObjectName("Email");
     auto *hEmail = new QHBoxLayout();
     hEmail->addWidget(lEmail);
     hEmail->addWidget(m_email);
@@ -169,6 +173,7 @@ AmendDialog::AmendDialog(const git::Signature &author,
 
   auto *lMessage = new QLabel(tr("Commit Message:"), this);
   m_commitMessage = new QTextEdit(commitMessage, this);
+  m_commitMessage->setObjectName("Textlabel Commit Message");
   l->addWidget(lMessage, Row::CommitMessageLabel, 0);
   l->addWidget(m_commitMessage, Row::CommitMessage, 0, 1, 2);
 

--- a/src/dialogs/AmendDialog.h
+++ b/src/dialogs/AmendDialog.h
@@ -4,6 +4,7 @@
 class QLineEdit;
 class QTextEdit;
 class QCheckBox;
+class QDateTimeEdit;
 
 class AmendDialog : public QDialog {
 public:
@@ -11,11 +12,11 @@ public:
               const QString &commitMessage, QWidget *parent = nullptr);
   QString authorName() const;
   QString authorEmail() const;
-  QString authorCommitDate() const;
+  QDateTime authorCommitDate() const;
   bool editAuthorCommitDate() const;
   QString committerName() const;
   QString committerEmail() const;
-  QString committerCommitDate() const;
+  QDateTime committerCommitDate() const;
   bool editCommitterCommitDate() const;
   QString commitMessage() const;
   
@@ -23,11 +24,11 @@ public:
 private:
   QLineEdit *m_authorName;
   QLineEdit *m_authorEmail;
-  QLineEdit *m_authorCommitDate;
+  QDateTimeEdit *m_authorCommitDate;
   QCheckBox *m_editAuthorCommitDate;
   QLineEdit *m_committerName;
   QLineEdit *m_committerEmail;
-  QLineEdit *m_committerCommitDate;
+  QDateTimeEdit *m_committerCommitDate;
   QCheckBox *m_editCommitterCommitDate;
   QTextEdit *m_commitMessage;
 };

--- a/src/dialogs/AmendDialog.h
+++ b/src/dialogs/AmendDialog.h
@@ -24,6 +24,10 @@ public:
   SelectedDateTimeType committerCommitDateType() const;
   QString commitMessage() const;
 
+private slots:
+  void authorDateTimeTypeChanged(const SelectedDateTimeType type);
+  void committerDateTimeTypeChanged(const SelectedDateTimeType type);
+
 private:
   QLineEdit *m_authorName;
   QLineEdit *m_authorEmail;

--- a/src/dialogs/AmendDialog.h
+++ b/src/dialogs/AmendDialog.h
@@ -3,6 +3,7 @@
 
 class QLineEdit;
 class QTextEdit;
+class QCheckBox;
 
 class AmendDialog : public QDialog {
 public:
@@ -10,14 +11,23 @@ public:
               const QString &commitMessage, QWidget *parent = nullptr);
   QString authorName() const;
   QString authorEmail() const;
+  QString authorCommitDate() const;
+  bool editAuthorCommitDate() const;
   QString committerName() const;
   QString committerEmail() const;
+  QString committerCommitDate() const;
+  bool editCommitterCommitDate() const;
   QString commitMessage() const;
+  
 
 private:
   QLineEdit *m_authorName;
   QLineEdit *m_authorEmail;
+  QLineEdit *m_authorCommitDate;
+  QCheckBox *m_editAuthorCommitDate;
   QLineEdit *m_committerName;
   QLineEdit *m_committerEmail;
+  QLineEdit *m_committerCommitDate;
+  QCheckBox *m_editCommitterCommitDate;
   QTextEdit *m_commitMessage;
 };

--- a/src/dialogs/AmendDialog.h
+++ b/src/dialogs/AmendDialog.h
@@ -5,29 +5,38 @@ class QLineEdit;
 class QTextEdit;
 class QCheckBox;
 class QDateTimeEdit;
+class DateSelectionGroupWidget;
+class QLabel;
 
 class AmendDialog : public QDialog {
 public:
+  enum class SelectedDateTimeType { Current, Manual, Original };
+
   AmendDialog(const git::Signature &author, const git::Signature &committer,
               const QString &commitMessage, QWidget *parent = nullptr);
   QString authorName() const;
   QString authorEmail() const;
   QDateTime authorCommitDate() const;
-  bool editAuthorCommitDate() const;
+  SelectedDateTimeType authorCommitDateType() const;
   QString committerName() const;
   QString committerEmail() const;
   QDateTime committerCommitDate() const;
-  bool editCommitterCommitDate() const;
+  SelectedDateTimeType committerCommitDateType() const;
   QString commitMessage() const;
 
 private:
   QLineEdit *m_authorName;
   QLineEdit *m_authorEmail;
   QDateTimeEdit *m_authorCommitDate;
-  QCheckBox *m_editAuthorCommitDate;
+  QLabel *m_lAuthorCommitDate;
+  DateSelectionGroupWidget *m_authorCommitDateType;
   QLineEdit *m_committerName;
   QLineEdit *m_committerEmail;
   QDateTimeEdit *m_committerCommitDate;
-  QCheckBox *m_editCommitterCommitDate;
+  QLabel *m_lCommitterCommitDate;
+  DateSelectionGroupWidget *m_committerCommitDateType;
   QTextEdit *m_commitMessage;
+
+  git::Signature m_author;
+  git::Signature m_committer;
 };

--- a/src/dialogs/AmendDialog.h
+++ b/src/dialogs/AmendDialog.h
@@ -1,4 +1,5 @@
 #include <QDialog>
+#include <QDateTime>
 #include "git/Signature.h"
 
 class QLineEdit;
@@ -7,40 +8,34 @@ class QCheckBox;
 class QDateTimeEdit;
 class DateSelectionGroupWidget;
 class QLabel;
+class InfoBox;
+class AmendDialog;
+
+struct ContributorInfo {
+  enum class SelectedDateTimeType { Current, Manual, Original };
+  QString name;
+  QString email;
+  QDateTime commitDate;
+  SelectedDateTimeType commitDateType;
+};
+
+struct AmendInfo {
+  ContributorInfo authorInfo;
+  ContributorInfo committerInfo;
+  QString commitMessage;
+};
 
 class AmendDialog : public QDialog {
 public:
-  enum class SelectedDateTimeType { Current, Manual, Original };
-
   AmendDialog(const git::Signature &author, const git::Signature &committer,
               const QString &commitMessage, QWidget *parent = nullptr);
-  QString authorName() const;
-  QString authorEmail() const;
-  QDateTime authorCommitDate() const;
-  SelectedDateTimeType authorCommitDateType() const;
-  QString committerName() const;
-  QString committerEmail() const;
-  QDateTime committerCommitDate() const;
-  SelectedDateTimeType committerCommitDateType() const;
-  QString commitMessage() const;
 
-private slots:
-  void authorDateTimeTypeChanged(const SelectedDateTimeType type);
-  void committerDateTimeTypeChanged(const SelectedDateTimeType type);
+  AmendInfo getInfo() const;
 
 private:
-  QLineEdit *m_authorName;
-  QLineEdit *m_authorEmail;
-  QDateTimeEdit *m_authorCommitDate;
-  QLabel *m_lAuthorCommitDate;
-  DateSelectionGroupWidget *m_authorCommitDateType;
-  QLineEdit *m_committerName;
-  QLineEdit *m_committerEmail;
-  QDateTimeEdit *m_committerCommitDate;
-  QLabel *m_lCommitterCommitDate;
-  DateSelectionGroupWidget *m_committerCommitDateType;
-  QTextEdit *m_commitMessage;
+  QString commitMessage() const;
 
-  git::Signature m_author;
-  git::Signature m_committer;
+  InfoBox *m_authorInfo;
+  InfoBox *m_committerInfo;
+  QTextEdit *m_commitMessage;
 };

--- a/src/dialogs/AmendDialog.h
+++ b/src/dialogs/AmendDialog.h
@@ -19,7 +19,6 @@ public:
   QDateTime committerCommitDate() const;
   bool editCommitterCommitDate() const;
   QString commitMessage() const;
-  
 
 private:
   QLineEdit *m_authorName;

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -192,6 +192,10 @@ Signature Repository::signature(const QString &name, const QString &email) {
   return Signature(name, email);
 }
 
+Signature Repository::signature(const QString &name, const QString &email, const QString &date) {
+  return Signature(name, email, date);
+}
+
 Signature Repository::defaultSignature(bool *fake, const QString &overrideUser,
                                        const QString &overrideEmail) const {
   QString name, email;

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -192,7 +192,8 @@ Signature Repository::signature(const QString &name, const QString &email) {
   return Signature(name, email);
 }
 
-Signature Repository::signature(const QString &name, const QString &email, const QDateTime &date) {
+Signature Repository::signature(const QString &name, const QString &email,
+                                const QDateTime &date) {
   return Signature(name, email, date);
 }
 

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -192,7 +192,7 @@ Signature Repository::signature(const QString &name, const QString &email) {
   return Signature(name, email);
 }
 
-Signature Repository::signature(const QString &name, const QString &email, const QString &date) {
+Signature Repository::signature(const QString &name, const QString &email, const QDateTime &date) {
   return Signature(name, email, date);
 }
 

--- a/src/git/Repository.h
+++ b/src/git/Repository.h
@@ -93,6 +93,7 @@ public:
                              const QString &overrideEmail = QString()) const;
 
   Signature signature(const QString &name, const QString &email);
+  Signature signature(const QString &name, const QString &email, const QString &date);
 
   // ignore
   bool isIgnored(const QString &path) const;

--- a/src/git/Repository.h
+++ b/src/git/Repository.h
@@ -93,7 +93,8 @@ public:
                              const QString &overrideEmail = QString()) const;
 
   Signature signature(const QString &name, const QString &email);
-  Signature signature(const QString &name, const QString &email, const QDateTime &date);
+  Signature signature(const QString &name, const QString &email,
+                      const QDateTime &date);
 
   // ignore
   bool isIgnored(const QString &path) const;

--- a/src/git/Repository.h
+++ b/src/git/Repository.h
@@ -93,7 +93,7 @@ public:
                              const QString &overrideEmail = QString()) const;
 
   Signature signature(const QString &name, const QString &email);
-  Signature signature(const QString &name, const QString &email, const QString &date);
+  Signature signature(const QString &name, const QString &email, const QDateTime &date);
 
   // ignore
   bool isIgnored(const QString &path) const;

--- a/src/git/Signature.cpp
+++ b/src/git/Signature.cpp
@@ -24,11 +24,13 @@ Signature::Signature(const QString &name, const QString &email) {
   d = QSharedPointer<git_signature>(signature, git_signature_free);
 }
 
-Signature::Signature(const QString &name, const QString &email, const QDateTime &date) {
+Signature::Signature(const QString &name, const QString &email,
+                     const QDateTime &date) {
   git_signature *signature = nullptr;
 
   auto offset = date.offsetFromUtc() / 60;
-  git_signature_new(&signature, name.toUtf8(), email.toUtf8(), date.toSecsSinceEpoch(), offset);
+  git_signature_new(&signature, name.toUtf8(), email.toUtf8(),
+                    date.toSecsSinceEpoch(), offset);
   d = QSharedPointer<git_signature>(signature, git_signature_free);
 }
 

--- a/src/git/Signature.cpp
+++ b/src/git/Signature.cpp
@@ -24,6 +24,15 @@ Signature::Signature(const QString &name, const QString &email) {
   d = QSharedPointer<git_signature>(signature, git_signature_free);
 }
 
+Signature::Signature(const QString &name, const QString &email, const QString &date) {
+  git_signature *signature = nullptr;
+
+  auto dateTime = QDateTime::fromString(date, Qt::RFC2822Date);
+  auto offset = dateTime.offsetFromUtc() / 60;
+  git_signature_new(&signature, name.toUtf8(), email.toUtf8(), dateTime.toSecsSinceEpoch(), offset);
+  d = QSharedPointer<git_signature>(signature, git_signature_free);
+}
+
 Signature::operator const git_signature *() const { return d.data(); }
 
 QString Signature::name() const { return d->name; }

--- a/src/git/Signature.cpp
+++ b/src/git/Signature.cpp
@@ -24,12 +24,11 @@ Signature::Signature(const QString &name, const QString &email) {
   d = QSharedPointer<git_signature>(signature, git_signature_free);
 }
 
-Signature::Signature(const QString &name, const QString &email, const QString &date) {
+Signature::Signature(const QString &name, const QString &email, const QDateTime &date) {
   git_signature *signature = nullptr;
 
-  auto dateTime = QDateTime::fromString(date, Qt::RFC2822Date);
-  auto offset = dateTime.offsetFromUtc() / 60;
-  git_signature_new(&signature, name.toUtf8(), email.toUtf8(), dateTime.toSecsSinceEpoch(), offset);
+  auto offset = date.offsetFromUtc() / 60;
+  git_signature_new(&signature, name.toUtf8(), email.toUtf8(), date.toSecsSinceEpoch(), offset);
   d = QSharedPointer<git_signature>(signature, git_signature_free);
 }
 

--- a/src/git/Signature.h
+++ b/src/git/Signature.h
@@ -36,6 +36,7 @@ public:
 private:
   Signature(git_signature *signature = nullptr, bool owned = false);
   Signature(const QString &name, const QString &email);
+  Signature(const QString &name, const QString &email, const QString &date);
   operator const git_signature *() const;
 
   QSharedPointer<git_signature> d;

--- a/src/git/Signature.h
+++ b/src/git/Signature.h
@@ -36,7 +36,7 @@ public:
 private:
   Signature(git_signature *signature = nullptr, bool owned = false);
   Signature(const QString &name, const QString &email);
-  Signature(const QString &name, const QString &email, const QString &date);
+  Signature(const QString &name, const QString &email, const QDateTime &date);
   operator const git_signature *() const;
 
   QSharedPointer<git_signature> d;

--- a/src/ui/DetailView.cpp
+++ b/src/ui/DetailView.cpp
@@ -353,8 +353,8 @@ public:
                                                committer.join(", "));
 
       // Set date range.
-      QDate lastDate = last.committer().date().date();
-      QDate firstDate = first.committer().date().date();
+      QDate lastDate = last.committer().date().toLocalTime().date();
+      QDate firstDate = first.committer().date().toLocalTime().date();
       QString lastDateStr = lastDate.toString(Qt::DefaultLocaleShortDate);
       QString firstDateStr = firstDate.toString(Qt::DefaultLocaleShortDate);
       QString dateStr = (lastDate == firstDate)
@@ -391,7 +391,7 @@ public:
     git::Commit commit = commits.first();
     git::Signature author = commit.author();
     git::Signature committer = commit.committer();
-    QDateTime date = commit.committer().date();
+    QDateTime date = commit.committer().date().toLocalTime();
     mHash->setText(brightText(tr("Id:")) + " " + commit.shortId());
     mAuthorCommitterDate->setDate(
         brightText(date.toString(Qt::DefaultLocaleLongDate)));

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -2912,7 +2912,7 @@ bool RepoView::checkForConflicts(LogEntry *parent, const QString &action) {
 }
 
 git::Signature RepoView::getAuthorSignature(const AmendDialog *d) {
-  if (d->editAuthorCommitDate())
+  if (d->authorCommitDateType() != AmendDialog::SelectedDateTimeType::Current)
     return mRepo.signature(d->authorName(), d->authorEmail(),
                            d->authorCommitDate());
 
@@ -2920,7 +2920,8 @@ git::Signature RepoView::getAuthorSignature(const AmendDialog *d) {
 }
 
 git::Signature RepoView::getCommitterSignature(const AmendDialog *d) {
-  if (d->editCommitterCommitDate())
+  if (d->committerCommitDateType() !=
+      AmendDialog::SelectedDateTimeType::Current)
     return mRepo.signature(d->committerName(), d->committerEmail(),
                            d->committerCommitDate());
 

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -2148,10 +2148,12 @@ void RepoView::promptToAmend(const git::Commit &commit) {
                             commit.message(), this);
   d->setAttribute(Qt::WA_DeleteOnClose);
   connect(d, &QDialog::accepted, [this, d, commit]() {
-    git::Signature author = getAuthorSignature(d);
-    git::Signature committer = getCommitterSignature(d);
+    auto info = d->getInfo();
 
-    amend(commit, author, committer, d->commitMessage());
+    git::Signature author = getSignature(info.authorInfo);
+    git::Signature committer = getSignature(info.committerInfo);
+
+    amend(commit, author, committer, info.commitMessage);
   });
 
   d->show();
@@ -2911,21 +2913,11 @@ bool RepoView::checkForConflicts(LogEntry *parent, const QString &action) {
   return true;
 }
 
-git::Signature RepoView::getAuthorSignature(const AmendDialog *d) {
-  if (d->authorCommitDateType() != AmendDialog::SelectedDateTimeType::Current)
-    return mRepo.signature(d->authorName(), d->authorEmail(),
-                           d->authorCommitDate());
+git::Signature RepoView::getSignature(const ContributorInfo &info) {
+  if (info.commitDateType != ContributorInfo::SelectedDateTimeType::Current)
+    return mRepo.signature(info.name, info.email, info.commitDate);
 
-  return mRepo.signature(d->authorName(), d->authorEmail());
-}
-
-git::Signature RepoView::getCommitterSignature(const AmendDialog *d) {
-  if (d->committerCommitDateType() !=
-      AmendDialog::SelectedDateTimeType::Current)
-    return mRepo.signature(d->committerName(), d->committerEmail(),
-                           d->committerCommitDate());
-
-  return mRepo.signature(d->committerName(), d->committerEmail());
+  return mRepo.signature(info.name, info.email);
 }
 
 bool RepoView::match(QObject *search, QObject *parent) {

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -2911,17 +2911,19 @@ bool RepoView::checkForConflicts(LogEntry *parent, const QString &action) {
   return true;
 }
 
-git::Signature RepoView::getAuthorSignature(const AmendDialog* d) {
-  if(d->editAuthorCommitDate())
-    return mRepo.signature(d->authorName(), d->authorEmail(), d->authorCommitDate());
-  
+git::Signature RepoView::getAuthorSignature(const AmendDialog *d) {
+  if (d->editAuthorCommitDate())
+    return mRepo.signature(d->authorName(), d->authorEmail(),
+                           d->authorCommitDate());
+
   return mRepo.signature(d->authorName(), d->authorEmail());
 }
 
-git::Signature RepoView::getCommitterSignature(const AmendDialog* d) {
-  if(d->editCommitterCommitDate())
-    return mRepo.signature(d->committerName(), d->committerEmail(), d->committerCommitDate());
-  
+git::Signature RepoView::getCommitterSignature(const AmendDialog *d) {
+  if (d->editCommitterCommitDate())
+    return mRepo.signature(d->committerName(), d->committerEmail(),
+                           d->committerCommitDate());
+
   return mRepo.signature(d->committerName(), d->committerEmail());
 }
 

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -2148,9 +2148,8 @@ void RepoView::promptToAmend(const git::Commit &commit) {
                             commit.message(), this);
   d->setAttribute(Qt::WA_DeleteOnClose);
   connect(d, &QDialog::accepted, [this, d, commit]() {
-    git::Signature author = mRepo.signature(d->authorName(), d->authorEmail());
-    git::Signature committer =
-        mRepo.signature(d->committerName(), d->committerEmail());
+    git::Signature author = getAuthorSignature(d);
+    git::Signature committer = getCommitterSignature(d);
 
     amend(commit, author, committer, d->commitMessage());
   });
@@ -2910,6 +2909,20 @@ bool RepoView::checkForConflicts(LogEntry *parent, const QString &action) {
 
   refresh();
   return true;
+}
+
+git::Signature RepoView::getAuthorSignature(const AmendDialog* d) {
+  if(d->editAuthorCommitDate())
+    return mRepo.signature(d->authorName(), d->authorEmail(), d->authorCommitDate());
+  
+  return mRepo.signature(d->authorName(), d->authorEmail());
+}
+
+git::Signature RepoView::getCommitterSignature(const AmendDialog* d) {
+  if(d->editCommitterCommitDate())
+    return mRepo.signature(d->committerName(), d->committerEmail(), d->committerCommitDate());
+  
+  return mRepo.signature(d->committerName(), d->committerEmail());
 }
 
 bool RepoView::match(QObject *search, QObject *parent) {

--- a/src/ui/RepoView.h
+++ b/src/ui/RepoView.h
@@ -41,6 +41,7 @@ class PathspecWidget;
 class ReferenceWidget;
 class RemoteCallbacks;
 class ToolBar;
+class AmendDialog;
 
 namespace git {
 class Result;
@@ -394,6 +395,9 @@ private:
                             bool recursive, git_reset_t type);
 
   bool checkForConflicts(LogEntry *parent, const QString &action);
+
+  git::Signature getAuthorSignature(const AmendDialog* d);
+  git::Signature getCommitterSignature(const AmendDialog* d);
 
   git::Repository mRepo;
 

--- a/src/ui/RepoView.h
+++ b/src/ui/RepoView.h
@@ -396,8 +396,8 @@ private:
 
   bool checkForConflicts(LogEntry *parent, const QString &action);
 
-  git::Signature getAuthorSignature(const AmendDialog* d);
-  git::Signature getCommitterSignature(const AmendDialog* d);
+  git::Signature getAuthorSignature(const AmendDialog *d);
+  git::Signature getCommitterSignature(const AmendDialog *d);
 
   git::Repository mRepo;
 

--- a/src/ui/RepoView.h
+++ b/src/ui/RepoView.h
@@ -41,7 +41,7 @@ class PathspecWidget;
 class ReferenceWidget;
 class RemoteCallbacks;
 class ToolBar;
-class AmendDialog;
+class ContributorInfo;
 
 namespace git {
 class Result;
@@ -396,8 +396,7 @@ private:
 
   bool checkForConflicts(LogEntry *parent, const QString &action);
 
-  git::Signature getAuthorSignature(const AmendDialog *d);
-  git::Signature getCommitterSignature(const AmendDialog *d);
+  git::Signature getSignature(const ContributorInfo &info);
 
   git::Repository mRepo;
 

--- a/test/amend.cpp
+++ b/test/amend.cpp
@@ -42,9 +42,9 @@ void TestAmend::testAmend() {
 
   const QString commitMessage = "New commit message";
 
-  auto authorSignature = repo.signature("New Author", "New Author Email", "Sun May 23 10:36:26 2022 +0200");
+  auto authorSignature = repo.signature("New Author", "New Author Email", QDateTime::fromString("Sun May 23 10:36:26 2022 +0200", Qt::RFC2822Date));
   auto committerSignature =
-      repo.signature("New Committer", "New Committer Email", "Sun May 23 11:36:26 2022 +0200");
+      repo.signature("New Committer", "New Committer Email", QDateTime::fromString("Sun May 23 11:36:26 2022 +0200", Qt::RFC2822Date));
 
   Tree tree;
   c.amend(authorSignature, committerSignature, commitMessage, tree);

--- a/test/amend.cpp
+++ b/test/amend.cpp
@@ -221,13 +221,13 @@ void TestAmend::testAmendDialog() {
       authorCurrent->click();
       QCOMPARE(d.authorCommitDateType(),
                AmendDialog::SelectedDateTimeType::Current);
-      QCOMPARE(authorCommitDate->isEnabled(), false);
+      QCOMPARE(authorCommitDate->isVisible(), false);
 
       // original
       authorOriginal->click();
       QCOMPARE(d.authorCommitDateType(),
                AmendDialog::SelectedDateTimeType::Original);
-      QCOMPARE(authorCommitDate->isEnabled(), false);
+      QCOMPARE(authorCommitDate->isVisible(), false);
       QCOMPARE(d.authorCommitDate(),
                QDateTime::fromString("Sun May 23 10:36:26 2022 +0200",
                                      Qt::RFC2822Date));
@@ -236,7 +236,7 @@ void TestAmend::testAmendDialog() {
       authorManual->click();
       QCOMPARE(d.authorCommitDateType(),
                AmendDialog::SelectedDateTimeType::Manual);
-      QCOMPARE(authorCommitDate->isEnabled(), true);
+      QCOMPARE(authorCommitDate->isVisible(), true);
       QCOMPARE(d.authorCommitDate(),
                QDateTime(QDate(2012, 7, 6), QTime(8, 30, 5)));
     }
@@ -267,13 +267,13 @@ void TestAmend::testAmendDialog() {
       committerCurrent->click();
       QCOMPARE(d.committerCommitDateType(),
                AmendDialog::SelectedDateTimeType::Current);
-      QCOMPARE(committerCommitDate->isEnabled(), false);
+      QCOMPARE(committerCommitDate->isVisible(), false);
 
       // original
       committerOriginal->click();
       QCOMPARE(d.committerCommitDateType(),
                AmendDialog::SelectedDateTimeType::Original);
-      QCOMPARE(committerCommitDate->isEnabled(), false);
+      QCOMPARE(committerCommitDate->isVisible(), false);
       QCOMPARE(d.committerCommitDate(),
                QDateTime::fromString("Sun May 23 11:36:26 2022 +0200",
                                      Qt::RFC2822Date));
@@ -282,7 +282,7 @@ void TestAmend::testAmendDialog() {
       committerManual->click();
       QCOMPARE(d.committerCommitDateType(),
                AmendDialog::SelectedDateTimeType::Manual);
-      QCOMPARE(committerCommitDate->isEnabled(), true);
+      QCOMPARE(committerCommitDate->isVisible(), true);
       QCOMPARE(d.committerCommitDate(),
                QDateTime(QDate(2013, 5, 2), QTime(11, 22, 7)));
     }

--- a/test/amend.cpp
+++ b/test/amend.cpp
@@ -200,6 +200,7 @@ void TestAmend::testAmendDialog() {
 
   {
     AmendDialog d(authorSignature, committerSignature, "Test commit message");
+    d.show();
 
     {
       const auto *authorCommitDateTimeTypeSelection =
@@ -245,7 +246,7 @@ void TestAmend::testAmendDialog() {
       info = d.getInfo();
       QCOMPARE(info.authorInfo.commitDateType,
                ContributorInfo::SelectedDateTimeType::Manual);
-      // QCOMPARE(authorCommitDate->isVisible(), true);
+      QCOMPARE(authorCommitDate->isVisible(), true);
       QCOMPARE(info.authorInfo.commitDate,
                QDateTime(QDate(2012, 7, 6), QTime(8, 30, 5)));
     }
@@ -294,7 +295,7 @@ void TestAmend::testAmendDialog() {
       info = d.getInfo();
       QCOMPARE(info.committerInfo.commitDateType,
                ContributorInfo::SelectedDateTimeType::Manual);
-      // QCOMPARE(committerCommitDate->isVisible(), true);
+      QCOMPARE(committerCommitDate->isVisible(), true);
       QCOMPARE(info.committerInfo.commitDate,
                QDateTime(QDate(2013, 5, 2), QTime(11, 22, 7)));
     }

--- a/test/amend.cpp
+++ b/test/amend.cpp
@@ -35,14 +35,16 @@ void TestAmend::testAmend() {
   QCOMPARE(c.message(), "changes");
   QCOMPARE(c.author().email(), "martin.marmsoler@gmail.com");
   QCOMPARE(c.author().name(), "Martin Marmsoler");
+  QCOMPARE(c.author().date(), QDateTime::fromString("Sun May 22 10:36:26 2022 +0200", Qt::RFC2822Date));
   QCOMPARE(c.committer().name(), "Martin Marmsoler");
   QCOMPARE(c.committer().email(), "martin.marmsoler@gmail.com");
+  QCOMPARE(c.committer().date(), QDateTime::fromString("Sun May 22 10:36:26 2022 +0200", Qt::RFC2822Date));
 
   const QString commitMessage = "New commit message";
 
-  auto authorSignature = repo.signature("New Author", "New Author Email");
+  auto authorSignature = repo.signature("New Author", "New Author Email", "Sun May 23 10:36:26 2022 +0200");
   auto committerSignature =
-      repo.signature("New Committer", "New Committer Email");
+      repo.signature("New Committer", "New Committer Email", "Sun May 23 11:36:26 2022 +0200");
 
   Tree tree;
   c.amend(authorSignature, committerSignature, commitMessage, tree);
@@ -53,8 +55,10 @@ void TestAmend::testAmend() {
   QCOMPARE(c.message(), "New commit message");
   QCOMPARE(c.author().email(), "New Author Email");
   QCOMPARE(c.author().name(), "New Author");
+  QCOMPARE(c.author().date(), QDateTime::fromString("Sun May 23 10:36:26 2022 +0200", Qt::RFC2822Date));
   QCOMPARE(c.committer().name(), "New Committer");
   QCOMPARE(c.committer().email(), "New Committer Email");
+  QCOMPARE(c.committer().date(), QDateTime::fromString("Sun May 23 11:36:26 2022 +0200", Qt::RFC2822Date));
 }
 
 void TestAmend::testAmendAddFile() {

--- a/test/amend.cpp
+++ b/test/amend.cpp
@@ -35,16 +35,23 @@ void TestAmend::testAmend() {
   QCOMPARE(c.message(), "changes");
   QCOMPARE(c.author().email(), "martin.marmsoler@gmail.com");
   QCOMPARE(c.author().name(), "Martin Marmsoler");
-  QCOMPARE(c.author().date(), QDateTime::fromString("Sun May 22 10:36:26 2022 +0200", Qt::RFC2822Date));
+  QCOMPARE(
+      c.author().date(),
+      QDateTime::fromString("Sun May 22 10:36:26 2022 +0200", Qt::RFC2822Date));
   QCOMPARE(c.committer().name(), "Martin Marmsoler");
   QCOMPARE(c.committer().email(), "martin.marmsoler@gmail.com");
-  QCOMPARE(c.committer().date(), QDateTime::fromString("Sun May 22 10:36:26 2022 +0200", Qt::RFC2822Date));
+  QCOMPARE(
+      c.committer().date(),
+      QDateTime::fromString("Sun May 22 10:36:26 2022 +0200", Qt::RFC2822Date));
 
   const QString commitMessage = "New commit message";
 
-  auto authorSignature = repo.signature("New Author", "New Author Email", QDateTime::fromString("Sun May 23 10:36:26 2022 +0200", Qt::RFC2822Date));
-  auto committerSignature =
-      repo.signature("New Committer", "New Committer Email", QDateTime::fromString("Sun May 23 11:36:26 2022 +0200", Qt::RFC2822Date));
+  auto authorSignature = repo.signature(
+      "New Author", "New Author Email",
+      QDateTime::fromString("Sun May 23 10:36:26 2022 +0200", Qt::RFC2822Date));
+  auto committerSignature = repo.signature(
+      "New Committer", "New Committer Email",
+      QDateTime::fromString("Sun May 23 11:36:26 2022 +0200", Qt::RFC2822Date));
 
   Tree tree;
   c.amend(authorSignature, committerSignature, commitMessage, tree);
@@ -55,10 +62,14 @@ void TestAmend::testAmend() {
   QCOMPARE(c.message(), "New commit message");
   QCOMPARE(c.author().email(), "New Author Email");
   QCOMPARE(c.author().name(), "New Author");
-  QCOMPARE(c.author().date(), QDateTime::fromString("Sun May 23 10:36:26 2022 +0200", Qt::RFC2822Date));
+  QCOMPARE(
+      c.author().date(),
+      QDateTime::fromString("Sun May 23 10:36:26 2022 +0200", Qt::RFC2822Date));
   QCOMPARE(c.committer().name(), "New Committer");
   QCOMPARE(c.committer().email(), "New Committer Email");
-  QCOMPARE(c.committer().date(), QDateTime::fromString("Sun May 23 11:36:26 2022 +0200", Qt::RFC2822Date));
+  QCOMPARE(
+      c.committer().date(),
+      QDateTime::fromString("Sun May 23 11:36:26 2022 +0200", Qt::RFC2822Date));
 }
 
 void TestAmend::testAmendAddFile() {

--- a/test/amend.cpp
+++ b/test/amend.cpp
@@ -203,7 +203,7 @@ void TestAmend::testAmendDialog() {
 
     {
       const auto *authorCommitDateTimeTypeSelection =
-          d.findChild<QWidget *>("AuthorCommitDateType");
+          d.findChild<QWidget *>(tr("Author") + "CommitDateType");
       QVERIFY(authorCommitDateTimeTypeSelection);
       auto *authorCurrent =
           authorCommitDateTimeTypeSelection->findChild<QRadioButton *>(
@@ -217,7 +217,8 @@ void TestAmend::testAmendDialog() {
           authorCommitDateTimeTypeSelection->findChild<QRadioButton *>(
               "Manual");
       QVERIFY(authorManual);
-      auto *authorCommitDate = d.findChild<QDateTimeEdit *>("AuthorCommitDate");
+      auto *authorCommitDate =
+          d.findChild<QDateTimeEdit *>(tr("Author") + "CommitDate");
       QVERIFY(authorCommitDate);
       authorCommitDate->setDateTime(
           QDateTime(QDate(2012, 7, 6), QTime(8, 30, 5)));
@@ -251,7 +252,7 @@ void TestAmend::testAmendDialog() {
 
     {
       const auto *committerCommitDateTimeTypeSelection =
-          d.findChild<QWidget *>("CommitterCommitDateType");
+          d.findChild<QWidget *>(tr("Committer") + "CommitDateType");
       QVERIFY(committerCommitDateTimeTypeSelection);
       auto *committerCurrent =
           committerCommitDateTimeTypeSelection->findChild<QRadioButton *>(
@@ -266,7 +267,7 @@ void TestAmend::testAmendDialog() {
               "Manual");
       QVERIFY(committerManual);
       auto *committerCommitDate =
-          d.findChild<QDateTimeEdit *>("CommitterCommitDate");
+          d.findChild<QDateTimeEdit *>(tr("Committer") + "CommitDate");
       QVERIFY(committerCommitDate);
       committerCommitDate->setDateTime(
           QDateTime(QDate(2013, 5, 2), QTime(11, 22, 7)));

--- a/test/amend.cpp
+++ b/test/amend.cpp
@@ -217,27 +217,29 @@ void TestAmend::testAmendDialog() {
       authorCommitDate->setDateTime(
           QDateTime(QDate(2012, 7, 6), QTime(8, 30, 5)));
 
+      auto info = d.getInfo();
+
       // current
       authorCurrent->click();
-      QCOMPARE(d.authorCommitDateType(),
-               AmendDialog::SelectedDateTimeType::Current);
+      QCOMPARE(info.authorInfo.commitDateType,
+               ContributorInfo::SelectedDateTimeType::Current);
       QCOMPARE(authorCommitDate->isVisible(), false);
 
       // original
       authorOriginal->click();
-      QCOMPARE(d.authorCommitDateType(),
-               AmendDialog::SelectedDateTimeType::Original);
+      QCOMPARE(info.authorInfo.commitDateType,
+               ContributorInfo::SelectedDateTimeType::Original);
       QCOMPARE(authorCommitDate->isVisible(), false);
-      QCOMPARE(d.authorCommitDate(),
+      QCOMPARE(info.authorInfo.commitDate,
                QDateTime::fromString("Sun May 23 10:36:26 2022 +0200",
                                      Qt::RFC2822Date));
 
       // manual
       authorManual->click();
-      QCOMPARE(d.authorCommitDateType(),
-               AmendDialog::SelectedDateTimeType::Manual);
+      QCOMPARE(info.authorInfo.commitDateType,
+               ContributorInfo::SelectedDateTimeType::Manual);
       QCOMPARE(authorCommitDate->isVisible(), true);
-      QCOMPARE(d.authorCommitDate(),
+      QCOMPARE(info.authorInfo.commitDate,
                QDateTime(QDate(2012, 7, 6), QTime(8, 30, 5)));
     }
 
@@ -263,27 +265,29 @@ void TestAmend::testAmendDialog() {
       committerCommitDate->setDateTime(
           QDateTime(QDate(2013, 5, 2), QTime(11, 22, 7)));
 
+      auto info = d.getInfo();
+
       // current
       committerCurrent->click();
-      QCOMPARE(d.committerCommitDateType(),
-               AmendDialog::SelectedDateTimeType::Current);
+      QCOMPARE(info.committerInfo.commitDateType,
+               ContributorInfo::SelectedDateTimeType::Current);
       QCOMPARE(committerCommitDate->isVisible(), false);
 
       // original
       committerOriginal->click();
-      QCOMPARE(d.committerCommitDateType(),
-               AmendDialog::SelectedDateTimeType::Original);
+      QCOMPARE(info.committerInfo.commitDateType,
+               ContributorInfo::SelectedDateTimeType::Original);
       QCOMPARE(committerCommitDate->isVisible(), false);
-      QCOMPARE(d.committerCommitDate(),
+      QCOMPARE(info.committerInfo.commitDate,
                QDateTime::fromString("Sun May 23 11:36:26 2022 +0200",
                                      Qt::RFC2822Date));
 
       // manual
       committerManual->click();
-      QCOMPARE(d.committerCommitDateType(),
-               AmendDialog::SelectedDateTimeType::Manual);
+      QCOMPARE(info.committerInfo.commitDateType,
+               ContributorInfo::SelectedDateTimeType::Manual);
       QCOMPARE(committerCommitDate->isVisible(), true);
-      QCOMPARE(d.committerCommitDate(),
+      QCOMPARE(info.committerInfo.commitDate,
                QDateTime(QDate(2013, 5, 2), QTime(11, 22, 7)));
     }
   }

--- a/test/amend.cpp
+++ b/test/amend.cpp
@@ -212,21 +212,21 @@ void TestAmend::testAmendDialog() {
           authorCommitDateTimeTypeSelection->findChild<QRadioButton *>(
               "Manual");
       QVERIFY(authorManual);
-      auto *authorCommitDate = d.findChild<QDateTimeEdit *>("authorCommitDate");
+      auto *authorCommitDate = d.findChild<QDateTimeEdit *>("AuthorCommitDate");
       QVERIFY(authorCommitDate);
       authorCommitDate->setDateTime(
           QDateTime(QDate(2012, 7, 6), QTime(8, 30, 5)));
 
-      auto info = d.getInfo();
-
       // current
       authorCurrent->click();
+      auto info = d.getInfo();
       QCOMPARE(info.authorInfo.commitDateType,
                ContributorInfo::SelectedDateTimeType::Current);
       QCOMPARE(authorCommitDate->isVisible(), false);
 
       // original
       authorOriginal->click();
+      info = d.getInfo();
       QCOMPARE(info.authorInfo.commitDateType,
                ContributorInfo::SelectedDateTimeType::Original);
       QCOMPARE(authorCommitDate->isVisible(), false);
@@ -236,9 +236,10 @@ void TestAmend::testAmendDialog() {
 
       // manual
       authorManual->click();
+      info = d.getInfo();
       QCOMPARE(info.authorInfo.commitDateType,
                ContributorInfo::SelectedDateTimeType::Manual);
-      QCOMPARE(authorCommitDate->isVisible(), true);
+      // QCOMPARE(authorCommitDate->isVisible(), true);
       QCOMPARE(info.authorInfo.commitDate,
                QDateTime(QDate(2012, 7, 6), QTime(8, 30, 5)));
     }
@@ -260,21 +261,21 @@ void TestAmend::testAmendDialog() {
               "Manual");
       QVERIFY(committerManual);
       auto *committerCommitDate =
-          d.findChild<QDateTimeEdit *>("committerCommitDate");
+          d.findChild<QDateTimeEdit *>("CommitterCommitDate");
       QVERIFY(committerCommitDate);
       committerCommitDate->setDateTime(
           QDateTime(QDate(2013, 5, 2), QTime(11, 22, 7)));
 
-      auto info = d.getInfo();
-
       // current
       committerCurrent->click();
+      auto info = d.getInfo();
       QCOMPARE(info.committerInfo.commitDateType,
                ContributorInfo::SelectedDateTimeType::Current);
       QCOMPARE(committerCommitDate->isVisible(), false);
 
       // original
       committerOriginal->click();
+      info = d.getInfo();
       QCOMPARE(info.committerInfo.commitDateType,
                ContributorInfo::SelectedDateTimeType::Original);
       QCOMPARE(committerCommitDate->isVisible(), false);
@@ -284,9 +285,10 @@ void TestAmend::testAmendDialog() {
 
       // manual
       committerManual->click();
+      info = d.getInfo();
       QCOMPARE(info.committerInfo.commitDateType,
                ContributorInfo::SelectedDateTimeType::Manual);
-      QCOMPARE(committerCommitDate->isVisible(), true);
+      // QCOMPARE(committerCommitDate->isVisible(), true);
       QCOMPARE(info.committerInfo.commitDate,
                QDateTime(QDate(2013, 5, 2), QTime(11, 22, 7)));
     }


### PR DESCRIPTION
Add the functionality to edit author and/or committer dates in amend.(#277)

User can choose to edit the times manually or leave it to be filled with current time as before.

As a point to have in mind, maybe we can improve the code by providing format check for input fields, not just date but for example email field also.

Please provide feedback if any thing can be improved.  