### PR TITLE
Adds "Hide Untracked Files" option to DoubleTreeWidget

### DIFF
--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -309,8 +309,11 @@ Diff Repository::status(const Index &index, Diff::Callbacks *callbacks,
 Diff Repository::diffTreeToIndex(const Tree &tree, const Index &index,
                                  bool ignoreWhitespace) const {
   git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
-  opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED | GIT_DIFF_RECURSE_UNTRACKED_DIRS |
-                GIT_DIFF_INCLUDE_TYPECHANGE;
+  opts.flags |= GIT_DIFF_INCLUDE_TYPECHANGE;
+
+  if (!appConfig().value<bool>("untracked.hide", false))
+    opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED | GIT_DIFF_RECURSE_UNTRACKED_DIRS;
+
   if (ignoreWhitespace)
     opts.flags |= GIT_DIFF_IGNORE_WHITESPACE;
 
@@ -323,8 +326,11 @@ Diff Repository::diffIndexToWorkdir(const Index &index,
                                     Diff::Callbacks *callbacks,
                                     bool ignoreWhitespace) const {
   git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
-  opts.flags |= (GIT_DIFF_INCLUDE_UNTRACKED | GIT_DIFF_RECURSE_UNTRACKED_DIRS |
-                 GIT_DIFF_DISABLE_MMAP | GIT_DIFF_INCLUDE_TYPECHANGE);
+  opts.flags |= (GIT_DIFF_DISABLE_MMAP | GIT_DIFF_INCLUDE_TYPECHANGE);
+
+  if (!appConfig().value<bool>("untracked.hide", false))
+    opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED | GIT_DIFF_RECURSE_UNTRACKED_DIRS;
+
   if (ignoreWhitespace)
     opts.flags |= GIT_DIFF_IGNORE_WHITESPACE;
 

--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -20,6 +20,7 @@
 #include "conf/Settings.h"
 #include "DiffView/DiffView.h"
 #include "git/Index.h"
+#include "git/Config.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -102,8 +103,16 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
                                    checked);
     RepoView::parentView(this)->refresh();
   });
+  QAction *hideUntrackedFiles = new QAction(tr("Hide Untracked Files"));
+  hideUntrackedFiles->setCheckable(true);
+  hideUntrackedFiles->setChecked(RepoView::parentView(parent)->repo().appConfig().value<bool>("untracked.hide", false));
+  connect(hideUntrackedFiles, &QAction::triggered, this, [this](bool checked) {
+    RepoView::parentView(this)->repo().appConfig().setValue("untracked.hide", checked);
+    RepoView::parentView(this)->refresh();
+  });
   contextMenu->addAction(singleTree);
   contextMenu->addAction(listView);
+  contextMenu->addAction(hideUntrackedFiles);
   QHBoxLayout *buttonLayout = new QHBoxLayout();
   buttonLayout->addStretch();
   buttonLayout->addWidget(segmentedButton);

--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -105,9 +105,12 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
   });
   QAction *hideUntrackedFiles = new QAction(tr("Hide Untracked Files"));
   hideUntrackedFiles->setCheckable(true);
-  hideUntrackedFiles->setChecked(RepoView::parentView(parent)->repo().appConfig().value<bool>("untracked.hide", false));
+  hideUntrackedFiles->setChecked(
+      RepoView::parentView(parent)->repo().appConfig().value<bool>(
+          "untracked.hide", false));
   connect(hideUntrackedFiles, &QAction::triggered, this, [this](bool checked) {
-    RepoView::parentView(this)->repo().appConfig().setValue("untracked.hide", checked);
+    RepoView::parentView(this)->repo().appConfig().setValue("untracked.hide",
+                                                            checked);
     RepoView::parentView(this)->refresh();
   });
   contextMenu->addAction(singleTree);

--- a/test/Setting.cpp
+++ b/test/Setting.cpp
@@ -23,9 +23,7 @@ private:
 
   template <class T, typename TId> QStringList settingsKeys() {
     QStringList settingsKeys;
-    foreach (const TId id, ids<TId>()) {
-      settingsKeys.append(T::key(id));
-    }
+    foreach (const TId id, ids<TId>()) { settingsKeys.append(T::key(id)); }
     return settingsKeys;
   }
 

--- a/test/Setting.cpp
+++ b/test/Setting.cpp
@@ -23,7 +23,9 @@ private:
 
   template <class T, typename TId> QStringList settingsKeys() {
     QStringList settingsKeys;
-    foreach (const TId id, ids<TId>()) { settingsKeys.append(T::key(id)); }
+    foreach (const TId id, ids<TId>()) {
+      settingsKeys.append(T::key(id));
+    }
     return settingsKeys;
   }
 


### PR DESCRIPTION
Adds option to hide untracked files to context menu, which causes the diff to be created with ignored untracked files.

Based on old PR for Gitahead: https://github.com/gitahead/gitahead/pull/232

![Animation](https://user-images.githubusercontent.com/31071712/250393046-558d4ec0-a66a-4ef9-9230-fa3cf75bdaf1.gif)