### PR TITLE
bump cmake_minimum_required to 3.12 for add_compile_definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build
 .project
 .vscode/
 CMakeLists.txt.user
+cmake-build-debug/
+cmake-build-release/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 CMakeLists.txt.user
 cmake-build-debug/
 cmake-build-release/
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6.2)
+cmake_minimum_required(VERSION 3.12)
 project(Gittyup)
 
 # Set name and version.


### PR DESCRIPTION
bump cmake_minimum_required to 3.12 for add_compile_definitions, fix #529 