### PR TITLE
DiffView: Load patches on demand

### DIFF
--- a/src/ui/DiffView/DiffView.cpp
+++ b/src/ui/DiffView/DiffView.cpp
@@ -104,7 +104,6 @@ void DiffView::setDiff(const git::Diff &diff) {
 
   // Clear state.
   mFiles.clear();
-  mStagedPatches.clear();
   mComments = Account::CommitComments();
 
   // Set data.
@@ -171,15 +170,7 @@ void DiffView::setDiff(const git::Diff &diff) {
                                 // is not distributed over the hole diff view
 
   // Generate a diff between the head tree and index.
-  if (diff.isStatusDiff()) {
-    if (git::Reference head = repo.head()) {
-      if (git::Commit commit = head.target()) {
-        mStagedDiff = repo.diffTreeToIndex(commit.tree());
-        for (int i = 0; i < mStagedDiff.count(); ++i)
-          mStagedPatches[mStagedDiff.name(i)] = i;
-      }
-    }
-  }
+  loadStagedPatches();
 
   if (canFetchMore())
     fetchMore();
@@ -238,6 +229,22 @@ void DiffView::setModel(DiffTreeModel *model) {
           &DiffView::diffTreeModelDataChanged);
 }
 
+void DiffView::loadStagedPatches() {
+  RepoView *view = RepoView::parentView(this);
+  git::Repository repo = view->repo();
+  mStagedPatches.clear();
+  // Generate a diff between the head tree and index.
+  if (mDiff.isStatusDiff()) {
+    if (git::Reference head = repo.head()) {
+      if (git::Commit commit = head.target()) {
+        mStagedDiff = repo.diffTreeToIndex(commit.tree());
+        for (int i = 0; i < mStagedDiff.count(); ++i)
+          mStagedPatches[mStagedDiff.name(i)] = i;
+      }
+    }
+  }
+}
+
 void DiffView::diffTreeModelDataChanged(const QModelIndex &topLeft,
                                         const QModelIndex &bottomRight,
                                         const QVector<int> &roles) {
@@ -257,20 +264,7 @@ void DiffView::diffTreeModelDataChanged(const QModelIndex &topLeft,
     if (file->modelIndex().internalPointer() == topLeft.internalPointer()) {
 
       // Respond to index changes only when file is visible in the diffview
-      RepoView *view = RepoView::parentView(this);
-      git::Repository repo = view->repo();
-
-      mStagedPatches.clear();
-      // Generate a diff between the head tree and index.
-      if (mDiff.isStatusDiff()) {
-        if (git::Reference head = repo.head()) {
-          if (git::Commit commit = head.target()) {
-            mStagedDiff = repo.diffTreeToIndex(commit.tree());
-            for (int i = 0; i < mStagedDiff.count(); ++i)
-              mStagedPatches[mStagedDiff.name(i)] = i;
-          }
-        }
-      }
+      loadStagedPatches();
 
       QString filename = file->name();
       git::Patch stagedPatch = mStagedDiff.patch(mStagedPatches[file->name()]);

--- a/src/ui/DiffView/DiffView.cpp
+++ b/src/ui/DiffView/DiffView.cpp
@@ -267,7 +267,10 @@ void DiffView::diffTreeModelDataChanged(const QModelIndex &topLeft,
       loadStagedPatches();
 
       QString filename = file->name();
-      git::Patch stagedPatch = mStagedDiff.patch(mStagedPatches[file->name()]);
+      git::Patch stagedPatch;
+      const int index = mStagedPatches.value(file->name(), -1);
+      if (index != -1)
+        stagedPatch = mStagedDiff.patch(index);
       file->updateHunks(stagedPatch);
       file->setStageState(stageState);
 

--- a/src/ui/DiffView/DiffView.h
+++ b/src/ui/DiffView/DiffView.h
@@ -124,7 +124,8 @@ private:
   void indexChanged(const QStringList &paths);
 
   git::Diff mDiff;
-  QMap<QString, git::Patch> mStagedPatches;
+  QMap<QString, int> mStagedPatches;
+  git::Diff mStagedDiff;
 
   QList<FileWidget *> mFiles;
   QList<QMetaObject::Connection> mConnections;

--- a/src/ui/DiffView/DiffView.h
+++ b/src/ui/DiffView/DiffView.h
@@ -122,6 +122,7 @@ private:
   void fetchMore();
   void fetchAll(int index = -1);
   void indexChanged(const QStringList &paths);
+  void loadStagedPatches();
 
   git::Diff mDiff;
   QMap<QString, int> mStagedPatches;


### PR DESCRIPTION
Do not load all patches when a new diff is set, it is enough to have the index and loading the patches on demand

Tested with a repo with 11k patches and we need 5-6s instead of 12-13s