### PR TITLE
flatpak CI build fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,9 +38,18 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # image: bilelmoussaoui/flatpak-github-actions:kde-5.15-21.08
-      image: exactlyonekas/gittyup-flatpak-builder:latest
+      image: archlinux:latest
       options: --privileged
     steps:
+
+    - name: Update
+      run: |
+        pacman --noconfirm -Suy
+        pacman --noconfirm -S flatpak flatpak-builder xorg-server-xvfb
+        flatpak install --assumeyes org.kde.Sdk//5.15-21.08
+        flatpak install --assumeyes org.freedesktop.Sdk.Extension.golang//21.08
+        flatpak install --assumeyes org.kde.Platform//5.15-21.08
+
     - name: Show environment variables
       run: >
         echo IS_RELEASE: ${{ env.IS_RELEASE }}


### PR DESCRIPTION
```
Committing stage build-Gittyup to cache
Cleaning up
Renaming gittyup.appdata.xml to share/appdata/com.github.Murmele.Gittyup.appdata.xml
Renaming gittyup.desktop to com.github.Murmele.Gittyup.desktop
Renaming icon hicolor/16x16/apps/gittyup.png to hicolor/16x16/apps/com.github.Murmele.Gittyup.png
Renaming icon hicolor/256x256/apps/gittyup.png to hicolor/256x256/apps/com.github.Murmele.Gittyup.png
Renaming icon hicolor/512x512/apps/gittyup.png to hicolor/512x512/apps/com.github.Murmele.Gittyup.png
Renaming icon hicolor/32x32/apps/gittyup.png to hicolor/32x32/apps/com.github.Murmele.Gittyup.png
Renaming icon hicolor/64x64/apps/gittyup.png to hicolor/64x64/apps/com.github.Murmele.Gittyup.png
Renaming icon hicolor/scalable/apps/gittyup.svg to hicolor/scalable/apps/com.github.Murmele.Gittyup.svg
Renaming icon hicolor/128x128/apps/gittyup.png to hicolor/128x128/apps/com.github.Murmele.Gittyup.png
Rewriting contents of com.github.Murmele.Gittyup.desktop
Running appstream-compose
Processing application com.github.Murmele.Gittyup
Saving icon /app/share/app-info/icons/flatpak/64x64/com.github.Murmele.Gittyup.png
Saving icon /app/share/app-info/icons/flatpak/128x128/com.github.Murmele.Gittyup.png
Saving AppStream /app/share/app-info/xmls/com.github.Murmele.Gittyup.xml.gz
Done!
Committing stage cleanup to cache
Finishing app
Exporting share/applications/com.github.Murmele.Gittyup.desktop
Exporting share/icons/hicolor/16x16/apps/com.github.Murmele.Gittyup.png
Exporting share/icons/hicolor/256x256/apps/com.github.Murmele.Gittyup.png
Exporting share/icons/hicolor/512x512/apps/com.github.Murmele.Gittyup.png
Exporting share/icons/hicolor/32x32/apps/com.github.Murmele.Gittyup.png
Exporting share/icons/hicolor/64x64/apps/com.github.Murmele.Gittyup.png
Exporting share/icons/hicolor/scalable/apps/com.github.Murmele.Gittyup.svg
Exporting share/icons/hicolor/128x128/apps/com.github.Murmele.Gittyup.png
Exporting share/appdata/com.github.Murmele.Gittyup.appdata.xml
Please review the exported files and the metadata
Committing stage finish to cache
Exporting com.github.Murmele.Gittyup to repo
error: /__w/Gittyup/Gittyup/build/export/share/icons/hicolor/scalable/apps/com.github.Murmele.Gittyup.svg is not a valid icon: Format not recognized

Export failed: Child process exited with code 1
Error: Process completed with exit code 1.
```