### PR TITLE
Close the branch drop-down list after the user checks out a branch.

### DIFF
--- a/src/ui/ReferenceView.cpp
+++ b/src/ui/ReferenceView.cpp
@@ -184,7 +184,7 @@ ReferenceView::ReferenceView(const git::Repository &repo, Kinds kinds,
               git::Reference ref =
                   index.data(Qt::UserRole).value<git::Reference>();
               if (ref.isValid() && !ref.isHead())
-                RepoView::parentView(this)->checkout(ref);
+                checkout(ref);
             });
   }
 
@@ -263,6 +263,12 @@ QString ReferenceView::kindString(const git::Reference &ref) {
   return QString();
 }
 
+void ReferenceView::checkout(git::Reference &ref)
+{
+    RepoView::parentView(this)->checkout(ref);
+    emit checkedOut();
+}
+
 void ReferenceView::showEvent(QShowEvent *event) {
   resetTabIndex();
   setFocus();
@@ -277,8 +283,8 @@ void ReferenceView::contextMenuEvent(QContextMenuEvent *event) {
     return;
 
   QMenu menu;
-  QAction *checkout = menu.addAction(tr("Checkout"), [this, ref] {
-    RepoView::parentView(this)->checkout(ref);
+  QAction *checkout = menu.addAction(tr("Checkout"), [this, &ref] {
+    this->checkout(ref);
   });
 
   RepoView *view = RepoView::parentView(this);

--- a/src/ui/ReferenceView.cpp
+++ b/src/ui/ReferenceView.cpp
@@ -263,10 +263,9 @@ QString ReferenceView::kindString(const git::Reference &ref) {
   return QString();
 }
 
-void ReferenceView::checkout(git::Reference &ref)
-{
-    RepoView::parentView(this)->checkout(ref);
-    emit checkedOut();
+void ReferenceView::checkout(git::Reference &ref) {
+  RepoView::parentView(this)->checkout(ref);
+  emit checkedOut();
 }
 
 void ReferenceView::showEvent(QShowEvent *event) {
@@ -283,9 +282,8 @@ void ReferenceView::contextMenuEvent(QContextMenuEvent *event) {
     return;
 
   QMenu menu;
-  QAction *checkout = menu.addAction(tr("Checkout"), [this, &ref] {
-    this->checkout(ref);
-  });
+  QAction *checkout =
+      menu.addAction(tr("Checkout"), [this, &ref] { this->checkout(ref); });
 
   RepoView *view = RepoView::parentView(this);
   checkout->setEnabled(!ref.isHead() && !view->repo().isBare());

--- a/src/ui/ReferenceView.h
+++ b/src/ui/ReferenceView.h
@@ -55,7 +55,7 @@ public:
   void setCommit(const git::Commit &commit);
 
 signals:
-    void checkedOut();
+  void checkedOut();
 
 protected:
   void showEvent(QShowEvent *event) override;

--- a/src/ui/ReferenceView.h
+++ b/src/ui/ReferenceView.h
@@ -54,9 +54,14 @@ public:
 
   void setCommit(const git::Commit &commit);
 
+signals:
+    void checkedOut();
+
 protected:
   void showEvent(QShowEvent *event) override;
   void contextMenuEvent(QContextMenuEvent *event) override;
+
+  void checkout(git::Reference &ref);
 
 private:
   bool mPopup;

--- a/src/ui/ReferenceWidget.cpp
+++ b/src/ui/ReferenceWidget.cpp
@@ -132,6 +132,9 @@ ReferenceWidget::ReferenceWidget(const git::Repository &repo,
   mView = new ReferenceView(repo, kinds, false, this);
   mView->setSelectionModel(new SelectionModel(mView->model(), repo));
 
+  // Close the drop-down list of branches if it has just been checked out.
+  connect(mView, &ReferenceView::checkedOut, [button] { button->click(); });
+
   QVBoxLayout *layout = new QVBoxLayout(this);
   layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(0);


### PR DESCRIPTION
Avoid the inconvenience of having to close the drop-down list manually after checking out a branch.