### PR TITLE
When refreshing all childs and parents must be updated as well

### DIFF
--- a/src/ui/DiffTreeModel.h
+++ b/src/ui/DiffTreeModel.h
@@ -153,6 +153,9 @@ signals:
                         bool init, bool checkout_force);
 
 private:
+  void handleDataChanged(const QModelIndex &index, int role);
+
+private:
   Node *node(const QModelIndex &index) const;
 
   QFileIconProvider mIconProvider;


### PR DESCRIPTION
Reason: When using StageAll and Unstage all previously only the element it self raises the dataChanged() signal and therefore all parents like folders get not updated, because they will not be updated, because the paths variable contains only files and not folders

fixes #244 