### PR TITLE
Do not let files steal focus from commit list

### DIFF
--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -538,10 +538,8 @@ void DoubleTreeWidget::filesSelected(const QModelIndexList &indexes) {
     TreeView *treeview = static_cast<TreeView *>(obj);
     if (treeview == stagedFiles) {
       unstagedFiles->deselectAll();
-      stagedFiles->setFocus();
     } else if (treeview == unstagedFiles) {
       stagedFiles->deselectAll();
-      unstagedFiles->setFocus();
     }
   }
   loadEditorContent(indexes);


### PR DESCRIPTION
This addresses #382 

The issues seems to be solved by deleting `setFocus()` in `DoubleTreeWidget::filesSelected()`.
I don't see any reason to set the focus explicitly: The tree view should get focus when selecting a file -- this is done by clicking the view; hence, it automatically gets focus. But there is no reason the view gets focus accidentally when changing the file selection by selecting a commit from commit list; focus should stay in commit list.