### PR TITLE
Fetch hunk as needed new

### DIFF
--- a/src/ui/DiffView/DiffView.h
+++ b/src/ui/DiffView/DiffView.h
@@ -119,7 +119,7 @@ protected:
 
 private:
   bool canFetchMore();
-  void fetchMore();
+  void fetchMore(int fetchWidgets = 4);
   void fetchAll(int index = -1);
   void indexChanged(const QStringList &paths);
   void loadStagedPatches();

--- a/src/ui/DiffView/FileWidget.h
+++ b/src/ui/DiffView/FileWidget.h
@@ -108,6 +108,12 @@ public:
   HunkWidget *addHunk(const git::Diff &diff, const git::Patch &patch,
                       const git::Patch &staged, int index, bool lfs,
                       bool submodule);
+  bool canFetchMore() const;
+  int fetchMore(int count = 4);
+  void fetchAll(int index);
+
+  git::Patch patch() const { return mPatch; }
+
   void setStageState(git::Index::StagedState state);
   QModelIndex modelIndex();
 
@@ -140,6 +146,7 @@ private:
 
   git::Diff mDiff;
   git::Patch mPatch;
+  git::Patch mStaged;
   QModelIndex mModelIndex;
 
   _FileWidget::Header *mHeader{nullptr};

--- a/src/ui/DiffView/FileWidget.h
+++ b/src/ui/DiffView/FileWidget.h
@@ -112,8 +112,6 @@ public:
   int fetchMore(int count = 4);
   void fetchAll(int index);
 
-  git::Patch patch() const { return mPatch; }
-
   void setStageState(git::Index::StagedState state);
   QModelIndex modelIndex();
 


### PR DESCRIPTION
 Scenario: When opening a commit which has a file with a lot of changes (mostly because of generated files, *.po, .kicad_pcb files). It takes really long to load the diffview. Currently only fetching filewidgets on demand is implemented.

This MR implements fetching hunks when they are needed.

Limitation:
- only implemented for commits, but not for the status diff, because as already discussed in #59, with status diffs if not all hunks are loaded it leads to problems when staging single lines

Reason replacing #59 : It is a really old and outdated MR and it contains a lot more changes than just incrementally fetching new hunks. It includes also a partly working line staging approach. So this MR is simplifying the review, because it will be much smaller

replacing #59 