### PR TITLE
do not crash if objects are invalid

### DIFF
--- a/src/git/Diff.cpp
+++ b/src/git/Diff.cpp
@@ -173,6 +173,9 @@ void Diff::findSimilar(bool untracked) {
   if (untracked)
     opts.flags = GIT_DIFF_FIND_FOR_UNTRACKED;
 
+  if (!isValid())
+    return;
+
   git_diff_find_similar(d->diff, &opts);
   d->resetMap();
 }

--- a/src/git/Index.cpp
+++ b/src/git/Index.cpp
@@ -363,7 +363,10 @@ Id Index::headId(const QString &path, uint32_t *mode) const {
     return Id();
 
   git_tree_entry *entry = nullptr;
-  if (git_tree_entry_bypath(&entry, commit.tree(), path.toUtf8()))
+  const auto tree = commit.tree();
+  if (!tree.isValid())
+    return Id(); // broken repository?
+  if (git_tree_entry_bypath(&entry, tree, path.toUtf8()))
     return Id();
 
   if (mode)


### PR DESCRIPTION
Currently I got a broken repository (not by Gittyup). But Gittyup crashes if the tree is invalid.

@exactly-one-kas maybe you have an idea if we can do a check at startup?

```
git status
Fehler: bad tree object HEAD

```