### PR TITLE
Fix doc path in Settings

### DIFF
--- a/src/conf/Settings.cpp
+++ b/src/conf/Settings.cpp
@@ -239,12 +239,7 @@ QDir Settings::appDir() {
   return dir;
 }
 
-QDir Settings::docDir() {
-  QDir dir = rootDir();
-  if (!dir.cd("doc"))
-    dir = confDir();
-  return dir;
-}
+QDir Settings::docDir() { return confDir(); }
 
 QDir Settings::confDir() {
   QDir dir = rootDir();


### PR DESCRIPTION
the doc files are copied into the "Resources" folder in the install path, so use for the docDir() directly the confDir()
As explained in #351 this does not have any impact on the application, because the "doc" / "docs" folder never exists in the install path.

fixes #351 