### PR TITLE
Use unchecked (unstaged) for conflicted and disabled

### DIFF
--- a/src/ui/DiffTreeModel.cpp
+++ b/src/ui/DiffTreeModel.cpp
@@ -179,7 +179,21 @@ QVariant DiffTreeModel::data(const QModelIndex &index, int role) const {
         return QVariant();
 
       git::Index index = mDiff.index();
-      return node->stageState(index, Node::ParentStageState::Any);
+      const auto state = node->stageState(index, Node::ParentStageState::Any);
+      switch (state) {
+        case git::Index::StagedState::PartiallyStaged:
+          return Qt::CheckState::PartiallyChecked;
+        case git::Index::StagedState::Staged:
+          return Qt::CheckState::Checked;
+        case git::Index::StagedState::Unstaged:
+          return Qt::CheckState::Unchecked;
+        case git::Index::StagedState::Conflicted:
+        // fall through
+        case git::Index::StagedState::Disabled: // dirty submodules
+          return Qt::CheckState::Unchecked;
+      }
+
+      return Qt::CheckState::Unchecked;
     }
 
     case KindRole: {

--- a/test/merge.cpp
+++ b/test/merge.cpp
@@ -182,11 +182,13 @@ void TestMerge::resolve() {
   auto doubleTree = view->findChild<DoubleTreeWidget *>();
   QVERIFY(doubleTree);
 
-  auto files = doubleTree->findChild<TreeView *>("Staged");
+  auto files = doubleTree->findChild<TreeView *>("Unstaged");
   QVERIFY(files);
 
   // Wait for refresh
   QAbstractItemModel *model = files->model();
+  qWait(1000); // Because before the merge, there is already an item in the
+               // unstaged model
   while (model->rowCount() < 1)
     qWait(300);
 
@@ -194,21 +196,25 @@ void TestMerge::resolve() {
                                   QItemSelectionModel::Select);
 
   QToolButton *theirs = diffView->findChild<QToolButton *>("ConflictTheirs");
+  QVERIFY(theirs);
   mouseClick(theirs, Qt::LeftButton, Qt::KeyboardModifiers(), QPoint(),
              inputDelay);
 
   QToolButton *undo =
       diffView->widget()->findChild<QToolButton *>("ConflictUndo");
+  QVERIFY(undo);
   mouseClick(undo, Qt::LeftButton, Qt::KeyboardModifiers(), QPoint(),
              inputDelay);
 
   QToolButton *ours =
       diffView->widget()->findChild<QToolButton *>("ConflictOurs");
+  QVERIFY(ours);
   mouseClick(ours, Qt::LeftButton, Qt::KeyboardModifiers(), QPoint(),
              inputDelay);
 
   QToolButton *save =
       diffView->widget()->findChild<QToolButton *>("ConflictSave");
+  QVERIFY(save);
   mouseClick(save, Qt::LeftButton, Qt::KeyboardModifiers(), QPoint(),
              inputDelay);
 


### PR DESCRIPTION
fix checkstate for conflicted and disabled stagestate. Use unchecked (unstaged) for conflicted and disabled

@exactly-one-kas what do you think about?
| Filetype | Old location | New location |
| ---- | ----- | -----|
| dirty submodules | Staged and Unstaged Tree | Unstaged Tree |
| conflicted files | Staged and Unstaged Tree | Unstaged Tree|
