### PR TITLE
Referring repos with their git-dir instead of their work-tree.

### DIFF
--- a/src/conf/RecentRepositories.cpp
+++ b/src/conf/RecentRepositories.cpp
@@ -57,7 +57,7 @@ void RecentRepositories::add(QString gitpath) {
   RecentRepository *repo = new RecentRepository(gitpath, this);
   auto it = std::remove_if(mRepos.begin(), end, [repo](RecentRepository *rhs) {
 #ifdef Q_OS_WIN
-    return repo-gitpath().compare(rhs->gitpath(), Qt::CaseInsensitive) == 0;
+    return repo - gitpath().compare(rhs->gitpath(), Qt::CaseInsensitive) == 0;
 #else
     return (repo->gitpath() == rhs->gitpath());
 #endif

--- a/src/conf/RecentRepositories.cpp
+++ b/src/conf/RecentRepositories.cpp
@@ -129,6 +129,13 @@ void RecentRepositories::load() {
   qDeleteAll(mRepos);
   mRepos.clear();
 
+  /* If two paths have the same name, increase the path segment so that they get
+   * unique For example: path1/anotherpath/repositoryname
+   * path2/anotherpath/repositoryname
+   *
+   * In this case the complete paths are shown and not only 'repositoryname',
+   * otherwise they are not distinguishable in the recent repository list:
+   */
   foreach (const QString &path, paths) {
     RecentRepository *repo = new RecentRepository(path, this);
     auto functor = [repo](RecentRepository *rhs) {

--- a/src/conf/RecentRepositories.cpp
+++ b/src/conf/RecentRepositories.cpp
@@ -57,7 +57,7 @@ void RecentRepositories::add(QString gitpath) {
   RecentRepository *repo = new RecentRepository(gitpath, this);
   auto it = std::remove_if(mRepos.begin(), end, [repo](RecentRepository *rhs) {
 #ifdef Q_OS_WIN
-    return repo - gitpath().compare(rhs->gitpath(), Qt::CaseInsensitive) == 0;
+    return repo->gitpath().compare(rhs->gitpath(), Qt::CaseInsensitive) == 0;
 #else
     return (repo->gitpath() == rhs->gitpath());
 #endif

--- a/src/conf/RecentRepositories.cpp
+++ b/src/conf/RecentRepositories.cpp
@@ -51,7 +51,8 @@ void RecentRepositories::remove(int index) {
 }
 
 /*!
- * gitpath: path to the git repository, does not neccesarly need to be the workdir
+ * gitpath: path to the git repository, does not neccesarly need to be the
+ * workdir
  */
 void RecentRepositories::add(QString gitpath) {
   emit repositoryAboutToBeAdded();

--- a/src/conf/RecentRepositories.cpp
+++ b/src/conf/RecentRepositories.cpp
@@ -50,6 +50,9 @@ void RecentRepositories::remove(int index) {
   emit repositoryRemoved();
 }
 
+/*!
+ * gitpath: path to the git repository, does not neccesarly need to be the workdir
+ */
 void RecentRepositories::add(QString gitpath) {
   emit repositoryAboutToBeAdded();
 

--- a/src/conf/RecentRepositories.cpp
+++ b/src/conf/RecentRepositories.cpp
@@ -50,16 +50,16 @@ void RecentRepositories::remove(int index) {
   emit repositoryRemoved();
 }
 
-void RecentRepositories::add(QString path) {
+void RecentRepositories::add(QString gitpath) {
   emit repositoryAboutToBeAdded();
 
   auto end = mRepos.end();
-  RecentRepository *repo = new RecentRepository(path, this);
+  RecentRepository *repo = new RecentRepository(gitpath, this);
   auto it = std::remove_if(mRepos.begin(), end, [repo](RecentRepository *rhs) {
 #ifdef Q_OS_WIN
-    return repo->path().compare(rhs->path(), Qt::CaseInsensitive) == 0;
+    return repo-gitpath().compare(rhs->gitpath(), Qt::CaseInsensitive) == 0;
 #else
-    return (repo->path() == rhs->path());
+    return (repo->gitpath() == rhs->gitpath());
 #endif
   });
 
@@ -82,7 +82,7 @@ RecentRepositories *RecentRepositories::instance() {
 void RecentRepositories::store() {
   QStringList paths;
   foreach (RecentRepository *repo, mRepos)
-    paths.append(repo->path());
+    paths.append(repo->gitpath());
 
   QSettings().setValue(kRecentKey, paths);
 

--- a/src/conf/RecentRepository.cpp
+++ b/src/conf/RecentRepository.cpp
@@ -15,12 +15,7 @@ RecentRepository::RecentRepository(const QString &gitpath, QObject *parent)
 QString RecentRepository::gitpath() const { return mGitPath; }
 
 QString RecentRepository::name() const {
-  QString name;
-  if (mGitPath.endsWith("/.git"))
-    name = mGitPath.section('/', -mSections - 1, -2);
-  else
-    name = mGitPath.section('/', -mSections, -1);
-  return name;
+  return mGitPath.section('/', -mSections, -1);
 }
 
 void RecentRepository::increment() { ++mSections; }

--- a/src/conf/RecentRepository.cpp
+++ b/src/conf/RecentRepository.cpp
@@ -16,7 +16,7 @@ QString RecentRepository::gitpath() const { return mPath; }
 
 QString RecentRepository::name() const {
   if (mPath.endsWith("/.git"))
-    return mPath.section('/', -mSections-1, -2);
+    return mPath.section('/', -mSections - 1, -2);
   else
     return mPath.section('/', -mSections, -1);
 }

--- a/src/conf/RecentRepository.cpp
+++ b/src/conf/RecentRepository.cpp
@@ -10,15 +10,17 @@
 #include "RecentRepository.h"
 
 RecentRepository::RecentRepository(const QString &gitpath, QObject *parent)
-    : QObject(parent), mPath(gitpath) {}
+    : QObject(parent), mGitPath(gitpath) {}
 
-QString RecentRepository::gitpath() const { return mPath; }
+QString RecentRepository::gitpath() const { return mGitPath; }
 
 QString RecentRepository::name() const {
-  if (mPath.endsWith("/.git"))
-    return mPath.section('/', -mSections - 1, -2);
+  QString name;
+  if (mGitPath.endsWith("/.git"))
+    name = mGitPath.section('/', -mSections - 1, -2);
   else
-    return mPath.section('/', -mSections, -1);
+    name = mGitPath.section('/', -mSections, -1);
+  return name;
 }
 
 void RecentRepository::increment() { ++mSections; }

--- a/src/conf/RecentRepository.cpp
+++ b/src/conf/RecentRepository.cpp
@@ -9,13 +9,16 @@
 
 #include "RecentRepository.h"
 
-RecentRepository::RecentRepository(const QString &path, QObject *parent)
-    : QObject(parent), mPath(path) {}
+RecentRepository::RecentRepository(const QString &gitpath, QObject *parent)
+    : QObject(parent), mPath(gitpath) {}
 
-QString RecentRepository::path() const { return mPath; }
+QString RecentRepository::gitpath() const { return mPath; }
 
 QString RecentRepository::name() const {
-  return mPath.section('/', -mSections);
+  if (mPath.endsWith("/.git"))
+    return mPath.section('/', -mSections-1, -2);
+  else
+    return mPath.section('/', -mSections, -1);
 }
 
 void RecentRepository::increment() { ++mSections; }

--- a/src/conf/RecentRepository.h
+++ b/src/conf/RecentRepository.h
@@ -24,7 +24,7 @@ public:
 private:
   void increment();
 
-  QString mPath;
+  QString mGitPath;
   int mSections = 1;
 
   friend class RecentRepositories;

--- a/src/conf/RecentRepository.h
+++ b/src/conf/RecentRepository.h
@@ -16,9 +16,9 @@ class RecentRepository : public QObject {
   Q_OBJECT
 
 public:
-  RecentRepository(const QString &path, QObject *parent = nullptr);
+  RecentRepository(const QString &gitpath, QObject *parent = nullptr);
 
-  QString path() const;
+  QString gitpath() const;
   QString name() const;
 
 private:

--- a/src/dialogs/StartDialog.cpp
+++ b/src/dialogs/StartDialog.cpp
@@ -117,10 +117,10 @@ public:
     RecentRepository *repo = repos->repository(index.row());
     switch (role) {
       case Qt::DisplayRole:
-        return mShowFullPath ? repo->path() : repo->name();
+        return mShowFullPath ? repo->gitpath() : repo->name();
 
       case Qt::UserRole:
-        return repo->path();
+        return repo->gitpath();
     }
 
     return QVariant();

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -152,7 +152,14 @@ Repository::Repository(git_repository *repo) : d(registerRepository(repo)) {}
 
 Repository::operator git_repository *() const { return d->repo; }
 
-QDir Repository::dir() const { return QDir(git_repository_path(d->repo)); }
+QDir Repository::dir(bool includeGitFolder) const {
+  QDir dir(git_repository_path(d->repo));
+  if (!includeGitFolder) {
+    assert(dir.dirName() == ".git");
+    assert(dir.cdUp());
+  }
+  return dir;
+}
 
 QDir Repository::workdir() const {
   return isBare() ? dir() : QDir(git_repository_workdir(d->repo));

--- a/src/git/Repository.h
+++ b/src/git/Repository.h
@@ -71,7 +71,7 @@ public:
 
   RepositoryNotifier *notifier() const { return d->notifier; }
 
-  QDir dir() const;
+  QDir dir(bool includeGitFolder = true) const;
   QDir workdir() const;
   QDir appDir() const;
 

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -52,7 +52,10 @@ class TabName {
 public:
   TabName(const QString &path) : mPath(path) {}
 
-  QString name() const { return mPath.endsWith("/.git") ?  mPath.section('/', -mSections-1,-2)  : mPath.section('/', -mSections); }
+  QString name() const {
+    return mPath.endsWith("/.git") ? mPath.section('/', -mSections - 1, -2)
+                                   : mPath.section('/', -mSections);
+  }
 
   void increment() { ++mSections; }
   int sections() const { return mSections; }
@@ -257,7 +260,8 @@ RepoView *MainWindow::addTab(const git::Repository &repo) {
 
   emit tabs->tabAboutToBeInserted();
 
-  // NB : this seems to be useless, because overwritten by MainWindow::updateTabNames
+  // NB : this seems to be useless, because overwritten by
+  // MainWindow::updateTabNames
   QString tabTitle = dir.dirName();
   if (tabTitle == ".git")
     tabTitle = dir.path().section("/", -2, -2);

--- a/src/ui/MenuBar.cpp
+++ b/src/ui/MenuBar.cpp
@@ -308,7 +308,7 @@ MenuBar::MenuBar(QWidget *parent) : QMenuBar(parent) {
       RecentRepository *repo = repos->repository(i);
       QAction *action = openRecent->addAction(repo->name());
       connect(action, &QAction::triggered,
-              [repo] { MainWindow::open(repo->path()); });
+              [repo] { MainWindow::open(repo->gitpath()); });
     }
   });
 

--- a/src/ui/SideBar.cpp
+++ b/src/ui/SideBar.cpp
@@ -352,7 +352,7 @@ public:
                 return mTabs->tabText(row);
 
               RepoView *view = static_cast<RepoView *>(mTabs->widget(row));
-              return view->repo().dir().path();
+              return view->repo().dir(false).path();
             }
 
             return tr("none");
@@ -446,7 +446,7 @@ public:
               return QVariant();
             QWidget *widget = mTabs->widget(row);
             RepoView *view = static_cast<RepoView *>(widget);
-            return view->repo().dir().path();
+            return view->repo().dir(false).path();
           }
 
           case Recent:
@@ -493,7 +493,7 @@ public:
           case Repo:
             if (mTabs->count()) {
               RepoView *view = static_cast<RepoView *>(mTabs->widget(row));
-              return view->repo().dir().path();
+              return view->repo().dir(false).path();
             }
 
             return "";

--- a/src/ui/SideBar.cpp
+++ b/src/ui/SideBar.cpp
@@ -352,7 +352,7 @@ public:
                 return mTabs->tabText(row);
 
               RepoView *view = static_cast<RepoView *>(mTabs->widget(row));
-              return view->repo().workdir().path();
+              return view->repo().dir().path();
             }
 
             return tr("none");
@@ -361,7 +361,7 @@ public:
             RecentRepositories *recent = RecentRepositories::instance();
             if (recent->count()) {
               RecentRepository *repo = repos->repository(row);
-              return mShowFullPath ? repo->path() : repo->name();
+              return mShowFullPath ? repo->gitpath() : repo->name();
             }
 
             return tr("none");
@@ -446,13 +446,13 @@ public:
               return QVariant();
             QWidget *widget = mTabs->widget(row);
             RepoView *view = static_cast<RepoView *>(widget);
-            return view->repo().workdir().path();
+            return view->repo().dir().path();
           }
 
           case Recent:
             if (!repos->count())
               return QVariant();
-            return repos->repository(row)->path();
+            return repos->repository(row)->gitpath();
 
           default:
             return QVariant();
@@ -493,7 +493,7 @@ public:
           case Repo:
             if (mTabs->count()) {
               RepoView *view = static_cast<RepoView *>(mTabs->widget(row));
-              return view->repo().workdir().path();
+              return view->repo().dir().path();
             }
 
             return "";
@@ -502,7 +502,7 @@ public:
             RecentRepositories *recent = RecentRepositories::instance();
             if (recent->count()) {
               RecentRepository *repo = repos->repository(row);
-              return repo->path();
+              return repo->gitpath();
             }
 
             return "";


### PR DESCRIPTION
Also sets up display routines to avoid displaying a repo as ".git" : we display the penultimate component of the path when the last one is ".git". This assumes nobody creates a repo in ``/.git``.

This closes #612.

This needs review, especially wrt opening "remote" repos, which I did not test.

One will need to purge one's repo history on upgrading to this version.