### PR TITLE
FileContextMenu: Show context menu when a commit is selected && show correct context menu entries when commit is selected

### DIFF
--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -314,7 +314,7 @@ static void addNodeToMenu(const git::Index &index, QStringList &files,
     auto stageState = index.isStaged(path);
 
     if ((staged && stageState != git::Index::Unstaged) ||
-        !staged && stageState != git::Index::Staged) {
+        (!staged && stageState != git::Index::Staged)) {
       files.append(path);
     }
   }

--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -300,12 +300,12 @@ QModelIndex DoubleTreeWidget::selectedIndex() const {
 }
 
 static void addNodeToMenu(const git::Index &index, QStringList &files,
-                          const Node *node, bool staged) {
+                          const Node *node, bool staged, bool statusDiff) {
   qDebug() << "DoubleTreeWidgetr addNodeToMenu()" << node->name();
 
   if (node->hasChildren()) {
     for (auto child : node->children()) {
-      addNodeToMenu(index, files, child, staged);
+      addNodeToMenu(index, files, child, staged, statusDiff);
     }
 
   } else {
@@ -314,7 +314,7 @@ static void addNodeToMenu(const git::Index &index, QStringList &files,
     auto stageState = index.isStaged(path);
 
     if ((staged && stageState != git::Index::Unstaged) ||
-        (!staged && stageState != git::Index::Staged)) {
+		(!staged && stageState != git::Index::Staged) || !statusDiff) {
       files.append(path);
     }
   }
@@ -324,10 +324,15 @@ void DoubleTreeWidget::showFileContextMenu(const QPoint &pos, RepoView *view,
                                            QTreeView *tree, bool staged) {
   QStringList files;
   QModelIndexList indexes = tree->selectionModel()->selectedIndexes();
+  const auto diff = view->diff();
+  if (!diff.isValid())
+    return;
+
+  const bool statusDiff = diff.isStatusDiff();
   foreach (const QModelIndex &index, indexes) {
     auto node = index.data(Qt::UserRole).value<Node *>();
 
-    addNodeToMenu(view->repo().index(), files, node, staged);
+    addNodeToMenu(view->repo().index(), files, node, staged, statusDiff);
   }
 
   if (files.isEmpty())

--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -314,7 +314,7 @@ static void addNodeToMenu(const git::Index &index, QStringList &files,
     auto stageState = index.isStaged(path);
 
     if ((staged && stageState != git::Index::Unstaged) ||
-		(!staged && stageState != git::Index::Staged) || !statusDiff) {
+        (!staged && stageState != git::Index::Staged) || !statusDiff) {
       files.append(path);
     }
   }

--- a/src/ui/FileContextMenu.h
+++ b/src/ui/FileContextMenu.h
@@ -12,6 +12,7 @@
 
 #include "git/Id.h"
 #include "git/Index.h"
+#include "git/Commit.h"
 #include <QMenu>
 
 class ExternalTool;
@@ -31,6 +32,10 @@ private:
   void addExternalToolsAction(const QList<ExternalTool *> &tools);
   bool exportFile(const RepoView *view, const QString &folder,
                   const QString &file);
+  void handleUncommittedChanges(const git::Index &index,
+                                const QStringList &files);
+  void handleCommits(const QList<git::Commit> &commits,
+                     const QStringList &files);
 
   RepoView *mView;
   QStringList mFiles;


### PR DESCRIPTION
…in the commitlist. To get a better overview, move the handles into dedicated functions

fixes #388  : first commit
fixes #387 : second commit

@exactly-one-kas do you see any reason not to return if diff is not valid?