### PR TITLE
FileContextMenu anymore available when IgnoreDialog is open

### DIFF
--- a/src/ui/FileContextMenu.cpp
+++ b/src/ui/FileContextMenu.cpp
@@ -431,10 +431,11 @@ void FileContextMenu::ignoreFile() {
   auto d = new IgnoreDialog(mFiles.join('\n'), parentWidget());
   d->setAttribute(Qt::WA_DeleteOnClose);
 
-  connect(d, &QDialog::accepted, [d, this]() {
+  auto *view = mView;
+  connect(d, &QDialog::accepted, [d, view]() {
     auto ignore = d->ignoreText();
     if (!ignore.isEmpty())
-      mView->ignore(ignore);
+      view->ignore(ignore);
   });
 
   d->open();


### PR DESCRIPTION
the FileContextMenu (this) is anymore available when the ignore dialog gets closed

fixes #348 