### PR TITLE
Fix release tag creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -370,6 +370,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false
           title: Gittyup Release ${{ steps.version.outputs.VERSION }}
+          automatic_release_tag: ${{ github.ref_name }}
           files: |
             **/artifacts/Gittyup win64/Gittyup*.exe
             **/artifacts/Gittyup win32/Gittyup*.exe


### PR DESCRIPTION
This fixes the publishing step failing on releases because it expects semver-tags (`v#.#.#`)