### PR TITLE
show details of discard dialog by default

### DIFF
--- a/src/ui/FileContextMenu.cpp
+++ b/src/ui/FileContextMenu.cpp
@@ -203,6 +203,15 @@ FileContextMenu::FileContextMenu(RepoView *view, const QStringList &files,
       dialog->setInformativeText(tr("This action cannot be undone."));
       dialog->setDetailedText(modified.join('\n'));
 
+	// Expand the Show Details  
+    foreach (QAbstractButton *button, dialog->buttons()) {
+        if (dialog->buttonRole(button) == QMessageBox::ActionRole) {
+            button->click(); // click it to expand the text
+            break;
+        }
+    }
+
+
       QString text = tr("Discard Changes");
       QPushButton *discard = dialog->addButton(text, QMessageBox::AcceptRole);
       discard->setObjectName("DiscardButton");

--- a/src/ui/FileContextMenu.cpp
+++ b/src/ui/FileContextMenu.cpp
@@ -203,14 +203,13 @@ FileContextMenu::FileContextMenu(RepoView *view, const QStringList &files,
       dialog->setInformativeText(tr("This action cannot be undone."));
       dialog->setDetailedText(modified.join('\n'));
 
-	// Expand the Show Details  
-    foreach (QAbstractButton *button, dialog->buttons()) {
+      // Expand the Show Details
+      foreach (QAbstractButton *button, dialog->buttons()) {
         if (dialog->buttonRole(button) == QMessageBox::ActionRole) {
-            button->click(); // click it to expand the text
-            break;
+          button->click(); // click it to expand the text
+          break;
         }
-    }
-
+      }
 
       QString text = tr("Discard Changes");
       QPushButton *discard = dialog->addButton(text, QMessageBox::AcceptRole);


### PR DESCRIPTION
Then the user sees directly the discarded files/folders

source: https://stackoverflow.com/questions/36083551/qmessagebox-show-details

fixes #325 