### PR TITLE
Replace stinb/libgit2 with upstream libgit2/libgit2 in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "dep/libgit2/libgit2"]
 	path = dep/libgit2/libgit2
-	url = https://github.com/stinb/libgit2.git
+	url = https://github.com/libgit2/libgit2.git
 [submodule "dep/libssh2/libssh2"]
 	path = dep/libssh2/libssh2
 	url = https://github.com/libssh2/libssh2.git


### PR DESCRIPTION
Hi,

It appears that, for some reason, Gittyup is using https://github.com/stinb/libgit2 as a git library, which, as of today, is all of **1790 commits behind** the upstream https://github.com/libgit2/libgit2. The substitution was in the original commit to this repo, 5 years ago, and although other submodules were subsequently updated (example: https://github.com/Murmele/Gittyup/commit/d156ef65a5c2ef0f0955aab2f9dc085bed8d014d), this one never was.

I took the time to test building and running Gittyup with this change, and didn't have any difficulty with any basic git functions, although I didn't do any very thorough digging to see if maybe some subtle things break (which, given the divergence between the two `libgit2`s, they might well do...)

Best,
Mark.