### PR TITLE
Remove german specific name entry in desktop entry

### DIFF
--- a/rsrc/linux/com.github.Murmele.Gittyup.desktop
+++ b/rsrc/linux/com.github.Murmele.Gittyup.desktop
@@ -9,4 +9,3 @@ Terminal=false
 Type=Application
 Categories=Development;
 X-Desktop-File-Install-Version=0.1
-Name[de_DE]=com.github.Murmele.Gittyup.desktop


### PR DESCRIPTION
I propose to remove the entry Name[de_DE]=com.github.Murmele.Gittyup.desktop. On linux systems with german language, instead of "Gittyup" the displayed application name is "com.github.Murmele.Gittyup.desktop".