### PR TITLE
Fix merge crash on wrong collapseCount, fixes #365

### DIFF
--- a/src/ui/TreeView.cpp
+++ b/src/ui/TreeView.cpp
@@ -245,7 +245,9 @@ void TreeView::itemExpanded(const QModelIndex &index) {
     return;
   qDebug() << "Expanded: Name: " << mName
            << ", Index data: " << index.data().toString();
-  setCollapseCount(mCollapseCount - 1 + countCollapsed(index, false));
+
+  mCollapseCount = mCollapseCount <= 0 ? mCollapseCount : mCollapseCount - 1;
+  setCollapseCount(mCollapseCount + countCollapsed(index, false));
 }
 
 void TreeView::itemCollapsed(const QModelIndex &index) {


### PR DESCRIPTION
I was not able to create a test repository for the problem so i fixed the problem with the repository and exactly the same merge operation i did when the problem arised.

It crashed on each conflicting file when the `use ours` button and afterwards the `save` is used (i did not test the `use theirs` button). 
After the crash i could resolve the conflict on which it crashed before and on the next conflicting file it would crash again.

I added a log inside the TreeView::itemExpanded function and as you can see the mCollapseCount can be 0 and then we subtract 1 from said count and call setCollapseCount with the result which is -1.
I think it is done in that way because it is assumed that itemExpaned is always used after itemCollapsed where 1 is added to the mCollapseCount.

![Screenshot from 2022-11-19 12-23-35](https://user-images.githubusercontent.com/105462605/202848428-9234ed3c-6831-423c-9c6a-3a50a60fc4bd.png)
