### PR TITLE
chore: fix compiler warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v13.0.1
+  hooks:
+  - id: clang-format
+    args: [ -i ]
+

--- a/README.md
+++ b/README.md
@@ -194,6 +194,15 @@ branch. Create pull requests against the `master` branch. Follow the
 [seven guidelines](https://chris.beams.io/posts/git-commit/) to writing a
 great commit message.
 
+Prior to committing a change, please use `cl-format.sh` to ensure your code
+adheres to the formatting conventions for this project. You can also use the
+`setup-env.sh` script to install a pre-commit hook which will automatically
+run `clang-format` against all modified files.
+
+Prior to pushing a change, please ensure you run the unit tests to avoid any
+regressions. These are found in `<build-dir>/test` and can be run using
+`ctest`.
+
 License
 -------
 

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "`dirname "$0"`"
+
+PRE_COMMIT=${SCRIPT_DIR}/.venv/bin/pre-commit
+
+pre_commit() {
+	# Set up pre-commit hook
+	if [ ! -f "${PRE_COMMIT}" ]; then
+		pushd ${SCRIPT_DIR}
+		python3 -m venv .venv
+		.venv/bin/pip install pre-commit
+		popd
+	fi
+	${PRE_COMMIT} install
+}
+
+remove_pre_commt() {
+	if [ -f "${PRE_COMMIT}" ]; then
+		${PRE_COMMIT} uninstall
+	fi
+}
+
+if [ $# -eq 0 ]; then
+	set -- --help
+fi
+
+for arg in "$@"; do
+	case $arg in
+	pre_commit | pre-commit | install_pre_commit |  install-pre-commit)
+		pre_commit
+	;;
+	remove_pre_commit | remove-pre-commit | uninstall_pre_commit |  uninstall-pre-commit)
+		remove_pre_commit
+	;;
+	*)
+		echo "USAGE $0 [commands]"
+		echo "  Commands:"
+		echo "    install-pre-commit - installs pre-commit hooks"
+		echo "    uninstall-pre-commit - removes pre-commit hooks"
+	;;
+	esac
+done

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,13 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 add_compile_options(-Werror=switch)
+# Uncomment to compile with more warnings
+#add_compile_options(-Wall)
+# Uncomment to compile with even more warnings
+#add_compile_options(-Wextra)
+# TODO: currently there are too many unused parameters which overwhelms the
+#       warning output with `-Wall`. So let's leave fixing these for later.
+add_compile_options(-Wno-unused-parameter)
 
 add_subdirectory(util)
 add_subdirectory(cli)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,10 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 add_compile_options(-Werror=switch)
-# Uncomment to compile with more warnings
-#add_compile_options(-Wall)
-# Uncomment to compile with even more warnings
-#add_compile_options(-Wextra)
-# TODO: currently there are too many unused parameters which overwhelms the
-#       warning output with `-Wall`. So let's leave fixing these for later.
+# Uncomment to compile with more warnings add_compile_options(-Wall) Uncomment
+# to compile with even more warnings add_compile_options(-Wextra) TODO:
+# currently there are too many unused parameters which overwhelms the warning
+# output with `-Wall`. So let's leave fixing these for later.
 add_compile_options(-Wno-unused-parameter)
 
 add_subdirectory(util)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
+add_compile_options(-Werror=switch-enum)
+
 add_subdirectory(util)
 add_subdirectory(cli)
 add_subdirectory(conf)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-add_compile_options(-Werror=switch-enum)
+add_compile_options(-Werror=switch)
 
 add_subdirectory(util)
 add_subdirectory(cli)

--- a/src/app/CustomTheme.cpp
+++ b/src/app/CustomTheme.cpp
@@ -436,7 +436,8 @@ QColor CustomTheme::commitEditor(CommitEditor color) {
     case CommitEditor::LengthWarning:
       return commitEditor.value("lengthwarning").value<QColor>();
     default:
-      throw std::runtime_error("Not Implemented or invalid enum " + std::to_string(static_cast<int>(color)));
+      throw std::runtime_error("Not Implemented or invalid enum " +
+                               std::to_string(static_cast<int>(color)));
   }
 }
 
@@ -467,7 +468,8 @@ QColor CustomTheme::diff(Diff color) {
     case Diff::Error:
       return diff.value("error").value<QColor>();
     default:
-      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
+      throw std::runtime_error("Not Implemented or invalid enum" +
+                               std::to_string(static_cast<int>(color)));
   }
 }
 
@@ -480,7 +482,8 @@ QColor CustomTheme::heatMap(HeatMap color) {
     case HeatMap::Cold:
       return QColor(heatmap.value("cold").toString());
     default:
-      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
+      throw std::runtime_error("Not Implemented or invalid enum" +
+                               std::to_string(static_cast<int>(color)));
   }
 }
 
@@ -497,7 +500,8 @@ QColor CustomTheme::remoteComment(Comment color) {
     case Comment::Timestamp:
       return QColor(comment.value("timestamp").toString());
     default:
-      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
+      throw std::runtime_error("Not Implemented or invalid enum" +
+                               std::to_string(static_cast<int>(color)));
   }
 }
 

--- a/src/app/CustomTheme.cpp
+++ b/src/app/CustomTheme.cpp
@@ -73,7 +73,55 @@ public:
         CustomTheme::drawCloseButton(option, painter);
         break;
 
-      default:
+      case PE_Frame:                           // fall through
+      case PE_FrameDefaultButton:              // fall through
+      case PE_FrameDockWidget:                 // fall through
+      case PE_FrameFocusRect:                  // fall through
+      case PE_FrameGroupBox:                   // fall through
+      case PE_FrameLineEdit:                   // fall through
+      case PE_FrameMenu:                       // fall through
+      case PE_FrameStatusBarItem:              // fall through
+      case PE_FrameTabWidget:                  // fall through
+      case PE_FrameWindow:                     // fall through
+      case PE_FrameButtonBevel:                // fall through
+      case PE_FrameButtonTool:                 // fall through
+      case PE_FrameTabBarBase:                 // fall through
+      case PE_PanelButtonCommand:              // fall through
+      case PE_PanelButtonBevel:                // fall through
+      case PE_PanelButtonTool:                 // fall through
+      case PE_PanelMenuBar:                    // fall through
+      case PE_PanelToolBar:                    // fall through
+      case PE_PanelLineEdit:                   // fall through
+      case PE_IndicatorArrowDown:              // fall through
+      case PE_IndicatorArrowLeft:              // fall through
+      case PE_IndicatorArrowRight:             // fall through
+      case PE_IndicatorArrowUp:                // fall through
+      case PE_IndicatorBranch:                 // fall through
+      case PE_IndicatorButtonDropDown:         // fall through
+      case PE_IndicatorItemViewItemCheck:      // fall through
+      case PE_IndicatorDockWidgetResizeHandle: // fall through
+      case PE_IndicatorHeaderArrow:            // fall through
+      case PE_IndicatorMenuCheckMark:          // fall through
+      case PE_IndicatorProgressChunk:          // fall through
+      case PE_IndicatorRadioButton:            // fall through
+      case PE_IndicatorSpinDown:               // fall through
+      case PE_IndicatorSpinMinus:              // fall through
+      case PE_IndicatorSpinPlus:               // fall through
+      case PE_IndicatorSpinUp:                 // fall through
+      case PE_IndicatorToolBarHandle:          // fall through
+      case PE_IndicatorToolBarSeparator:       // fall through
+      case PE_PanelTipLabel:                   // fall through
+      case PE_IndicatorTabTear:                // fall through
+      case PE_PanelScrollAreaCorner:           // fall through
+      case PE_Widget:                          // fall through
+      case PE_IndicatorColumnViewArrow:        // fall through
+      case PE_IndicatorItemViewItemDrop:       // fall through
+      case PE_PanelItemViewItem:               // fall through
+      case PE_PanelItemViewRow:                // fall through
+      case PE_PanelStatusBar:                  // fall through
+      case PE_PanelMenu:                       // fall through
+      case PE_IndicatorTabTearRight:           // fall through
+      case PE_CustomBase:                      // fall through
         baseStyle()->drawPrimitive(elem, option, painter, widget);
         break;
     }
@@ -435,10 +483,9 @@ QColor CustomTheme::commitEditor(CommitEditor color) {
       return commitEditor.value("spellignore").value<QColor>();
     case CommitEditor::LengthWarning:
       return commitEditor.value("lengthwarning").value<QColor>();
-    default:
-      throw std::runtime_error("Not Implemented or invalid enum " +
-                               std::to_string(static_cast<int>(color)));
   }
+  throw std::runtime_error("Not Implemented or invalid enum " +
+                           std::to_string(static_cast<int>(color)));
 }
 
 QColor CustomTheme::diff(Diff color) {
@@ -467,10 +514,9 @@ QColor CustomTheme::diff(Diff color) {
       return diff.value("warning").value<QColor>();
     case Diff::Error:
       return diff.value("error").value<QColor>();
-    default:
-      throw std::runtime_error("Not Implemented or invalid enum" +
-                               std::to_string(static_cast<int>(color)));
   }
+  throw std::runtime_error("Not Implemented or invalid enum" +
+                           std::to_string(static_cast<int>(color)));
 }
 
 QColor CustomTheme::heatMap(HeatMap color) {

--- a/src/app/CustomTheme.cpp
+++ b/src/app/CustomTheme.cpp
@@ -481,7 +481,7 @@ QColor CustomTheme::heatMap(HeatMap color) {
       return QColor(heatmap.value("cold").toString());
   }
   throw std::runtime_error("unreachable; value=" +
-                            std::to_string(static_cast<int>(color)));
+                           std::to_string(static_cast<int>(color)));
 }
 
 QColor CustomTheme::remoteComment(Comment color) {
@@ -498,7 +498,7 @@ QColor CustomTheme::remoteComment(Comment color) {
       return QColor(comment.value("timestamp").toString());
   }
   throw std::runtime_error("unreachable; value=" +
-                            std::to_string(static_cast<int>(color)));
+                           std::to_string(static_cast<int>(color)));
 }
 
 QColor CustomTheme::star() {

--- a/src/app/CustomTheme.cpp
+++ b/src/app/CustomTheme.cpp
@@ -435,6 +435,8 @@ QColor CustomTheme::commitEditor(CommitEditor color) {
       return commitEditor.value("spellignore").value<QColor>();
     case CommitEditor::LengthWarning:
       return commitEditor.value("lengthwarning").value<QColor>();
+    default:
+      throw std::runtime_error("Not Implemented or invalid enum " + std::to_string(static_cast<int>(color)));
   }
 }
 
@@ -464,6 +466,8 @@ QColor CustomTheme::diff(Diff color) {
       return diff.value("warning").value<QColor>();
     case Diff::Error:
       return diff.value("error").value<QColor>();
+    default:
+      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
   }
 }
 
@@ -475,6 +479,8 @@ QColor CustomTheme::heatMap(HeatMap color) {
       return QColor(heatmap.value("hot").toString());
     case HeatMap::Cold:
       return QColor(heatmap.value("cold").toString());
+    default:
+      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
   }
 }
 
@@ -490,6 +496,8 @@ QColor CustomTheme::remoteComment(Comment color) {
       return QColor(comment.value("author").toString());
     case Comment::Timestamp:
       return QColor(comment.value("timestamp").toString());
+    default:
+      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
   }
 }
 

--- a/src/app/CustomTheme.cpp
+++ b/src/app/CustomTheme.cpp
@@ -73,55 +73,7 @@ public:
         CustomTheme::drawCloseButton(option, painter);
         break;
 
-      case PE_Frame:                           // fall through
-      case PE_FrameDefaultButton:              // fall through
-      case PE_FrameDockWidget:                 // fall through
-      case PE_FrameFocusRect:                  // fall through
-      case PE_FrameGroupBox:                   // fall through
-      case PE_FrameLineEdit:                   // fall through
-      case PE_FrameMenu:                       // fall through
-      case PE_FrameStatusBarItem:              // fall through
-      case PE_FrameTabWidget:                  // fall through
-      case PE_FrameWindow:                     // fall through
-      case PE_FrameButtonBevel:                // fall through
-      case PE_FrameButtonTool:                 // fall through
-      case PE_FrameTabBarBase:                 // fall through
-      case PE_PanelButtonCommand:              // fall through
-      case PE_PanelButtonBevel:                // fall through
-      case PE_PanelButtonTool:                 // fall through
-      case PE_PanelMenuBar:                    // fall through
-      case PE_PanelToolBar:                    // fall through
-      case PE_PanelLineEdit:                   // fall through
-      case PE_IndicatorArrowDown:              // fall through
-      case PE_IndicatorArrowLeft:              // fall through
-      case PE_IndicatorArrowRight:             // fall through
-      case PE_IndicatorArrowUp:                // fall through
-      case PE_IndicatorBranch:                 // fall through
-      case PE_IndicatorButtonDropDown:         // fall through
-      case PE_IndicatorItemViewItemCheck:      // fall through
-      case PE_IndicatorDockWidgetResizeHandle: // fall through
-      case PE_IndicatorHeaderArrow:            // fall through
-      case PE_IndicatorMenuCheckMark:          // fall through
-      case PE_IndicatorProgressChunk:          // fall through
-      case PE_IndicatorRadioButton:            // fall through
-      case PE_IndicatorSpinDown:               // fall through
-      case PE_IndicatorSpinMinus:              // fall through
-      case PE_IndicatorSpinPlus:               // fall through
-      case PE_IndicatorSpinUp:                 // fall through
-      case PE_IndicatorToolBarHandle:          // fall through
-      case PE_IndicatorToolBarSeparator:       // fall through
-      case PE_PanelTipLabel:                   // fall through
-      case PE_IndicatorTabTear:                // fall through
-      case PE_PanelScrollAreaCorner:           // fall through
-      case PE_Widget:                          // fall through
-      case PE_IndicatorColumnViewArrow:        // fall through
-      case PE_IndicatorItemViewItemDrop:       // fall through
-      case PE_PanelItemViewItem:               // fall through
-      case PE_PanelItemViewRow:                // fall through
-      case PE_PanelStatusBar:                  // fall through
-      case PE_PanelMenu:                       // fall through
-      case PE_IndicatorTabTearRight:           // fall through
-      case PE_CustomBase:                      // fall through
+      default:
         baseStyle()->drawPrimitive(elem, option, painter, widget);
         break;
     }
@@ -484,7 +436,7 @@ QColor CustomTheme::commitEditor(CommitEditor color) {
     case CommitEditor::LengthWarning:
       return commitEditor.value("lengthwarning").value<QColor>();
   }
-  throw std::runtime_error("Not Implemented or invalid enum " +
+  throw std::runtime_error("unreachable; value=" +
                            std::to_string(static_cast<int>(color)));
 }
 
@@ -515,7 +467,7 @@ QColor CustomTheme::diff(Diff color) {
     case Diff::Error:
       return diff.value("error").value<QColor>();
   }
-  throw std::runtime_error("Not Implemented or invalid enum" +
+  throw std::runtime_error("unreachable; value=" +
                            std::to_string(static_cast<int>(color)));
 }
 
@@ -527,10 +479,9 @@ QColor CustomTheme::heatMap(HeatMap color) {
       return QColor(heatmap.value("hot").toString());
     case HeatMap::Cold:
       return QColor(heatmap.value("cold").toString());
-    default:
-      throw std::runtime_error("Not Implemented or invalid enum" +
-                               std::to_string(static_cast<int>(color)));
   }
+  throw std::runtime_error("unreachable; value=" +
+                            std::to_string(static_cast<int>(color)));
 }
 
 QColor CustomTheme::remoteComment(Comment color) {
@@ -545,10 +496,9 @@ QColor CustomTheme::remoteComment(Comment color) {
       return QColor(comment.value("author").toString());
     case Comment::Timestamp:
       return QColor(comment.value("timestamp").toString());
-    default:
-      throw std::runtime_error("Not Implemented or invalid enum" +
-                               std::to_string(static_cast<int>(color)));
   }
+  throw std::runtime_error("unreachable; value=" +
+                            std::to_string(static_cast<int>(color)));
 }
 
 QColor CustomTheme::star() {

--- a/src/app/Theme.cpp
+++ b/src/app/Theme.cpp
@@ -101,7 +101,14 @@ QColor Theme::badge(BadgeRole role, BadgeState state) {
         case BadgeState::Head:
           return QPalette().color(QPalette::HighlightedText);
 
-        default:
+        case BadgeState::Normal:       // fall through
+        case BadgeState::Conflicted:   // fall through
+        case BadgeState::Notification: // fall through
+        case BadgeState::Modified:     // fall through
+        case BadgeState::Added:        // fall through
+        case BadgeState::Deleted:      // fall through
+        case BadgeState::Untracked:    // fall through
+        case BadgeState::Renamed:
           return QPalette().color(QPalette::WindowText);
       }
 
@@ -163,10 +170,9 @@ QColor Theme::commitEditor(CommitEditor color) {
       return Qt::gray;
     case CommitEditor::LengthWarning:
       return Qt::yellow;
-    default:
-      throw std::runtime_error("Not Implemented or invalid enum" +
-                               std::to_string(static_cast<int>(color)));
   }
+  throw std::runtime_error("Not Implemented or invalid enum" +
+                           std::to_string(static_cast<int>(color)));
 }
 
 QColor Theme::diff(Diff color) {
@@ -194,10 +200,9 @@ QColor Theme::diff(Diff color) {
         return "#E8C080";
       case Diff::Error:
         return "#7E494B";
-      default:
-        throw std::runtime_error("Not Implemented or invalid enum" +
-                                 std::to_string(static_cast<int>(color)));
     }
+    throw std::runtime_error("Not Implemented or invalid enum" +
+                             std::to_string(static_cast<int>(color)));
   }
 
   switch (color) {
@@ -223,10 +228,9 @@ QColor Theme::diff(Diff color) {
       return "#FFFF00";
     case Diff::Error:
       return "#FF0000";
-    default:
-      throw std::runtime_error("Not Implemented or invalid enum" +
-                               std::to_string(static_cast<int>(color)));
   }
+  throw std::runtime_error("Not Implemented or invalid enum" +
+                           std::to_string(static_cast<int>(color)));
 }
 
 QColor Theme::heatMap(HeatMap color) {
@@ -236,10 +240,9 @@ QColor Theme::heatMap(HeatMap color) {
     case HeatMap::Cold:
       return mDark ? QPalette().color(QPalette::Inactive, QPalette::Highlight)
                    : QPalette().color(QPalette::Mid);
-    default:
-      throw std::runtime_error("Not Implemented or invalid enum" +
-                               std::to_string(static_cast<int>(color)));
   }
+  throw std::runtime_error("Not Implemented or invalid enum" +
+                           std::to_string(static_cast<int>(color)));
 }
 
 QColor Theme::remoteComment(Comment color) {
@@ -252,10 +255,9 @@ QColor Theme::remoteComment(Comment color) {
       return QPalette().color(QPalette::WindowText);
     case Comment::Timestamp:
       return QPalette().color(QPalette::WindowText);
-    default:
-      throw std::runtime_error("Not Implemented or invalid enum" +
-                               std::to_string(static_cast<int>(color)));
   }
+  throw std::runtime_error("Not Implemented or invalid enum" +
+                           std::to_string(static_cast<int>(color)));
 }
 
 QColor Theme::star() { return QPalette().color(QPalette::Highlight); }

--- a/src/app/Theme.cpp
+++ b/src/app/Theme.cpp
@@ -163,6 +163,8 @@ QColor Theme::commitEditor(CommitEditor color) {
       return Qt::gray;
     case CommitEditor::LengthWarning:
       return Qt::yellow;
+    default:
+      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
   }
 }
 
@@ -191,6 +193,8 @@ QColor Theme::diff(Diff color) {
         return "#E8C080";
       case Diff::Error:
         return "#7E494B";
+    default:
+      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
     }
   }
 
@@ -217,6 +221,8 @@ QColor Theme::diff(Diff color) {
       return "#FFFF00";
     case Diff::Error:
       return "#FF0000";
+    default:
+      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
   }
 }
 
@@ -227,6 +233,8 @@ QColor Theme::heatMap(HeatMap color) {
     case HeatMap::Cold:
       return mDark ? QPalette().color(QPalette::Inactive, QPalette::Highlight)
                    : QPalette().color(QPalette::Mid);
+    default:
+      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
   }
 }
 
@@ -240,6 +248,8 @@ QColor Theme::remoteComment(Comment color) {
       return QPalette().color(QPalette::WindowText);
     case Comment::Timestamp:
       return QPalette().color(QPalette::WindowText);
+    default:
+      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
   }
 }
 

--- a/src/app/Theme.cpp
+++ b/src/app/Theme.cpp
@@ -108,7 +108,7 @@ QColor Theme::badge(BadgeRole role, BadgeState state) {
         case BadgeState::Added:        // fall through
         case BadgeState::Deleted:      // fall through
         case BadgeState::Untracked:    // fall through
-        case BadgeState::Renamed:
+        case BadgeState::Renamed:      // fall through
           return QPalette().color(QPalette::WindowText);
       }
 
@@ -171,7 +171,7 @@ QColor Theme::commitEditor(CommitEditor color) {
     case CommitEditor::LengthWarning:
       return Qt::yellow;
   }
-  throw std::runtime_error("Not Implemented or invalid enum" +
+  throw std::runtime_error("unreachable; value=" +
                            std::to_string(static_cast<int>(color)));
 }
 
@@ -201,7 +201,7 @@ QColor Theme::diff(Diff color) {
       case Diff::Error:
         return "#7E494B";
     }
-    throw std::runtime_error("Not Implemented or invalid enum" +
+    throw std::runtime_error("unreachable; value=" +
                              std::to_string(static_cast<int>(color)));
   }
 
@@ -229,7 +229,7 @@ QColor Theme::diff(Diff color) {
     case Diff::Error:
       return "#FF0000";
   }
-  throw std::runtime_error("Not Implemented or invalid enum" +
+  throw std::runtime_error("unreachable; value=" +
                            std::to_string(static_cast<int>(color)));
 }
 
@@ -241,7 +241,7 @@ QColor Theme::heatMap(HeatMap color) {
       return mDark ? QPalette().color(QPalette::Inactive, QPalette::Highlight)
                    : QPalette().color(QPalette::Mid);
   }
-  throw std::runtime_error("Not Implemented or invalid enum" +
+  throw std::runtime_error("unreachable; value=" +
                            std::to_string(static_cast<int>(color)));
 }
 
@@ -256,7 +256,7 @@ QColor Theme::remoteComment(Comment color) {
     case Comment::Timestamp:
       return QPalette().color(QPalette::WindowText);
   }
-  throw std::runtime_error("Not Implemented or invalid enum" +
+  throw std::runtime_error("unreachable; value=" +
                            std::to_string(static_cast<int>(color)));
 }
 

--- a/src/app/Theme.cpp
+++ b/src/app/Theme.cpp
@@ -164,7 +164,8 @@ QColor Theme::commitEditor(CommitEditor color) {
     case CommitEditor::LengthWarning:
       return Qt::yellow;
     default:
-      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
+      throw std::runtime_error("Not Implemented or invalid enum" +
+                               std::to_string(static_cast<int>(color)));
   }
 }
 
@@ -193,8 +194,9 @@ QColor Theme::diff(Diff color) {
         return "#E8C080";
       case Diff::Error:
         return "#7E494B";
-    default:
-      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
+      default:
+        throw std::runtime_error("Not Implemented or invalid enum" +
+                                 std::to_string(static_cast<int>(color)));
     }
   }
 
@@ -222,7 +224,8 @@ QColor Theme::diff(Diff color) {
     case Diff::Error:
       return "#FF0000";
     default:
-      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
+      throw std::runtime_error("Not Implemented or invalid enum" +
+                               std::to_string(static_cast<int>(color)));
   }
 }
 
@@ -234,7 +237,8 @@ QColor Theme::heatMap(HeatMap color) {
       return mDark ? QPalette().color(QPalette::Inactive, QPalette::Highlight)
                    : QPalette().color(QPalette::Mid);
     default:
-      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
+      throw std::runtime_error("Not Implemented or invalid enum" +
+                               std::to_string(static_cast<int>(color)));
   }
 }
 
@@ -249,7 +253,8 @@ QColor Theme::remoteComment(Comment color) {
     case Comment::Timestamp:
       return QPalette().color(QPalette::WindowText);
     default:
-      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(color)));
+      throw std::runtime_error("Not Implemented or invalid enum" +
+                               std::to_string(static_cast<int>(color)));
   }
 }
 

--- a/src/conf/Settings.cpp
+++ b/src/conf/Settings.cpp
@@ -171,11 +171,9 @@ QString Settings::promptDescription(Prompt::Kind kind) const {
 
     case Prompt::Kind::LargeFiles:
       return tr("Prompt to stage large files");
-
-    default:
-      throw std::runtime_error("Not Implemented or invalid enum" +
-                               std::to_string(static_cast<int>(kind)));
   }
+  throw std::runtime_error("unreachable; value=" +
+                            std::to_string(static_cast<int>(kind)));
 }
 
 void Settings::setHotkey(const QString &action, const QString &hotkey) {

--- a/src/conf/Settings.cpp
+++ b/src/conf/Settings.cpp
@@ -173,7 +173,7 @@ QString Settings::promptDescription(Prompt::Kind kind) const {
       return tr("Prompt to stage large files");
   }
   throw std::runtime_error("unreachable; value=" +
-                            std::to_string(static_cast<int>(kind)));
+                           std::to_string(static_cast<int>(kind)));
 }
 
 void Settings::setHotkey(const QString &action, const QString &hotkey) {

--- a/src/conf/Settings.cpp
+++ b/src/conf/Settings.cpp
@@ -23,18 +23,18 @@
 
 namespace {
 
-const QString kIgnoreWsKey = "diff/whitespace/ignore";
-const QString kLastPathKey = "lastpath";
+const QString kIgnoreWsKey("diff/whitespace/ignore");
+const QString kLastPathKey("lastpath");
 
 // Look up variant at key relative to root.
 QVariant lookup(const QVariantMap &root, const QString &key) {
-  QStringList list = key.split("/", QString::SkipEmptyParts);
+  QStringList list(key.split("/", Qt::SkipEmptyParts));
   if (list.isEmpty())
     return root;
 
-  QVariantMap map = root;
+  QVariantMap map(root);
   while (map.contains(list.first())) {
-    QVariant result = map.value(list.takeFirst());
+    QVariant result(map.value(list.takeFirst()));
     if (list.isEmpty())
       return result;
     map = result.toMap();
@@ -63,7 +63,7 @@ QVariant Settings::value(const QString &key,
                          const QVariant &defaultValue) const {
   QSettings settings;
   settings.beginGroup(group());
-  QVariant result = settings.value(key, defaultValue);
+  QVariant result(settings.value(key, defaultValue));
   settings.endGroup();
   return result;
 }
@@ -107,13 +107,13 @@ QString Settings::lexer(const QString &filename) {
     return "null";
 
   QFileInfo info(filename);
-  QString name = info.fileName();
-  QString suffix = info.suffix().toLower();
+  QString name(info.fileName());
+  QString suffix(info.suffix().toLower());
 
   // Try all patterns first.
-  QVariantMap lexers = mDefaults.value("lexers").toMap();
+  QVariantMap lexers(mDefaults.value("lexers").toMap());
   foreach (const QString &key, lexers.keys()) {
-    QVariantMap map = lexers.value(key).toMap();
+    QVariantMap map(lexers.value(key).toMap());
     if (map.contains("patterns")) {
       foreach (QString pattern, map.value("patterns").toString().split(",")) {
         QRegExp regExp(pattern, CS, QRegExp::Wildcard);
@@ -125,7 +125,7 @@ QString Settings::lexer(const QString &filename) {
 
   // Try to match by extension.
   foreach (const QString &key, lexers.keys()) {
-    QVariantMap map = lexers.value(key).toMap();
+    QVariantMap map(lexers.value(key).toMap());
     if (map.contains("extensions")) {
       foreach (QString ext, map.value("extensions").toString().split(",")) {
         if (suffix == ext)
@@ -138,8 +138,8 @@ QString Settings::lexer(const QString &filename) {
 }
 
 QString Settings::kind(const QString &filename) {
-  QString key = lexer(filename);
-  QVariantMap lexers = mDefaults.value("lexers").toMap();
+  QString key(lexer(filename));
+  QVariantMap lexers(mDefaults.value("lexers").toMap());
   return lexers.value(key).toMap().value("name").toString();
 }
 
@@ -170,6 +170,9 @@ QString Settings::promptDescription(Prompt::Kind kind) const {
 
     case Prompt::Kind::LargeFiles:
       return tr("Prompt to stage large files");
+
+    default:
+      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(kind)));
   }
 }
 
@@ -221,10 +224,10 @@ QDir Settings::confDir() {
 #if !defined(NDEBUG)
   QDir dir(SRC_CONF_DIR);
 #else
-  QDir dir = rootDir();
+  QDir dir(rootDir());
   if (!dir.cd("Resources")) {
     if (!dir.cd(CONF_DIR))
-      dir = SRC_CONF_DIR;
+      dir.setPath(SRC_CONF_DIR);
   }
 #endif
   return dir;
@@ -232,20 +235,20 @@ QDir Settings::confDir() {
 
 QDir Settings::l10nDir() {
 #if !defined(NDEBUG)
-  QDir dir = QDir(SRC_L10N_DIR);
+  QDir dir(QDir(SRC_L10N_DIR));
 #else
-  QDir dir = confDir();
+  QDir dir(confDir());
   if (!dir.cd("l10n")) {
     dir = rootDir();
     if (!dir.cd(L10N_DIR))
-      dir = SRC_L10N_DIR;
+      dir.setPath(SRC_L10N_DIR);
   }
 #endif
   return dir;
 }
 
 QDir Settings::dictionariesDir() {
-  QDir dir = confDir();
+  QDir dir(confDir());
   dir.cd("dictionaries");
   return dir;
 }
@@ -254,24 +257,24 @@ QDir Settings::lexerDir() {
 #if !defined(NDEBUG)
   QDir dir(SRC_SCINTILLUA_LEXERS_DIR);
 #else
-  QDir dir = confDir();
+  QDir dir(confDir());
   if (!dir.cd("lexers")) {
     dir = rootDir();
     if (!dir.cd(SCINTILLUA_LEXERS_DIR))
-      dir = SRC_SCINTILLUA_LEXERS_DIR;
+      dir.setPath(SRC_SCINTILLUA_LEXERS_DIR);
   }
 #endif
   return dir;
 }
 
 QDir Settings::themesDir() {
-  QDir dir = confDir();
+  QDir dir(confDir());
   dir.cd("themes");
   return dir;
 }
 
 QDir Settings::pluginsDir() {
-  QDir dir = confDir();
+  QDir dir(confDir());
   dir.cd("plugins");
   return dir;
 }
@@ -281,8 +284,8 @@ QDir Settings::userDir() {
 }
 
 QDir Settings::tempDir() {
-  QString name = QCoreApplication::applicationName();
-  QDir dir = QDir::temp();
+  QString name(QCoreApplication::applicationName());
+  QDir dir(QDir::temp());
   dir.mkpath(name);
   dir.cd(name);
   return dir;

--- a/src/conf/Settings.cpp
+++ b/src/conf/Settings.cpp
@@ -173,7 +173,8 @@ QString Settings::promptDescription(Prompt::Kind kind) const {
       return tr("Prompt to stage large files");
 
     default:
-      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(kind)));
+      throw std::runtime_error("Not Implemented or invalid enum" +
+                               std::to_string(static_cast<int>(kind)));
   }
 }
 

--- a/src/conf/Settings.cpp
+++ b/src/conf/Settings.cpp
@@ -10,6 +10,7 @@
 #include "Settings.h"
 #include "ConfFile.h"
 #include "Debug.h"
+#include "qtsupport.h"
 #include <QCoreApplication>
 #include <QDir>
 #include <QSettings>

--- a/src/cred/CredentialHelper.cpp
+++ b/src/cred/CredentialHelper.cpp
@@ -10,6 +10,7 @@
 #include "CredentialHelper.h"
 #include "Cache.h"
 #include "GitCredential.h"
+#include "qtsupport.h"
 #include "Store.h"
 #include "conf/Settings.h"
 #include "git/Config.h"

--- a/src/cred/CredentialHelper.cpp
+++ b/src/cred/CredentialHelper.cpp
@@ -98,5 +98,5 @@ void CredentialHelper::log(const QString &text) {
     return;
 
   QString time = QTime::currentTime().toString(Qt::ISODateWithMs);
-  QTextStream(&file) << time << " - " << text << endl;
+  QTextStream(&file) << time << " - " << text << Qt::endl;
 }

--- a/src/cred/GitCredential.cpp
+++ b/src/cred/GitCredential.cpp
@@ -45,11 +45,11 @@ bool GitCredential::get(const QString &url, QString &username,
     return false;
 
   QTextStream out(&process);
-  out << "protocol=" << protocol(url) << endl;
-  out << "host=" << host(url) << endl;
+  out << "protocol=" << protocol(url) << Qt::endl;
+  out << "host=" << host(url) << Qt::endl;
   if (!username.isEmpty())
-    out << "username=" << username << endl;
-  out << endl;
+    out << "username=" << username << Qt::endl;
+  out << Qt::endl;
 
   process.closeWriteChannel();
   process.waitForFinished();
@@ -80,11 +80,11 @@ bool GitCredential::store(const QString &url, const QString &username,
     return false;
 
   QTextStream out(&process);
-  out << "protocol=" << protocol(url) << endl;
-  out << "host=" << host(url) << endl;
-  out << "username=" << username << endl;
-  out << "password=" << password << endl;
-  out << endl;
+  out << "protocol=" << protocol(url) << Qt::endl;
+  out << "host=" << host(url) << Qt::endl;
+  out << "username=" << username << Qt::endl;
+  out << "password=" << password << Qt::endl;
+  out << Qt::endl;
 
   process.closeWriteChannel();
   process.waitForFinished();

--- a/src/cred/GitCredential.cpp
+++ b/src/cred/GitCredential.cpp
@@ -8,6 +8,7 @@
 //
 
 #include "GitCredential.h"
+#include "qtsupport.h"
 #include <QStandardPaths>
 #include <QCoreApplication>
 #include <QDir>

--- a/src/dialogs/ExternalToolsDialog.cpp
+++ b/src/dialogs/ExternalToolsDialog.cpp
@@ -85,7 +85,7 @@ QVBoxLayout *ExternalToolsDialog::createUserDefinedLayout(const QString &type) {
     table->resizeColumnsToContents();
   });
 
-  connect(footer, &Footer::minusClicked, [this, table, model] {
+  connect(footer, &Footer::minusClicked, [table, model] {
     QModelIndexList indexes = table->selectionModel()->selectedRows(0);
     foreach (const QModelIndex &index, indexes)
       model->remove(index.data(Qt::DisplayRole).toString());

--- a/src/dialogs/StartDialog.cpp
+++ b/src/dialogs/StartDialog.cpp
@@ -698,7 +698,7 @@ void StartDialog::updateButtons() {
       open->setEnabled(false);
     } else {
       Account *account = parent.data(AccountRole).value<Account *>();
-      if (Repository *repo = index.data(RepositoryRole).value<Repository *>()) {
+      if (nullptr != index.data(RepositoryRole).value<Repository *>()) {
         if (account->repositoryPath(index.row()).isEmpty())
           clone = true;
       } else {

--- a/src/dialogs/ThemeDialog.cpp
+++ b/src/dialogs/ThemeDialog.cpp
@@ -62,7 +62,7 @@ public:
         case Theme::Dark:
           Settings::instance()->setValue(Setting::Id::ColorTheme, "Dark");
           break;
-        default:
+        case Theme::Default:
           Settings::instance()->setValue(Setting::Id::ColorTheme, "Default");
           break;
       }

--- a/src/editor/LexLPeg.cpp
+++ b/src/editor/LexLPeg.cpp
@@ -552,7 +552,8 @@ public:
    * @param key The string keyword.
    * @param val The string value.
    */
-  Sci_Position SCI_METHOD PropertySet(const char *key, const char *value) override {
+  Sci_Position SCI_METHOD PropertySet(const char *key,
+                                      const char *value) override {
     const char *val = *value ? value : " ";
     props.Set(key, val, strlen(key), strlen(val)); // ensure property is cleared
     return -1;                                     // no need to re-lex

--- a/src/editor/LexLPeg.cpp
+++ b/src/editor/LexLPeg.cpp
@@ -413,7 +413,7 @@ public:
   virtual ~LexerLPeg() {}
 
   /** Destroys the lexer object. */
-  void SCI_METHOD Release() {
+  void SCI_METHOD Release() override {
     lua_getfield(L, LUA_REGISTRYINDEX, "sci_lexers");
     lua_pushlightuserdata(L, reinterpret_cast<void *>(this));
     lua_pushnil(L), lua_settable(L, -3), lua_pop(L, 1); // sci_lexers
@@ -429,7 +429,7 @@ public:
    * @param buffer The document interface.
    */
   void SCI_METHOD Lex(Sci_PositionU startPos, Sci_Position lengthDoc,
-                      int initStyle, IDocument *buffer) {
+                      int initStyle, IDocument *buffer) override {
     lua_pushlightuserdata(L, reinterpret_cast<void *>(&props));
     lua_setfield(L, LUA_REGISTRYINDEX, "sci_props");
     lua_pushlightuserdata(L, reinterpret_cast<void *>(buffer));
@@ -515,7 +515,7 @@ public:
    * @param buffer The document interface.
    */
   void SCI_METHOD Fold(Sci_PositionU startPos, Sci_Position lengthDoc,
-                       int initStyle, IDocument *buffer) {
+                       int initStyle, IDocument *buffer) override {
     lua_pushlightuserdata(L, reinterpret_cast<void *>(&props));
     lua_setfield(L, LUA_REGISTRYINDEX, "sci_props");
     lua_pushlightuserdata(L, reinterpret_cast<void *>(buffer));
@@ -552,7 +552,7 @@ public:
    * @param key The string keyword.
    * @param val The string value.
    */
-  Sci_Position SCI_METHOD PropertySet(const char *key, const char *value) {
+  Sci_Position SCI_METHOD PropertySet(const char *key, const char *value) override {
     const char *val = *value ? value : " ";
     props.Set(key, val, strlen(key), strlen(val)); // ensure property is cleared
     return -1;                                     // no need to re-lex
@@ -566,7 +566,7 @@ public:
    * @param arg The argument.
    * @return void *data
    */
-  void *SCI_METHOD PrivateCall(int code, void *arg) {
+  void *SCI_METHOD PrivateCall(int code, void *arg) override {
     switch (code) {
       case SCI_GETDIRECTFUNCTION:
         fn = reinterpret_cast<SciFnDirect>(arg);
@@ -603,12 +603,12 @@ public:
     }
   }
 
-  int SCI_METHOD Version() const { return 0; }
-  const char *SCI_METHOD PropertyNames() { return ""; }
-  int SCI_METHOD PropertyType(const char *) { return 0; }
-  const char *SCI_METHOD DescribeProperty(const char *) { return ""; }
-  const char *SCI_METHOD DescribeWordListSets() { return ""; }
-  Sci_Position SCI_METHOD WordListSet(int, const char *) { return -1; }
+  int SCI_METHOD Version() const override { return 0; }
+  const char *SCI_METHOD PropertyNames() override { return ""; }
+  int SCI_METHOD PropertyType(const char *) override { return 0; }
+  const char *SCI_METHOD DescribeProperty(const char *) override { return ""; }
+  const char *SCI_METHOD DescribeWordListSets() override { return ""; }
+  Sci_Position SCI_METHOD WordListSet(int, const char *) override { return -1; }
 
   int SCI_METHOD LineEndTypesSupported() noexcept override {
     return SC_LINE_END_TYPE_UNICODE;
@@ -636,7 +636,7 @@ public:
 
   int SCI_METHOD GetIdentifier() override { return 0; }
 
-  const char *SCI_METHOD PropertyGet(const char *key) { return ""; }
+  const char *SCI_METHOD PropertyGet(const char *key) override { return ""; }
 
   /** Constructs a new instance of the lexer. */
   static ILexer5 *LexerFactoryLPeg() { return new LexerLPeg(); }

--- a/src/editor/PlatQt.cpp
+++ b/src/editor/PlatQt.cpp
@@ -486,7 +486,8 @@ void Window::SetCursor(Cursor curs) {
       case cursorHand:
         shape = Qt::PointingHandCursor;
         break;
-      default:
+      case cursorInvalid: // fall through
+      case cursorReverseArrow:
         shape = Qt::ArrowCursor;
         break;
     }

--- a/src/editor/PlatQt.cpp
+++ b/src/editor/PlatQt.cpp
@@ -128,7 +128,7 @@ void SurfaceImpl::Polygon(Point *pts, size_t npts, ColourDesired fore,
   PenColour(fore);
 
   QVarLengthArray<QPoint, 8> qpts(npts);
-  for (int i = 0; i < npts; i++)
+  for (size_t i = 0; i < npts; i++)
     qpts[i] = QPoint(pts[i].x, pts[i].y);
 
   QPainter *painter = GetPainter();
@@ -306,7 +306,7 @@ void SurfaceImpl::MeasureWidths(Font &font, std::string_view s,
   QTextLine tl = tlay.createLine();
   tlay.endLayout();
 
-  int i = 0;
+  size_t i = 0;
   int ui = 0;
   int fit = su.size();
   const unsigned char *us = reinterpret_cast<const unsigned char *>(s.data());
@@ -468,9 +468,6 @@ void Window::SetCursor(Cursor curs) {
       case cursorText:
         shape = Qt::IBeamCursor;
         break;
-      case cursorArrow:
-        shape = Qt::ArrowCursor;
-        break;
       case cursorUp:
         shape = Qt::UpArrowCursor;
         break;
@@ -486,8 +483,7 @@ void Window::SetCursor(Cursor curs) {
       case cursorHand:
         shape = Qt::PointingHandCursor;
         break;
-      case cursorInvalid: // fall through
-      case cursorReverseArrow:
+      default:
         shape = Qt::ArrowCursor;
         break;
     }

--- a/src/editor/ScintillaQt.cpp
+++ b/src/editor/ScintillaQt.cpp
@@ -520,7 +520,6 @@ void ScintillaQt::inputMethodEvent(QInputMethodEvent *event) {
       const unsigned int ucWidth = commitStr.at(i).isHighSurrogate() ? 2 : 1;
       const QString oneCharUTF16 = commitStr.mid(i, ucWidth);
       const QByteArray oneChar = oneCharUTF16.toUtf8();
-      const int oneCharLen = oneChar.length();
 
       InsertCharacter(oneChar.toStdString(), CharacterSource::directInput);
       i += ucWidth;

--- a/src/editor/ScintillaQt.cpp
+++ b/src/editor/ScintillaQt.cpp
@@ -439,6 +439,7 @@ void ScintillaQt::dragEnterEvent(QDragEnterEvent *event) {
 }
 
 void ScintillaQt::dragLeaveEvent(QDragLeaveEvent *event) {
+  Q_UNUSED(event);
   SetDragPosition(SelectionPosition(Sci::invalidPosition));
 }
 
@@ -567,7 +568,7 @@ void ScintillaQt::inputMethodEvent(QInputMethodEvent *event) {
             indicator = SC_INDICATOR_CONVERTED;
             break;
 
-          default:
+          case QTextCharFormat::DashDotDotLine:
             indicator = SC_INDICATOR_UNKNOWN;
         }
 
@@ -690,9 +691,23 @@ QVariant ScintillaQt::inputMethodQuery(Qt::InputMethodQuery query) const {
       return buffer.constData();
     }
 
-    default:
-      return QVariant();
+    case Qt::ImEnabled:                // fall through
+    case Qt::ImAnchorPosition:         // fall through
+    case Qt::ImHints:                  // fall through
+    case Qt::ImMaximumTextLength:      // fall through
+    case Qt::ImPreferredLanguage:      // fall through
+    case Qt::ImAbsolutePosition:       // fall through
+    case Qt::ImTextBeforeCursor:       // fall through
+    case Qt::ImTextAfterCursor:        // fall through
+    case Qt::ImEnterKeyType:           // fall through
+    case Qt::ImAnchorRectangle:        // fall through
+    case Qt::ImInputItemClipRectangle: // fall through
+    case Qt::ImPlatformData:           // fall through
+    case Qt::ImQueryInput:             // fall through
+    case Qt::ImQueryAll:               // fall through
+      break;
   }
+  return QVariant();
 }
 
 void ScintillaQt::PasteFromMode(QClipboard::Mode clipboardMode) {

--- a/src/editor/TextEditor.cpp
+++ b/src/editor/TextEditor.cpp
@@ -43,8 +43,6 @@ QPixmap stagedUnstagedIcon(const bool &checked, const QColor &background,
       QRect(QPoint(0, 0), QSize(fontHeight - 2, fontHeight - 2)));
 }
 
-const float textHeightFactorCheckBoxSize = 2.0;
-
 } // namespace
 
 extern LexerModule lmLPeg;

--- a/src/editor/TextEditor.cpp
+++ b/src/editor/TextEditor.cpp
@@ -43,6 +43,10 @@ QPixmap stagedUnstagedIcon(const bool &checked, const QColor &background,
       QRect(QPoint(0, 0), QSize(fontHeight - 2, fontHeight - 2)));
 }
 
+#if defined(FLATPAK)
+const float textHeightFactorCheckBoxSize = 2.0;
+#endif
+
 } // namespace
 
 extern LexerModule lmLPeg;

--- a/src/editor/TextEditor.h
+++ b/src/editor/TextEditor.h
@@ -105,7 +105,7 @@ public:
 
   QList<Diagnostic> diagnostics(int line);
   void addDiagnostic(int line, const Diagnostic &diag);
-  sptr_t WndProc(unsigned int message, uptr_t wParam, sptr_t lParam);
+  sptr_t WndProc(unsigned int message, uptr_t wParam, sptr_t lParam) override;
 
   // Make wheel event public.
   // FIXME: This should be an event filter?
@@ -154,7 +154,7 @@ private:
   int diagnosticMarker(int line);
   void loadMarkerIcon(Marker marker, const QIcon &icon);
   void loadMarkerPixmap(Marker marker, const QPixmap &pixmap);
-  void AddToPopUp(const char *label, int cmd = 0, bool enabled = true);
+  void AddToPopUp(const char *label, int cmd = 0, bool enabled = true) override;
   void ContextMenu(Scintilla::Point pt);
 
   QString mPath;

--- a/src/git/Diff.cpp
+++ b/src/git/Diff.cpp
@@ -199,7 +199,8 @@ void Diff::sort(SortRole role, Qt::SortOrder order) {
           }
 
           default:
-            throw std::runtime_error("Unhandled case or invalid enum " + std::to_string(static_cast<int>(role)));
+            throw std::runtime_error("Unhandled case or invalid enum " +
+                                     std::to_string(static_cast<int>(role)));
         }
       });
 }

--- a/src/git/Diff.cpp
+++ b/src/git/Diff.cpp
@@ -197,11 +197,9 @@ void Diff::sort(SortRole role, Qt::SortOrder order) {
             return ascending ? (lhsStatus < rhsStatus)
                              : (rhsStatus < lhsStatus);
           }
-
-          default:
-            throw std::runtime_error("Unhandled case or invalid enum " +
-                                     std::to_string(static_cast<int>(role)));
         }
+        throw std::runtime_error("unreachable; value=" +
+                                  std::to_string(static_cast<int>(role)));
       });
 }
 

--- a/src/git/Diff.cpp
+++ b/src/git/Diff.cpp
@@ -108,10 +108,10 @@ QByteArray Diff::print() {
   QByteArray diff;
   for (auto file : data.files) {
     for (auto hunk : file.hunks) {
-      diff.append(hunk.header);
+      diff.append(hunk.header.toUtf8());
 
       for (auto line : hunk.lines)
-        diff.append(line);
+        diff.append(line.toUtf8());
     }
   }
   Debug(QString(diff));
@@ -197,6 +197,9 @@ void Diff::sort(SortRole role, Qt::SortOrder order) {
             return ascending ? (lhsStatus < rhsStatus)
                              : (rhsStatus < lhsStatus);
           }
+
+          default:
+            throw std::runtime_error("Unhandled case or invalid enum " + std::to_string(static_cast<int>(role)));
         }
       });
 }

--- a/src/git/Diff.cpp
+++ b/src/git/Diff.cpp
@@ -199,7 +199,7 @@ void Diff::sort(SortRole role, Qt::SortOrder order) {
           }
         }
         throw std::runtime_error("unreachable; value=" +
-                                  std::to_string(static_cast<int>(role)));
+                                 std::to_string(static_cast<int>(role)));
       });
 }
 

--- a/src/git/Patch.cpp
+++ b/src/git/Patch.cpp
@@ -265,7 +265,8 @@ QByteArray Patch::lineContent(int hidx, int ln) const {
 
   const git_diff_line *line = nullptr;
   int result = git_patch_get_line_in_hunk(&line, d.data(), hidx, ln);
-  return (GIT_OK == result) ? QByteArray(line->content, line->content_len) : QByteArray();
+  return (GIT_OK == result) ? QByteArray(line->content, line->content_len)
+                            : QByteArray();
 }
 
 Patch::ConflictResolution Patch::conflictResolution(int hidx) {

--- a/src/git/Patch.cpp
+++ b/src/git/Patch.cpp
@@ -195,7 +195,7 @@ QByteArray Patch::header(int hidx) const {
 
   const git_diff_hunk *hunk = nullptr;
   int result = git_patch_get_hunk(&hunk, nullptr, d.data(), hidx);
-  return !result ? hunk->header : QByteArray();
+  return (GIT_OK == result) ? hunk->header : QByteArray();
 }
 
 const git_diff_hunk *Patch::header_struct(int hidx) const {
@@ -204,7 +204,7 @@ const git_diff_hunk *Patch::header_struct(int hidx) const {
 
   const git_diff_hunk *hunk = nullptr;
   int result = git_patch_get_hunk(&hunk, nullptr, d.data(), hidx);
-  return hunk;
+  return (GIT_OK == result) ? hunk : nullptr;
 }
 
 int Patch::lineCount(int hidx) const {
@@ -235,7 +235,7 @@ char Patch::lineOrigin(int hidx, int ln) const {
 
   const git_diff_line *line = nullptr;
   int result = git_patch_get_line_in_hunk(&line, d.data(), hidx, ln);
-  return !result ? line->origin : GIT_DIFF_LINE_CONTEXT;
+  return (GIT_OK == result) ? line->origin : GIT_DIFF_LINE_CONTEXT;
 }
 
 int Patch::lineNumber(int hidx, int ln, Diff::File file) const {
@@ -256,7 +256,7 @@ git_off_t Patch::contentOffset(int hidx) const {
   const git_diff_line *line = nullptr;
   int result = git_patch_get_line_in_hunk(&line, d.data(), hidx,
                                           0); // TODO: line index 0?
-  return result == 0 ? line->content_offset : 0;
+  return (GIT_OK == result) ? line->content_offset : 0;
 }
 
 QByteArray Patch::lineContent(int hidx, int ln) const {
@@ -265,7 +265,7 @@ QByteArray Patch::lineContent(int hidx, int ln) const {
 
   const git_diff_line *line = nullptr;
   int result = git_patch_get_line_in_hunk(&line, d.data(), hidx, ln);
-  return !result ? QByteArray(line->content, line->content_len) : QByteArray();
+  return (GIT_OK == result) ? QByteArray(line->content, line->content_len) : QByteArray();
 }
 
 Patch::ConflictResolution Patch::conflictResolution(int hidx) {

--- a/src/git/Patch.cpp
+++ b/src/git/Patch.cpp
@@ -435,6 +435,7 @@ void Patch::apply(QList<QList<QByteArray>> &image, int hidx, int start_line,
         break;
 
       default:
+        // no-op
         break;
     }
   }

--- a/src/git/Rebase.cpp
+++ b/src/git/Rebase.cpp
@@ -36,8 +36,8 @@ const git_rebase_operation *Rebase::operation(size_t index) {
 }
 
 bool Rebase::hasNext() const {
-  int index = currentIndex();
-  int count = git_rebase_operation_entrycount(d.data());
+  size_t index = currentIndex();
+  size_t count = git_rebase_operation_entrycount(d.data());
   return (count > 0 && (index == GIT_REBASE_NO_OPERATION || index < count - 1));
 }
 

--- a/src/git/Remote.cpp
+++ b/src/git/Remote.cpp
@@ -445,9 +445,10 @@ int Remote::Callbacks::transfer(const git_indexer_progress *stats,
     case Resolve:
       return cbs->resolve(stats->total_deltas, stats->indexed_deltas) ? 0 : -1;
 
-    default:
+    case Update:
       return 0;
   }
+  return 0;
 }
 
 int Remote::Callbacks::update(const char *name, const git_oid *a,

--- a/src/git/Remote.cpp
+++ b/src/git/Remote.cpp
@@ -11,6 +11,7 @@
 #include "Branch.h"
 #include "Config.h"
 #include "Id.h"
+#include "qtsupport.h"
 #include "TagRef.h"
 #include "git2/buffer.h"
 #include "git2/clone.h"

--- a/src/git/Remote.cpp
+++ b/src/git/Remote.cpp
@@ -674,7 +674,7 @@ void Remote::log(const QString &text) {
     return;
 
   QString time = QTime::currentTime().toString(Qt::ISODateWithMs);
-  QTextStream(&file) << time << " - " << text << endl;
+  QTextStream(&file) << time << " - " << text << Qt::endl;
 }
 
 } // namespace git

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -1052,7 +1052,7 @@ QStringList Repository::lfsEnvironment() {
 
 Repository::LfsTracking Repository::lfsTracked() {
   QString output = lfsExecute({"track"});
-  QStringList lines = output.split('\n', QString::SkipEmptyParts);
+  QStringList lines = output.split('\n', Qt::SkipEmptyParts);
   if (!lines.isEmpty())
     lines.removeFirst();
 

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -18,6 +18,7 @@
 #include "FilterList.h"
 #include "Index.h"
 #include "Patch.h"
+#include "qtsupport.h"
 #include "Rebase.h"
 #include "Reference.h"
 #include "Remote.h"

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -488,7 +488,7 @@ QStringList Repository::existingTags() const {
 
   QStringList list;
 
-  for (int i = 0; i < array.count; i++) {
+  for (size_t i = 0; i < array.count; i++) {
     list.append(array.strings[i]);
   }
 
@@ -746,7 +746,7 @@ QList<Remote> Repository::remotes() const {
     return QList<Remote>();
 
   QList<Remote> remotes;
-  for (int i = 0; i < names.count; ++i) {
+  for (size_t i = 0; i < names.count; ++i) {
     if (Remote remote = lookupRemote(names.strings[i]))
       remotes.append(remote);
   }
@@ -934,7 +934,6 @@ void Repository::rebaseContinue(const QString &commitMessage) {
     }
   }
   // Loop over rebase operations.
-  int count = r.count();
   while (r.hasNext()) {
     git::Commit before = r.next();
     if (!before.isValid()) {

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -629,6 +629,7 @@ Commit Repository::commit(const Signature &author, const Signature &committer,
       break;
 
     default:
+      // no-op
       break;
   }
 

--- a/src/host/Account.cpp
+++ b/src/host/Account.cpp
@@ -203,11 +203,9 @@ QString Account::helpText(Kind kind) {
     case Bitbucket:
     case Beanstalk:
       return QString();
-
-    default:
-      throw std::runtime_error("Unhandled case or invalid enum " +
-                               std::to_string(static_cast<int>(kind)));
   }
+  throw std::runtime_error("unreachable; value=" +
+                            std::to_string(static_cast<int>(kind)));
 }
 
 QString Account::defaultUrl(Kind kind) {
@@ -222,10 +220,9 @@ QString Account::defaultUrl(Kind kind) {
       return Beanstalk::defaultUrl();
     case GitLab:
       return GitLab::defaultUrl();
-    default:
-      throw std::runtime_error("Unhandled case or invalid enum " +
-                               std::to_string(static_cast<int>(kind)));
   }
+  throw std::runtime_error("unreachable; value=" +
+                            std::to_string(static_cast<int>(kind)));
 }
 
 Account::Kind Account::kindFromString(const QString &kind, bool *ok) {
@@ -264,10 +261,9 @@ QString Account::kindToString(Kind kind) {
       return "beanstalk";
     case GitLab:
       return "gitlab";
-    default:
-      throw std::runtime_error("Unhandled case or invalid enum " +
-                               std::to_string(static_cast<int>(kind)));
   }
+  throw std::runtime_error("unreachable; value=" +
+                            std::to_string(static_cast<int>(kind)));
 }
 
 void Account::startProgress() {

--- a/src/host/Account.cpp
+++ b/src/host/Account.cpp
@@ -203,6 +203,9 @@ QString Account::helpText(Kind kind) {
     case Bitbucket:
     case Beanstalk:
       return QString();
+
+    default:
+      throw std::runtime_error("Unhandled case or invalid enum " + std::to_string(static_cast<int>(kind)));
   }
 }
 
@@ -218,6 +221,8 @@ QString Account::defaultUrl(Kind kind) {
       return Beanstalk::defaultUrl();
     case GitLab:
       return GitLab::defaultUrl();
+    default:
+      throw std::runtime_error("Unhandled case or invalid enum " + std::to_string(static_cast<int>(kind)));
   }
 }
 
@@ -257,6 +262,8 @@ QString Account::kindToString(Kind kind) {
       return "beanstalk";
     case GitLab:
       return "gitlab";
+    default:
+      throw std::runtime_error("Unhandled case or invalid enum " + std::to_string(static_cast<int>(kind)));
   }
 }
 

--- a/src/host/Account.cpp
+++ b/src/host/Account.cpp
@@ -205,7 +205,8 @@ QString Account::helpText(Kind kind) {
       return QString();
 
     default:
-      throw std::runtime_error("Unhandled case or invalid enum " + std::to_string(static_cast<int>(kind)));
+      throw std::runtime_error("Unhandled case or invalid enum " +
+                               std::to_string(static_cast<int>(kind)));
   }
 }
 
@@ -222,7 +223,8 @@ QString Account::defaultUrl(Kind kind) {
     case GitLab:
       return GitLab::defaultUrl();
     default:
-      throw std::runtime_error("Unhandled case or invalid enum " + std::to_string(static_cast<int>(kind)));
+      throw std::runtime_error("Unhandled case or invalid enum " +
+                               std::to_string(static_cast<int>(kind)));
   }
 }
 
@@ -263,7 +265,8 @@ QString Account::kindToString(Kind kind) {
     case GitLab:
       return "gitlab";
     default:
-      throw std::runtime_error("Unhandled case or invalid enum " + std::to_string(static_cast<int>(kind)));
+      throw std::runtime_error("Unhandled case or invalid enum " +
+                               std::to_string(static_cast<int>(kind)));
   }
 }
 

--- a/src/host/Account.cpp
+++ b/src/host/Account.cpp
@@ -30,8 +30,10 @@ const QString kThemeIconFmt = ":/%1_%2.png";
 } // namespace
 
 Account::Account(const QString &username)
-    : mMgr(new QNetworkAccessManager()), mUsername(username),
-      mError(new AccountError(this)), mProgress(new AccountProgress(this)) {
+    : mUsername(username),
+      mError(new AccountError(this)),
+      mProgress(new AccountProgress(this)),
+      mMgr(new QNetworkAccessManager()) {
   QObject::connect(
       mMgr, &QNetworkAccessManager::sslErrors,
       [this](QNetworkReply *reply, const QList<QSslError> &errors) {

--- a/src/host/Account.cpp
+++ b/src/host/Account.cpp
@@ -30,10 +30,8 @@ const QString kThemeIconFmt = ":/%1_%2.png";
 } // namespace
 
 Account::Account(const QString &username)
-    : mUsername(username),
-      mError(new AccountError(this)),
-      mProgress(new AccountProgress(this)),
-      mMgr(new QNetworkAccessManager()) {
+    : mUsername(username), mError(new AccountError(this)),
+      mProgress(new AccountProgress(this)), mMgr(new QNetworkAccessManager()) {
   QObject::connect(
       mMgr, &QNetworkAccessManager::sslErrors,
       [this](QNetworkReply *reply, const QList<QSslError> &errors) {
@@ -207,7 +205,7 @@ QString Account::helpText(Kind kind) {
       return QString();
   }
   throw std::runtime_error("unreachable; value=" +
-                            std::to_string(static_cast<int>(kind)));
+                           std::to_string(static_cast<int>(kind)));
 }
 
 QString Account::defaultUrl(Kind kind) {
@@ -224,7 +222,7 @@ QString Account::defaultUrl(Kind kind) {
       return GitLab::defaultUrl();
   }
   throw std::runtime_error("unreachable; value=" +
-                            std::to_string(static_cast<int>(kind)));
+                           std::to_string(static_cast<int>(kind)));
 }
 
 Account::Kind Account::kindFromString(const QString &kind, bool *ok) {
@@ -265,7 +263,7 @@ QString Account::kindToString(Kind kind) {
       return "gitlab";
   }
   throw std::runtime_error("unreachable; value=" +
-                            std::to_string(static_cast<int>(kind)));
+                           std::to_string(static_cast<int>(kind)));
 }
 
 void Account::startProgress() {

--- a/src/index/GenericLexer.cpp
+++ b/src/index/GenericLexer.cpp
@@ -93,7 +93,19 @@ Lexer::Lexeme GenericLexer::next() {
         }
         break;
 
-      default:
+      case Comment:      // fall through
+      case Keyword:      // fall through
+      case Operator:     // fall through
+      case Error:        // fall through
+      case Preprocessor: // fall through
+      case Constant:     // fall through
+      case Variable:     // fall through
+      case Function:     // fall through
+      case Class:        // fall through
+      case Type:         // fall through
+      case Label:        // fall through
+      case Regex:        // fall through
+      case Embedded:     // fall through
         Q_ASSERT(false);
     }
   }

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -443,7 +443,8 @@ QByteArray Index::fieldName(Index::Field field) {
     case Index::Pathspec:
       return "pathspec";
     default:
-      throw std::runtime_error("Unhandled case or invalid enum " + std::to_string(static_cast<int>(field)));
+      throw std::runtime_error("Unhandled case or invalid enum " +
+                               std::to_string(static_cast<int>(field)));
   }
 }
 

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -442,10 +442,9 @@ QByteArray Index::fieldName(Index::Field field) {
       return "after";
     case Index::Pathspec:
       return "pathspec";
-    default:
-      throw std::runtime_error("Unhandled case or invalid enum " +
-                               std::to_string(static_cast<int>(field)));
   }
+  throw std::runtime_error("unreachable; value=" +
+                           std::to_string(static_cast<int>(field)));
 }
 
 QDir Index::indexDir(const git::Repository &repo) {

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -442,6 +442,8 @@ QByteArray Index::fieldName(Index::Field field) {
       return "after";
     case Index::Pathspec:
       return "pathspec";
+    default:
+      throw std::runtime_error("Unhandled case or invalid enum " + std::to_string(static_cast<int>(field)));
   }
 }
 

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -182,7 +182,7 @@ bool Index::write(PostingMap map) {
       quint32 postCount = readVInt(postIn);
       bool end = (newIt == newEnd || newIt.key() != it->key);
       postings.reserve(postCount + (!end ? newIt.value().size() : 0));
-      for (int i = 0; i < postCount; ++i) {
+      for (quint32 i = 0; i < postCount; ++i) {
         quint32 proxPos;
         Posting posting;
         posting.id = readVInt(postIn);
@@ -243,7 +243,7 @@ QList<git::Commit> Index::commits(const QString &filter) const {
   // Sort by commit date.
   QList<git::Commit> commits = query->commits(this);
   std::sort(commits.begin(), commits.end(),
-            [this](const git::Commit &lhs, const git::Commit &rhs) {
+            [](const git::Commit &lhs, const git::Commit &rhs) {
               return (lhs.committer().date() > rhs.committer().date());
             });
 
@@ -288,7 +288,7 @@ QList<Index::Posting> Index::postings(const Term &term, bool positional) const {
   // Read list.
   QList<Posting> postings;
   quint32 postCount = readVInt(in);
-  for (int i = 0; i < postCount; ++i) {
+  for (quint32 i = 0; i < postCount; ++i) {
     quint32 proxPos;
     Posting posting;
     posting.id = readVInt(in);
@@ -331,7 +331,7 @@ QList<Index::Posting> Index::postings(const Predicate &pred,
 
     // Read list.
     quint32 postCount = readVInt(in);
-    for (int i = 0; i < postCount; ++i) {
+    for (quint32 i = 0; i < postCount; ++i) {
       quint32 proxPos;
       Posting posting;
       posting.id = readVInt(in);
@@ -373,7 +373,7 @@ QMap<Index::Field, QStringList> Index::fieldMap(const QString &prefix) const {
     // Read list.
     QString name = it->key;
     quint32 postCount = readVInt(in);
-    for (int i = 0; i < postCount; ++i) {
+    for (quint32 i = 0; i < postCount; ++i) {
       quint8 field;
       quint32 proxPos;
       readVInt(in); // Discard id.
@@ -508,7 +508,7 @@ void Index::readPositions(QDataStream &in, QVector<quint32> &positions) {
   quint32 prev = 0;
   quint32 count = readVInt(in);
   positions.reserve(count);
-  for (int i = 0; i < count; ++i) {
+  for (quint32 i = 0; i < count; ++i) {
     // Convert to absolute from delta.
     quint32 position = prev + readVInt(in);
     positions.append(position);

--- a/src/index/Query.cpp
+++ b/src/index/Query.cpp
@@ -74,7 +74,23 @@ public:
           return (tmp < date);
         case Index::After:
           return (tmp > date);
-        default:
+        case Index::Id:         // fall through
+        case Index::Author:     // fall through
+        case Index::Email:      // fall through
+        case Index::Message:    // fall through
+        case Index::Date:       // fall through
+        case Index::Path:       // fall through
+        case Index::File:       // fall through
+        case Index::Scope:      // fall through
+        case Index::Context:    // fall through
+        case Index::Addition:   // fall through
+        case Index::Deletion:   // fall through
+        case Index::Any:        // fall through
+        case Index::Comment:    // fall through
+        case Index::String:     // fall through
+        case Index::Identifier: // fall through
+        case Index::Is:         // fall through
+        case Index::Pathspec:
           Q_ASSERT(false);
           return false;
       }

--- a/src/index/Query.cpp
+++ b/src/index/Query.cpp
@@ -182,24 +182,24 @@ public:
     QList<git::Commit> rhs = mRhs->commits(index);
     QList<git::Commit> commits = mLhs->commits(index);
     if (mKind == And) {
-      // Remove commits that don't match the right hand side.
-      #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+// Remove commits that don't match the right hand side.
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
       QSet<git::Commit> set(rhs.begin(), rhs.end());
-      #else
+#else
       QSet<git::Commit> set = QSet<git::Commit>::fromList(rhs);
-      #endif
+#endif
       QMutableListIterator<git::Commit> it(commits);
       while (it.hasNext()) {
         if (!set.contains(it.next()))
           it.remove();
       }
     } else {
-      // Add commits that aren't already in the result set.
-      #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+// Add commits that aren't already in the result set.
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
       QSet<git::Commit> set(commits.begin(), commits.end());
-      #else
+#else
       QSet<git::Commit> set = QSet<git::Commit>::fromList(commits);
-      #endif
+#endif
       foreach (const git::Commit &commit, rhs) {
         if (!set.contains(commit))
           commits.append(commit);

--- a/src/index/Query.cpp
+++ b/src/index/Query.cpp
@@ -183,7 +183,7 @@ public:
     QList<git::Commit> commits = mLhs->commits(index);
     if (mKind == And) {
       // Remove commits that don't match the right hand side.
-      QSet<git::Commit> set = QSet<git::Commit>::fromList(rhs);
+      QSet<git::Commit> set(rhs.begin(), rhs.end());
       QMutableListIterator<git::Commit> it(commits);
       while (it.hasNext()) {
         if (!set.contains(it.next()))
@@ -191,7 +191,7 @@ public:
       }
     } else {
       // Add commits that aren't already in the result set.
-      QSet<git::Commit> set = QSet<git::Commit>::fromList(commits);
+      QSet<git::Commit> set(commits.begin(), commits.end());
       foreach (const git::Commit &commit, rhs) {
         if (!set.contains(commit))
           commits.append(commit);

--- a/src/index/Query.cpp
+++ b/src/index/Query.cpp
@@ -183,7 +183,11 @@ public:
     QList<git::Commit> commits = mLhs->commits(index);
     if (mKind == And) {
       // Remove commits that don't match the right hand side.
+      #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
       QSet<git::Commit> set(rhs.begin(), rhs.end());
+      #else
+      QSet<git::Commit> set = QSet<git::Commit>::fromList(rhs);
+      #endif
       QMutableListIterator<git::Commit> it(commits);
       while (it.hasNext()) {
         if (!set.contains(it.next()))
@@ -191,7 +195,11 @@ public:
       }
     } else {
       // Add commits that aren't already in the result set.
+      #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
       QSet<git::Commit> set(commits.begin(), commits.end());
+      #else
+      QSet<git::Commit> set = QSet<git::Commit>::fromList(commits);
+      #endif
       foreach (const git::Commit &commit, rhs) {
         if (!set.contains(commit))
           commits.append(commit);

--- a/src/index/Query.cpp
+++ b/src/index/Query.cpp
@@ -74,23 +74,7 @@ public:
           return (tmp < date);
         case Index::After:
           return (tmp > date);
-        case Index::Id:         // fall through
-        case Index::Author:     // fall through
-        case Index::Email:      // fall through
-        case Index::Message:    // fall through
-        case Index::Date:       // fall through
-        case Index::Path:       // fall through
-        case Index::File:       // fall through
-        case Index::Scope:      // fall through
-        case Index::Context:    // fall through
-        case Index::Addition:   // fall through
-        case Index::Deletion:   // fall through
-        case Index::Any:        // fall through
-        case Index::Comment:    // fall through
-        case Index::String:     // fall through
-        case Index::Identifier: // fall through
-        case Index::Is:         // fall through
-        case Index::Pathspec:
+        default:
           Q_ASSERT(false);
           return false;
       }

--- a/src/index/indexer.cpp
+++ b/src/index/indexer.cpp
@@ -105,7 +105,7 @@ void log(QFile *out, const QString &text) {
     return;
 
   QString time = QTime::currentTime().toString(Qt::ISODateWithMs);
-  QTextStream(out) << time << " - " << text << endl;
+  QTextStream(out) << time << " - " << text << Qt::endl;
 }
 
 void log(QFile *out, const QString &fmt, const git::Id &id) {
@@ -405,7 +405,7 @@ public:
     int count = 0;
     QList<git::Commit> commits;
     git::Commit commit = mWalker.next();
-    QSet<git::Id> ids = QSet<git::Id>::fromList(mIndex.ids());
+    QSet<git::Id> ids(mIndex.ids().begin(), mIndex.ids().end());
     while (commit.isValid() && count < 8192) {
       // Don't index merge commits.
       if (!commit.isMerge() && !ids.contains(commit.id())) {
@@ -440,7 +440,7 @@ public:
       // Write to disk.
       log(mOut, "start write");
       if (mIndex.write(mWatcher.result()) && mNotify)
-        QTextStream(stdout) << "write" << endl;
+        QTextStream(stdout) << "write" << Qt::endl;
       log(mOut, "end write");
 
       // Restart.

--- a/src/index/indexer.cpp
+++ b/src/index/indexer.cpp
@@ -149,7 +149,22 @@ void index(const Lexer::Lexeme &lexeme, Intermediate::FieldMap &fields,
         case Lexer::Comment:
           field |= Index::Comment;
           break;
-        default:
+        case Lexer::Nothing:      // fall through
+        case Lexer::Whitespace:   // fall through
+        case Lexer::Number:       // fall through
+        case Lexer::Keyword:      // fall through
+        case Lexer::Identifier:   // fall through
+        case Lexer::Operator:     // fall through
+        case Lexer::Error:        // fall through
+        case Lexer::Preprocessor: // fall through
+        case Lexer::Constant:     // fall through
+        case Lexer::Variable:     // fall through
+        case Lexer::Function:     // fall through
+        case Lexer::Class:        // fall through
+        case Lexer::Type:         // fall through
+        case Lexer::Label:        // fall through
+        case Lexer::Regex:        // fall through
+        case Lexer::Embedded:     // fall through
           break;
       }
 
@@ -173,7 +188,13 @@ void index(const Lexer::Lexeme &lexeme, Intermediate::FieldMap &fields,
       break;
 
     // Ignore everything else.
-    default:
+    case Lexer::Nothing:    // fall through
+    case Lexer::Whitespace: // fall through
+    case Lexer::Number:     // fall through
+    case Lexer::Operator:   // fall through
+    case Lexer::Error:      // fall through
+    case Lexer::Regex:      // fall through
+    case Lexer::Embedded:   // fall through
       break;
   }
 }
@@ -456,10 +477,14 @@ public:
 
   bool nativeEventFilter(const QByteArray &type, void *message,
                          long *result) override {
+    Q_UNUSED(result);
 #ifdef Q_OS_WIN
     MSG *msg = static_cast<MSG *>(message);
     if (msg->message == WM_CLOSE)
       cancel();
+#else
+    Q_UNUSED(type);
+    Q_UNUSED(message);
 #endif
 
     return false;

--- a/src/index/indexer.cpp
+++ b/src/index/indexer.cpp
@@ -407,11 +407,11 @@ public:
     QList<git::Commit> commits;
     git::Commit commit = mWalker.next();
 
-    #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     QSet<git::Id> ids(mIndex.ids().begin(), mIndex.ids().end());
-    #else
+#else
     QSet<git::Id> ids = QSet<git::Id>::fromList(mIndex.ids());
-    #endif
+#endif
     while (commit.isValid() && count < 8192) {
       // Don't index merge commits.
       if (!commit.isMerge() && !ids.contains(commit.id())) {

--- a/src/index/indexer.cpp
+++ b/src/index/indexer.cpp
@@ -10,6 +10,7 @@
 #include "Index.h"
 #include "GenericLexer.h"
 #include "LPegLexer.h"
+#include "qtsupport.h"
 #include "conf/Settings.h"
 #include "git/Config.h"
 #include "git/Index.h"
@@ -405,7 +406,12 @@ public:
     int count = 0;
     QList<git::Commit> commits;
     git::Commit commit = mWalker.next();
+
+    #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     QSet<git::Id> ids(mIndex.ids().begin(), mIndex.ids().end());
+    #else
+    QSet<git::Id> ids = QSet<git::Id>::fromList(mIndex.ids());
+    #endif
     while (commit.isValid() && count < 8192) {
       // Don't index merge commits.
       if (!commit.isMerge() && !ids.contains(commit.id())) {

--- a/src/index/indexer.cpp
+++ b/src/index/indexer.cpp
@@ -353,7 +353,7 @@ private:
   QFile *mOut;
 
   int mContextLines = 3;
-  int mTermLimit = 1000000;
+  quint32 mTermLimit = 1000000;
 };
 
 class Reduce {

--- a/src/index/lexer_test.cpp
+++ b/src/index/lexer_test.cpp
@@ -29,7 +29,7 @@ void print(QTextStream &out, const Lexer::Lexeme &lexeme, int indent = 0) {
   out << lexeme.text << " - " << lexeme.token;
   if (lexeme.token < kStyleNames.length())
     out << " (" << kStyleNames.at(lexeme.token) << ")";
-  out << endl;
+  out << Qt::endl;
 }
 
 void print(QTextStream &out, Lexer *lexer, int indent = 0) {
@@ -102,7 +102,7 @@ int main(int argc, char *argv[]) {
     // Lex buffer.
     Lexer *lexer = lexers.value(name);
     if (lexer->lex(buffer)) {
-      out << name << " - " << arg << ":" << endl;
+      out << name << " - " << arg << ":" << Qt::endl;
       print(out, lexer);
     }
   }

--- a/src/index/lexer_test.cpp
+++ b/src/index/lexer_test.cpp
@@ -66,7 +66,13 @@ void print(QTextStream &out, Lexer *lexer, int indent = 0) {
         break;
 
       // Ignore everything else.
-      default:
+      case Lexer::Whitespace: // fall through
+      case Lexer::Nothing:    // fall through
+      case Lexer::Number:     // fall through
+      case Lexer::Operator:   // fall through
+      case Lexer::Error:      // fall through
+      case Lexer::Regex:      // fall through
+      case Lexer::Embedded:
         break;
     }
   }

--- a/src/index/lexer_test.cpp
+++ b/src/index/lexer_test.cpp
@@ -9,6 +9,7 @@
 
 #include "GenericLexer.h"
 #include "LPegLexer.h"
+#include "qtsupport.h"
 #include "conf/Settings.h"
 #include <QCoreApplication>
 #include <QFile>

--- a/src/log/LogModel.cpp
+++ b/src/log/LogModel.cpp
@@ -9,6 +9,7 @@
 
 #include "LogModel.h"
 #include "LogEntry.h"
+#include <QLocale>
 #include <QStyle>
 
 namespace {
@@ -74,8 +75,8 @@ QVariant LogModel::data(const QModelIndex &index, int role) const {
               QDateTime date = entry->timestamp();
               QString timestamp =
                   (date.date() == QDate::currentDate())
-                      ? date.time().toString(Qt::DefaultLocaleShortDate)
-                      : date.toString(Qt::DefaultLocaleShortDate);
+                      ? QLocale().toString(date.time(), QLocale::ShortFormat)
+                      : QLocale().toString(date, QLocale::ShortFormat);
               text = kTimeFmt.arg(timestamp, text);
             }
           }

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -613,12 +613,9 @@ QVariant Plugin::optionValue(const QString &key) const {
 
     case String:
       return config().value<QString>(kKeyFmt.arg(mName, key), value.toString());
-
-    default:
-      throw std::runtime_error(
-          "Not Implemented or invalid enum" +
-          std::to_string(static_cast<int>(optionKind(key))));
   }
+  throw std::runtime_error("unreachable; value=" +
+                            std::to_string(static_cast<int>(optionKind(key))));
 }
 
 Plugin::OptionKind Plugin::optionKind(const QString &key) const {

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -491,7 +491,7 @@ Plugin::Plugin(const QString &file, const git::Repository &repo,
 
   // Print error messages to the console.
   connect(this, &Plugin::error, [](const QString &msg) {
-    QTextStream(stderr) << "plugin error: " << msg << endl;
+    QTextStream(stderr) << "plugin error: " << msg << Qt::endl;
   });
 
   // Load libraries.
@@ -612,6 +612,9 @@ QVariant Plugin::optionValue(const QString &key) const {
 
     case String:
       return config().value<QString>(kKeyFmt.arg(mName, key), value.toString());
+
+    default:
+      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(optionKind(key))));
   }
 }
 

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -615,7 +615,7 @@ QVariant Plugin::optionValue(const QString &key) const {
       return config().value<QString>(kKeyFmt.arg(mName, key), value.toString());
   }
   throw std::runtime_error("unreachable; value=" +
-                            std::to_string(static_cast<int>(optionKind(key))));
+                           std::to_string(static_cast<int>(optionKind(key))));
 }
 
 Plugin::OptionKind Plugin::optionKind(const QString &key) const {

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -8,6 +8,7 @@
 //
 
 #include "Plugin.h"
+#include "qtsupport.h"
 #include "conf/Settings.h"
 #include "editor/TextEditor.h"
 #include "git/Config.h"

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -615,7 +615,9 @@ QVariant Plugin::optionValue(const QString &key) const {
       return config().value<QString>(kKeyFmt.arg(mName, key), value.toString());
 
     default:
-      throw std::runtime_error("Not Implemented or invalid enum" + std::to_string(static_cast<int>(optionKind(key))));
+      throw std::runtime_error(
+          "Not Implemented or invalid enum" +
+          std::to_string(static_cast<int>(optionKind(key))));
   }
 }
 

--- a/src/qtsupport.h
+++ b/src/qtsupport.h
@@ -6,12 +6,11 @@
 #include <QTextStream>
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-namespace Qt
-{
-    static auto endl = ::endl;
-    static auto KeepEmptyParts = QString::KeepEmptyParts;
-    static auto SkipEmptyParts = QString::SkipEmptyParts;
-}
+namespace Qt {
+static auto endl = ::endl;
+static auto KeepEmptyParts = QString::KeepEmptyParts;
+static auto SkipEmptyParts = QString::SkipEmptyParts;
+} // namespace Qt
 
 // QButtonGroup::buttonClicked is deprecated in favor of QButtonGroup::idClicked
 #define idClicked buttonClicked

--- a/src/qtsupport.h
+++ b/src/qtsupport.h
@@ -1,0 +1,18 @@
+/// Backwards compatibility for older versions of QT
+/// Several symbols have been deprecated in QT5.14 and moved to new
+/// namespaces. This file provides support for older versions of QT.
+
+#include <QString>
+#include <QTextStream>
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+namespace Qt
+{
+    static auto endl = ::endl;
+    static auto KeepEmptyParts = QString::KeepEmptyParts;
+    static auto SkipEmptyParts = QString::SkipEmptyParts;
+}
+
+// QButtonGroup::buttonClicked is deprecated in favor of QButtonGroup::idClicked
+#define idClicked buttonClicked
+#endif

--- a/src/ui/BlameMargin.cpp
+++ b/src/ui/BlameMargin.cpp
@@ -110,7 +110,7 @@ bool BlameMargin::event(QEvent *event) {
     git::Signature signature = mBlame.signature(index);
     if (signature.isValid()) {
       email = QString("&lt;%1&gt;").arg(signature.email());
-      date = signature.date().toString(Qt::DefaultLocaleLongDate);
+      date = QLocale().toString(signature.date(), QLocale::LongFormat);
     }
 
     if (!name.isEmpty())
@@ -223,8 +223,8 @@ void BlameMargin::paintEvent(QPaintEvent *event) {
     if (signature.isValid()) {
       QDateTime dateTime = signature.date();
       date = (dateTime.date() == today)
-                 ? dateTime.time().toString(Qt::DefaultLocaleShortDate)
-                 : dateTime.date().toString(Qt::DefaultLocaleShortDate);
+                 ? QLocale().toString(dateTime.time(), QLocale::ShortFormat)
+                 : QLocale().toString(dateTime.date(), QLocale::ShortFormat);
       time = dateTime.toTime_t();
     }
 
@@ -284,8 +284,8 @@ void BlameMargin::paintEvent(QPaintEvent *event) {
       QDateTime dateTime = signature.date();
       QString longDate =
           (dateTime.date() == today)
-              ? dateTime.time().toString(Qt::DefaultLocaleLongDate)
-              : dateTime.date().toString(Qt::DefaultLocaleLongDate);
+              ? QLocale().toString(dateTime.time(), QLocale::LongFormat)
+              : QLocale().toString(dateTime.date(), QLocale::LongFormat);
 
       QRectF dateRect = regularMetrics.boundingRect(longDate);
       if (nameRect.width() + dateRect.width() + 4 <= rect.width())

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -791,8 +791,8 @@ public:
       QDateTime date = commit.committer().date().toLocalTime();
       QString timestamp =
           (date.date() == QDate::currentDate())
-              ? date.time().toString(Qt::DefaultLocaleShortDate)
-              : date.date().toString(Qt::DefaultLocaleShortDate);
+              ? QLocale().toString(date.time(), QLocale::ShortFormat)
+              : QLocale().toString(date.date(), QLocale::ShortFormat);
       int timestampWidth = fm.horizontalAdvance(timestamp);
 
       if (compact) {

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -1239,6 +1239,7 @@ git::Diff CommitList::selectedDiff() const {
   DebugRefresh("Selected indices count: " << indexes.count());
   for (const auto &index : indexes) {
     const auto &id = index.data(CommitRole).value<git::Commit>().shortId();
+    (void)id; // Unused in release builds
     DebugRefresh("Commit: " << id);
   }
   if (indexes.isEmpty())

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -1186,6 +1186,7 @@ CommitList::CommitList(Index *index, QWidget *parent)
   connect(model, &CommitModel::statusFinished, [this, model](bool visible) {
     mRestoreSelection = true; // Reset to default
     // Fake a selection notification if the diff is visible and selected.
+    // FIXME: Should we reference `model` or `this->mModel` here?
     if (visible && selectionModel()->isSelected(mModel->index(0, 0)))
       resetSelection();
 

--- a/src/ui/DetailView.cpp
+++ b/src/ui/DetailView.cpp
@@ -139,8 +139,8 @@ public:
     if (mSameAuthorCommitter)
       height = qMax(qMax(author.height(), committer.height()), date.height());
     else
-      height =
-          qMax(author.height(), date.height()) + committer.height() + mSpacing.y();
+      height = qMax(author.height(), date.height()) + committer.height() +
+               mSpacing.y();
     return QSize(width, height);
   }
 
@@ -153,8 +153,8 @@ public:
     if (mSameAuthorCommitter)
       height = qMax(qMax(author.height(), committer.height()), date.height());
     else
-      height =
-          qMax(author.height(), date.height()) + committer.height() + mSpacing.y();
+      height = qMax(author.height(), date.height()) + committer.height() +
+               mSpacing.y();
     return QSize(width, height);
   }
 
@@ -202,8 +202,9 @@ private:
 
     bool wrapped = (width() < sizeHint().width());
     int x = wrapped ? 0 : width() - mDate->width();
-    int y =
-        wrapped ? mAuthor->height() + mCommitter->height() + 2 * mSpacing.y() : 0;
+    int y = wrapped
+                ? mAuthor->height() + mCommitter->height() + 2 * mSpacing.y()
+                : 0;
     mDate->move(x, y);
     updateGeometry();
   }
@@ -351,7 +352,8 @@ public:
       QDate lastDate = last.committer().date().toLocalTime().date();
       QDate firstDate = first.committer().date().toLocalTime().date();
       QString lastDateStr = QLocale().toString(lastDate, QLocale::ShortFormat);
-      QString firstDateStr = QLocale().toString(firstDate, QLocale::ShortFormat);
+      QString firstDateStr =
+          QLocale().toString(firstDate, QLocale::ShortFormat);
       QString dateStr = (lastDate == firstDate)
                             ? lastDateStr
                             : kDateRangeFmt.arg(lastDateStr, firstDateStr);

--- a/src/ui/DetailView.cpp
+++ b/src/ui/DetailView.cpp
@@ -38,6 +38,7 @@
 #include <QNetworkRequest>
 #include <QPainter>
 #include <QPainterPath>
+#include <QPoint>
 #include <QPushButton>
 #include <QRegularExpression>
 #include <QStackedWidget>
@@ -121,7 +122,8 @@ public:
     mDate = new QLabel(this);
     mDate->setTextInteractionFlags(kTextFlags);
 
-    mSpacing = style()->pixelMetric(QStyle::PM_DefaultLayoutSpacing);
+    mSpacing.setX(style()->pixelMetric(QStyle::PM_LayoutHorizontalSpacing));
+    mSpacing.setY(style()->pixelMetric(QStyle::PM_LayoutVerticalSpacing));
   }
 
   void moveEvent(QMoveEvent *event) override { updateLayout(); }
@@ -132,13 +134,13 @@ public:
     QSize date = mDate->sizeHint();
     QSize author = mAuthor->sizeHint();
     QSize committer = mCommitter->sizeHint();
-    int width = author.width() + date.width() + mSpacing;
+    int width = author.width() + date.width() + mSpacing.x();
     int height;
     if (mSameAuthorCommitter)
       height = qMax(qMax(author.height(), committer.height()), date.height());
     else
       height =
-          qMax(author.height(), date.height()) + committer.height() + mSpacing;
+          qMax(author.height(), date.height()) + committer.height() + mSpacing.y();
     return QSize(width, height);
   }
 
@@ -152,7 +154,7 @@ public:
       height = qMax(qMax(author.height(), committer.height()), date.height());
     else
       height =
-          qMax(author.height(), date.height()) + committer.height() + mSpacing;
+          qMax(author.height(), date.height()) + committer.height() + mSpacing.y();
     return QSize(width, height);
   }
 
@@ -165,8 +167,8 @@ public:
     bool wrapped = (width < sizeHint().width());
     int unwrappedHeight = mSameAuthorCommitter
                               ? qMax(committer, qMax(author, date))
-                              : qMax(author + committer + mSpacing, date);
-    return wrapped ? (author + committer + date + 2 * mSpacing)
+                              : qMax(author + committer + mSpacing.y(), date);
+    return wrapped ? (author + committer + date + 2 * mSpacing.y())
                    : unwrappedHeight;
   }
 
@@ -196,12 +198,12 @@ private:
   void updateLayout() {
     mAuthor->move(0, 0);
     if (mCommitter->isVisible())
-      mCommitter->move(0, mAuthor->height() + mSpacing);
+      mCommitter->move(0, mAuthor->height() + mSpacing.y());
 
     bool wrapped = (width() < sizeHint().width());
     int x = wrapped ? 0 : width() - mDate->width();
     int y =
-        wrapped ? mAuthor->height() + mCommitter->height() + 2 * mSpacing : 0;
+        wrapped ? mAuthor->height() + mCommitter->height() + 2 * mSpacing.y() : 0;
     mDate->move(x, y);
     updateGeometry();
   }
@@ -210,7 +212,7 @@ private:
   QLabel *mCommitter;
   QLabel *mDate;
 
-  int mSpacing;
+  QPoint mSpacing;
   bool mSameAuthorCommitter{false};
 };
 
@@ -348,8 +350,8 @@ public:
       // Set date range.
       QDate lastDate = last.committer().date().toLocalTime().date();
       QDate firstDate = first.committer().date().toLocalTime().date();
-      QString lastDateStr = lastDate.toString(Qt::DefaultLocaleShortDate);
-      QString firstDateStr = firstDate.toString(Qt::DefaultLocaleShortDate);
+      QString lastDateStr = QLocale().toString(lastDate, QLocale::ShortFormat);
+      QString firstDateStr = QLocale().toString(firstDate, QLocale::ShortFormat);
       QString dateStr = (lastDate == firstDate)
                             ? lastDateStr
                             : kDateRangeFmt.arg(lastDateStr, firstDateStr);
@@ -387,7 +389,7 @@ public:
     QDateTime date = commit.committer().date().toLocalTime();
     mHash->setText(brightText(tr("Id:")) + " " + commit.shortId());
     mAuthorCommitterDate->setDate(
-        brightText(date.toString(Qt::DefaultLocaleLongDate)));
+        brightText(QLocale().toString(date, QLocale::LongFormat)));
     mAuthorCommitterDate->setAuthorCommitter(
         kAuthorFmt.arg(author.name(), author.email()),
         kAuthorFmt.arg(committer.name(), committer.email()));

--- a/src/ui/DiffTreeModel.cpp
+++ b/src/ui/DiffTreeModel.cpp
@@ -430,10 +430,7 @@ void Node::addChild(const QStringList &pathPart, int patchIndex,
 
 git::Index::StagedState
 Node::stageState(const git::Index &idx, ParentStageState searchingState) const {
-  if (!hasChildren())
-    return idx.isStaged(path(true));
-
-  git::Index::StagedState childState;
+  git::Index::StagedState childState = idx.isStaged(path(true));
   for (auto child : mChildren) {
 
     childState = child->stageState(idx, searchingState);

--- a/src/ui/DiffView/Comment.cpp
+++ b/src/ui/DiffView/Comment.cpp
@@ -25,7 +25,7 @@ Comment::Comment(const QDateTime &date, const Account::Comment &comment,
   QTextCharFormat timestamp;
   timestamp.setForeground(theme->remoteComment(Theme::Comment::Timestamp));
   cursor.setCharFormat(timestamp);
-  cursor.insertText(date.toString(Qt::DefaultLocaleLongDate));
+  cursor.insertText(QLocale().toString(date, QLocale::LongFormat));
 
   QTextBlockFormat indent;
   indent.setLeftMargin(fontMetrics().horizontalAdvance(' ') *

--- a/src/ui/DiffView/FileWidget.cpp
+++ b/src/ui/DiffView/FileWidget.cpp
@@ -85,7 +85,7 @@ _FileWidget::Header::Header(const git::Diff &diff, const git::Patch &patch,
 
     git::RepositoryNotifier *notifier = patch.repo().notifier();
     connect(notifier, &git::RepositoryNotifier::lfsLocksChanged, this,
-            [this, patch, lfsLockButton] {
+            [patch, lfsLockButton] {
               bool locked = patch.repo().lfsIsLocked(patch.name());
               lfsLockButton->setText(locked ? FileWidget::tr("Unlock")
                                             : FileWidget::tr("Lock"));
@@ -560,10 +560,7 @@ void FileWidget::updatePatch(const git::Patch &patch, const git::Patch &staged,
     int hunkCount = patch.count();
     for (int hidx = 0; hidx < hunkCount; ++hidx) {
       HunkWidget *hunk = addHunk(mDiff, patch, staged, hidx, lfs, submodule);
-      int startLine = patch.lineNumber(hidx, 0, git::Diff::OldFile);
-      // hunk->header()->check()->setChecked(stagedHunks.contains(startLine));
-      // // not correct, because it could also only a part of the hunk staged
-      // (single lines)
+      patch.lineNumber(hidx, 0, git::Diff::OldFile);
       mHunkLayout->addWidget(hunk);
     }
   } else {
@@ -786,7 +783,7 @@ void FileWidget::discard() {
                              : FileWidget::tr("Discard Changes");
   QPushButton *discard = dialog->addButton(button, QMessageBox::AcceptRole);
   connect(discard, &QPushButton::clicked,
-          [this, untracked] { emit discarded(mModelIndex); });
+          [this] { emit discarded(mModelIndex); });
 
   dialog->exec();
 }

--- a/src/ui/DiffView/HunkWidget.cpp
+++ b/src/ui/DiffView/HunkWidget.cpp
@@ -785,7 +785,7 @@ void HunkWidget::load(git::Patch &staged, bool force) {
         mHeader->theirsButton()->click();
         break;
 
-      default:
+      case git::Patch::Unresolved:
         break;
     }
   }

--- a/src/ui/DiffView/HunkWidget.cpp
+++ b/src/ui/DiffView/HunkWidget.cpp
@@ -1125,7 +1125,7 @@ void HunkWidget::createMarkersAndLineNumbers(const Line &line, int lidx,
       }
 
       QString author = comment.author;
-      QString time = key.toString(Qt::DefaultLocaleLongDate);
+      QString time = QLocale().toString(key, QLocale::LongFormat);
       QString body = paragraphs.join('\n');
       QString text = author + ' ' + time + '\n' + body;
       QByteArray styles =
@@ -1164,18 +1164,18 @@ QByteArray HunkWidget::hunk() const {
     int mask = mEditor->markers(i);
     if (mask & 1 << TextEditor::Marker::Addition) {
       if (!(mask & 1 << TextEditor::Marker::DiscardMarker)) {
-        ar.append(mEditor->line(i));
+        ar.append(mEditor->line(i).toUtf8());
         appended = true;
       }
     } else if (mask & 1 << TextEditor::Marker::Deletion) {
       if (mask & 1 << TextEditor::Marker::DiscardMarker) {
         // with a discard, a deletion becomes reverted
         // and the line is still present
-        ar.append(mEditor->line(i));
+        ar.append(mEditor->line(i).toUtf8());
         appended = true;
       }
     } else {
-      ar.append(mEditor->line(i));
+      ar.append(mEditor->line(i).toUtf8());
       appended = true;
     }
 
@@ -1198,16 +1198,16 @@ QByteArray HunkWidget::apply() {
     int mask = mEditor->markers(i);
     if (mask & 1 << TextEditor::Marker::Addition) {
       if (mask & 1 << TextEditor::Marker::StagedMarker) {
-        ar.append(mEditor->line(i));
+        ar.append(mEditor->line(i).toUtf8());
         appended = true;
       }
     } else if (mask & 1 << TextEditor::Marker::Deletion) {
       if (!(mask & 1 << TextEditor::Marker::StagedMarker)) {
-        ar.append(mEditor->line(i));
+        ar.append(mEditor->line(i).toUtf8());
         appended = true;
       }
     } else {
-      ar.append(mEditor->line(i));
+      ar.append(mEditor->line(i).toUtf8());
       appended = true;
     }
 

--- a/src/ui/DiffView/HunkWidget.cpp
+++ b/src/ui/DiffView/HunkWidget.cpp
@@ -497,8 +497,6 @@ void HunkWidget::unstageSelected(int startLine, int end, bool emitSignal) {
 
 void HunkWidget::discardDialog(int startLine, int end) {
   QString name = mPatch.name();
-  int line = mPatch.lineNumber(mIndex, 0, git::Diff::NewFile);
-
   QString title = HunkWidget::tr("Discard selected lines?");
   QString text =
       mPatch.isUntracked()

--- a/src/ui/EditorWindow.cpp
+++ b/src/ui/EditorWindow.cpp
@@ -97,7 +97,27 @@ void EditorWindow::closeEvent(QCloseEvent *event) {
       case QMessageBox::Save:
         editor->save();
         break;
-      default:
+      case QMessageBox::NoButton:
+      case QMessageBox::SaveAll:
+      case QMessageBox::Open:
+      case QMessageBox::Yes:
+      case QMessageBox::No:
+      case QMessageBox::Abort:
+      case QMessageBox::Retry:
+      case QMessageBox::Ignore:
+      case QMessageBox::Close:
+      case QMessageBox::Discard:
+      case QMessageBox::Help:
+      case QMessageBox::Apply:
+      case QMessageBox::Reset:
+      case QMessageBox::RestoreDefaults:
+      case QMessageBox::FirstButton:
+      case QMessageBox::YesAll:
+      case QMessageBox::NoAll:
+      case QMessageBox::Default:
+      case QMessageBox::Escape:
+      case QMessageBox::FlagMask:
+      case QMessageBox::ButtonMask:
         break;
     }
   }

--- a/src/ui/EditorWindow.cpp
+++ b/src/ui/EditorWindow.cpp
@@ -97,27 +97,8 @@ void EditorWindow::closeEvent(QCloseEvent *event) {
       case QMessageBox::Save:
         editor->save();
         break;
-      case QMessageBox::NoButton:
-      case QMessageBox::SaveAll:
-      case QMessageBox::Open:
-      case QMessageBox::Yes:
-      case QMessageBox::No:
-      case QMessageBox::Abort:
-      case QMessageBox::Retry:
-      case QMessageBox::Ignore:
-      case QMessageBox::Close:
-      case QMessageBox::Discard:
-      case QMessageBox::Help:
-      case QMessageBox::Apply:
-      case QMessageBox::Reset:
-      case QMessageBox::RestoreDefaults:
-      case QMessageBox::FirstButton:
-      case QMessageBox::YesAll:
-      case QMessageBox::NoAll:
-      case QMessageBox::Default:
-      case QMessageBox::Escape:
-      case QMessageBox::FlagMask:
-      case QMessageBox::ButtonMask:
+      default:
+        // no-op
         break;
     }
   }

--- a/src/ui/FileContextMenu.cpp
+++ b/src/ui/FileContextMenu.cpp
@@ -71,7 +71,14 @@ void handlePath(const git::Repository &repo, const QString &path,
         untracked.append(path);
         break;
 
-      default:
+      case GIT_DELTA_UNMODIFIED: // fall through
+      case GIT_DELTA_ADDED:      // fall through
+      case GIT_DELTA_RENAMED:    // fall through
+      case GIT_DELTA_COPIED:     // fall through
+      case GIT_DELTA_IGNORED:    // fall through
+      case GIT_DELTA_TYPECHANGE: // fall through
+      case GIT_DELTA_UNREADABLE: // fall through
+      case GIT_DELTA_CONFLICTED: // fall through
         break;
     }
   }
@@ -115,7 +122,8 @@ FileContextMenu::FileContextMenu(RepoView *view, const QStringList &files,
           mergeTools.append(tool);
           break;
 
-        default:
+        case ExternalTool::Show: // fall through
+        case ExternalTool::Edit:
           Q_ASSERT(false);
           break;
       }

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -193,7 +193,7 @@ void MainWindow::setSideBarVisible(bool visible) {
 
   QTimeLine *timeline = new QTimeLine(250, this);
   timeline->setDirection(visible ? QTimeLine::Forward : QTimeLine::Backward);
-  timeline->setCurveShape(QTimeLine::LinearCurve);
+  timeline->setEasingCurve(QEasingCurve(QEasingCurve::Linear));
   timeline->setUpdateInterval(20);
 
   connect(timeline, &QTimeLine::valueChanged, [this, pos](qreal value) {

--- a/src/ui/MenuBar.cpp
+++ b/src/ui/MenuBar.cpp
@@ -364,7 +364,7 @@ MenuBar::MenuBar(QWidget *parent) : QMenuBar(parent) {
 
   mRedo = edit->addAction(tr("Redo"));
   redoHotkey.use(mRedo);
-  connect(mRedo, &QAction::triggered, [this] {
+  connect(mRedo, &QAction::triggered, [] {
     QWidget *widget = QApplication::focusWidget();
     if (TextEditor *editor = qobject_cast<TextEditor *>(widget)) {
       editor->redo();
@@ -984,6 +984,7 @@ void MenuBar::updateCutCopyPaste() {
     mPaste->setEnabled(canPaste);
     mFindSelection->setEnabled(editor->hasSelectedText());
   } else if (LogView *logView = qobject_cast<LogView *>(widget)) {
+    (void)logView; // unused
     mCopy->setEnabled(true);
   }
 }

--- a/src/ui/ReferenceModel.cpp
+++ b/src/ui/ReferenceModel.cpp
@@ -266,7 +266,8 @@ QVariant ReferenceModel::data(const QModelIndex &index, int role) const {
         QString email = QString("&lt;%1&gt;").arg(signature.email());
         lines.append(kNowrapFmt.arg(QString("%1 %2").arg(name, email)));
 
-        QString date = QLocale().toString(signature.date(), QLocale::LongFormat);
+        QString date =
+            QLocale().toString(signature.date(), QLocale::LongFormat);
         lines.append(kNowrapFmt.arg(date));
       }
 

--- a/src/ui/ReferenceModel.cpp
+++ b/src/ui/ReferenceModel.cpp
@@ -266,7 +266,7 @@ QVariant ReferenceModel::data(const QModelIndex &index, int role) const {
         QString email = QString("&lt;%1&gt;").arg(signature.email());
         lines.append(kNowrapFmt.arg(QString("%1 %2").arg(name, email)));
 
-        QString date = signature.date().toString(Qt::DefaultLocaleLongDate);
+        QString date = QLocale().toString(signature.date(), QLocale::LongFormat);
         lines.append(kNowrapFmt.arg(date));
       }
 

--- a/src/ui/ReferenceView.cpp
+++ b/src/ui/ReferenceView.cpp
@@ -321,7 +321,7 @@ void ReferenceView::contextMenuEvent(QContextMenuEvent *event) {
     git::Remote remote = ref.repo().defaultRemote();
     if (remote.isValid()) {
       menu.addAction(tr("Push Tag to %1").arg(remote.name()),
-                     [this, ref, view, remote] { view->push(remote, ref); });
+                     [ref, view, remote] { view->push(remote, ref); });
     }
   }
 

--- a/src/ui/RemoteCallbacks.cpp
+++ b/src/ui/RemoteCallbacks.cpp
@@ -7,6 +7,7 @@
 // Author: Jason Haslam
 //
 
+#include "qtsupport.h"
 #include "RemoteCallbacks.h"
 #include "conf/Settings.h"
 #include "cred/CredentialHelper.h"

--- a/src/ui/RemoteCallbacks.cpp
+++ b/src/ui/RemoteCallbacks.cpp
@@ -235,7 +235,7 @@ bool RemoteCallbacks::negotiation(
   QTextStream out(&process);
   foreach (const git::Remote::PushUpdate &update, updates)
     out << update.dstName << " " << update.dstId.toString() << " "
-        << update.srcName << " " << update.srcId.toString() << endl;
+        << update.srcName << " " << update.srcId.toString() << Qt::endl;
   process.closeWriteChannel();
 
   if (loop.exec()) {

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -17,6 +17,7 @@
 #include "MainWindow.h"
 #include "MenuBar.h"
 #include "PathspecWidget.h"
+#include "qtsupport.h"
 #include "ReferenceWidget.h"
 #include "RemoteCallbacks.h"
 #include "SearchField.h"

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -1458,7 +1458,7 @@ void RepoView::rebaseAboutToRebase(const git::Rebase rebase,
   QString beforeText = before.link();
   QString step = tr("%1/%2").arg(currIndex).arg(rebase.count());
   QString text = tr("%1 - %2").arg(step, beforeText);
-  LogEntry *entry = mRebase->addEntry(text, tr("Apply"));
+  mRebase->addEntry(text, tr("Apply"));
 }
 
 void RepoView::rebaseConflict(const git::Rebase rebase) {
@@ -2788,14 +2788,15 @@ void RepoView::refresh() { refresh(true); }
 
 void RepoView::refresh(bool restoreSelection) {
   // Fake head update.
-  uint32_t counter = 0;
   auto dtw = findChild<DoubleTreeWidget *>();
-  if (dtw)
-    counter = dtw->setDiffCounter();
-  if (mRepo.head().isValid())
+  if (dtw) {
+    dtw->setDiffCounter();
+  }
+  if (mRepo.head().isValid()) {
     DebugRefresh("Head name: " << mRepo.head().name());
-  else
+  } else {
     DebugRefresh("Head invalid");
+  }
   DebugRefresh("time: " << QDateTime::currentDateTime()
                         << " Set diff counter: " << counter);
   emit mRepo.notifier()->referenceUpdated(mRepo.head(), restoreSelection);

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -882,7 +882,7 @@ void RepoView::setLogVisible(bool visible) {
 
   QTimeLine *timeline = new QTimeLine(250, this);
   timeline->setDirection(visible ? QTimeLine::Forward : QTimeLine::Backward);
-  timeline->setCurveShape(QTimeLine::LinearCurve);
+  timeline->setEasingCurve(QEasingCurve(QEasingCurve::Linear));
   timeline->setUpdateInterval(20);
 
   connect(timeline, &QTimeLine::valueChanged, this, [this, pos](qreal value) {
@@ -907,7 +907,7 @@ LogEntry *RepoView::error(LogEntry *parent, const QString &action,
                      ? tr("Unable to %1 - %2").arg(action, detail)
                      : tr("Unable to %1 '%2' - %3").arg(action, name, detail);
 
-  QStringList items = text.split("\\n", QString::KeepEmptyParts);
+  QStringList items = text.split("\\n", Qt::KeepEmptyParts);
   if (items.last() == "\n")
     items.removeLast();
 

--- a/src/ui/RepoView.h
+++ b/src/ui/RepoView.h
@@ -41,7 +41,7 @@ class PathspecWidget;
 class ReferenceWidget;
 class RemoteCallbacks;
 class ToolBar;
-class ContributorInfo;
+struct ContributorInfo;
 
 namespace git {
 class Result;

--- a/src/ui/SideBar.cpp
+++ b/src/ui/SideBar.cpp
@@ -709,7 +709,7 @@ SideBar::SideBar(TabWidget *tabs, QWidget *parent) : QWidget(parent) {
   QAction *clone = plusMenu->addAction(tr("Clone Repository"));
   connect(clone, &QAction::triggered, [this] {
     CloneDialog *dialog = new CloneDialog(CloneDialog::Clone, this);
-    connect(dialog, &CloneDialog::accepted, [this, dialog] {
+    connect(dialog, &CloneDialog::accepted, [dialog] {
       if (MainWindow *window = MainWindow::open(dialog->path()))
         window->currentView()->addLogEntry(dialog->message(),
                                            dialog->messageTitle());
@@ -733,7 +733,7 @@ SideBar::SideBar(TabWidget *tabs, QWidget *parent) : QWidget(parent) {
   QAction *init = plusMenu->addAction(tr("Initialize New Repository"));
   connect(init, &QAction::triggered, [this] {
     CloneDialog *dialog = new CloneDialog(CloneDialog::Init, this);
-    connect(dialog, &CloneDialog::accepted, [this, dialog] {
+    connect(dialog, &CloneDialog::accepted, [dialog] {
       if (MainWindow *window = MainWindow::open(dialog->path()))
         window->currentView()->addLogEntry(dialog->message(),
                                            dialog->messageTitle());
@@ -811,7 +811,7 @@ SideBar::SideBar(TabWidget *tabs, QWidget *parent) : QWidget(parent) {
 
   QAction *clear = contextMenu->addAction(tr("Clear All Recent"));
   connect(clear, &QAction::triggered,
-          [this] { RecentRepositories::instance()->clear(); });
+          [] { RecentRepositories::instance()->clear(); });
 
   QAction *showFullPath = contextMenu->addAction(tr("Show Full Path"));
   bool recentChecked = settings.value("start/recent/fullpath").toBool();

--- a/src/ui/TabWidget.cpp
+++ b/src/ui/TabWidget.cpp
@@ -42,7 +42,7 @@ public:
         addButton(QIcon(":/clone.png"), tr("Clone repository"));
     connect(clone, &QPushButton::clicked, [this] {
       CloneDialog *dialog = new CloneDialog(CloneDialog::Clone, this);
-      connect(dialog, &CloneDialog::accepted, [this, dialog] {
+      connect(dialog, &CloneDialog::accepted, [dialog] {
         if (MainWindow *window = MainWindow::open(dialog->path()))
           window->currentView()->addLogEntry(dialog->message(),
                                              dialog->messageTitle());
@@ -68,7 +68,7 @@ public:
         addButton(QIcon(":/new.png"), tr("Initialize new repository"));
     connect(init, &QPushButton::clicked, [this] {
       CloneDialog *dialog = new CloneDialog(CloneDialog::Init, this);
-      connect(dialog, &CloneDialog::accepted, [this, dialog] {
+      connect(dialog, &CloneDialog::accepted, [dialog] {
         if (MainWindow *window = MainWindow::open(dialog->path()))
           window->currentView()->addLogEntry(dialog->message(),
                                              dialog->messageTitle());

--- a/src/ui/TemplateDialog.cpp
+++ b/src/ui/TemplateDialog.cpp
@@ -296,7 +296,7 @@ void TemplateDialog::exportTemplates(QString filename) {
   }
 
   QString templatesStr;
-  for (const auto tmpl : mNew) {
+  for (const auto &tmpl : mNew) {
     QString name = tmpl.name;
     QString value = tmpl.value;
     value = value.replace(QStringLiteral("\n"), QStringLiteral("\\n"));

--- a/src/ui/ToolBar.cpp
+++ b/src/ui/ToolBar.cpp
@@ -10,6 +10,7 @@
 #include "ToolBar.h"
 #include "History.h"
 #include "MainWindow.h"
+#include "qtsupport.h"
 #include "RepoView.h"
 #include "SearchField.h"
 #include "app/Application.h"

--- a/src/ui/ToolBar.cpp
+++ b/src/ui/ToolBar.cpp
@@ -916,7 +916,7 @@ ToolBar::ToolBar(MainWindow *parent) : QToolBar(parent) {
   addWidget(mode);
 
   using Signal = void (QButtonGroup::*)(int);
-  auto signal = static_cast<Signal>(&QButtonGroup::buttonClicked);
+  auto signal = static_cast<Signal>(&QButtonGroup::idClicked);
   connect(mModeGroup, signal, [this](int index) {
     currentView()->setViewMode(static_cast<RepoView::ViewMode>(index));
   });

--- a/src/ui/ToolBar.cpp
+++ b/src/ui/ToolBar.cpp
@@ -696,7 +696,6 @@ public:
     initStyleOption(&opt);
 
     QColor color = opt.palette.buttonText().color();
-    QColor light = (isEnabled() && isActiveWindow()) ? color.lighter() : color;
 
     QPainter painter(this);
     painter.setPen(QPen(color, 1.0));
@@ -884,7 +883,7 @@ ToolBar::ToolBar(MainWindow *parent) : QToolBar(parent) {
 
   QAction *appConfigAction = configMenu->addAction(tr("Application settings"));
   connect(appConfigAction, &QAction::triggered,
-          [this] { SettingsDialog::openSharedInstance(); });
+          [] { SettingsDialog::openSharedInstance(); });
 
   addWidget(new Spacer(4, this));
 

--- a/src/ui/TreeProxy.cpp
+++ b/src/ui/TreeProxy.cpp
@@ -24,7 +24,7 @@ const QString kLinkFmt = "<a href='%1'>%2</a>";
 } // namespace
 
 TreeProxy::TreeProxy(bool staged, QObject *parent)
-    : mStaged(staged), QSortFilterProxyModel(parent) {}
+    : QSortFilterProxyModel(parent), mStaged(staged) {}
 
 TreeProxy::~TreeProxy() {}
 

--- a/src/ui/TreeProxy.h
+++ b/src/ui/TreeProxy.h
@@ -31,6 +31,7 @@ public:
   void enableFilter(bool enable) { mFilter = enable; }
 
 private:
+  using QSortFilterProxyModel::setData;
   bool filterAcceptsRow(int source_row,
                         const QModelIndex &source_parent) const override;
   bool mStaged{

--- a/src/update/Updater.cpp
+++ b/src/update/Updater.cpp
@@ -65,7 +65,7 @@ Updater::Download::~Download() { delete mFile; }
 Updater::Updater(QObject *parent) : QObject(parent) {
   // Set up connections.
   connect(&mMgr, &QNetworkAccessManager::sslErrors, this, &Updater::sslErrors);
-  connect(this, &Updater::upToDate, [this] {
+  connect(this, &Updater::upToDate, [] {
     UpToDateDialog dialog;
     dialog.exec();
   });

--- a/src/watcher/RepositoryWatcher_linux.cpp
+++ b/src/watcher/RepositoryWatcher_linux.cpp
@@ -90,7 +90,7 @@ public:
               ignored = false;
 
               // Start watching new directories.
-              int mask = (IN_CREATE | IN_ISDIR);
+              uint32_t mask = (IN_CREATE | IN_ISDIR);
               if ((event->mask & mask) == mask)
                 watch(path);
             }

--- a/src/watcher/RepositoryWatcher_win.cpp
+++ b/src/watcher/RepositoryWatcher_win.cpp
@@ -67,6 +67,7 @@ public:
           break;
 
         default:
+          // no-op
           break; // FIXME: Report error?
       }
     }

--- a/test/Setting.cpp
+++ b/test/Setting.cpp
@@ -23,9 +23,7 @@ private:
 
   template <class T, typename TId> QStringList settingsKeys() {
     QStringList settingsKeys;
-    foreach (const TId id, ids<TId>()) {
-      settingsKeys.append(T::key(id));
-    }
+    foreach (const TId id, ids<TId>()) { settingsKeys.append(T::key(id)); }
     return settingsKeys;
   }
 

--- a/test/Setting.cpp
+++ b/test/Setting.cpp
@@ -23,7 +23,9 @@ private:
 
   template <class T, typename TId> QStringList settingsKeys() {
     QStringList settingsKeys;
-    foreach (const TId id, ids<TId>()) { settingsKeys.append(T::key(id)); }
+    foreach (const TId id, ids<TId>()) {
+      settingsKeys.append(T::key(id));
+    }
     return settingsKeys;
   }
 

--- a/test/Submodule.cpp
+++ b/test/Submodule.cpp
@@ -147,14 +147,14 @@ void TestSubmodule::discardFile() {
   {
     QFile file(repo.workdir().filePath("README.md"));
     QVERIFY(file.open(QFile::WriteOnly));
-    QTextStream(&file) << "Changing readme of main repository" << endl;
+    QTextStream(&file) << "Changing readme of main repository" << Qt::endl;
     file.close();
   }
 
   {
     QFile file(repo.workdir().filePath("GittyupTestRepo/README.md"));
     QVERIFY(file.open(QFile::WriteOnly));
-    QTextStream(&file) << "Changing content of submodule readme" << endl;
+    QTextStream(&file) << "Changing content of submodule readme" << Qt::endl;
     file.close();
   }
 

--- a/test/Submodule.cpp
+++ b/test/Submodule.cpp
@@ -9,6 +9,7 @@
 
 #include "Test.h"
 
+#include "qtsupport.h"
 #include "dialogs/CloneDialog.h"
 #include "ui/MainWindow.h"
 #include "ui/RepoView.h"

--- a/test/amend.cpp
+++ b/test/amend.cpp
@@ -94,7 +94,7 @@ void TestAmend::testAmendAddFile() {
     // Add file and refresh.
     QFile file(mRepo->workdir().filePath("test"));
     QVERIFY(file.open(QFile::WriteOnly));
-    QTextStream(&file) << "This will be a test." << endl;
+    QTextStream(&file) << "This will be a test." << Qt::endl;
 
     Test::refresh(view);
 
@@ -139,7 +139,7 @@ void TestAmend::testAmendAddFile() {
   {
     QFile file(mRepo->workdir().filePath("test"));
     QVERIFY(file.open(QFile::WriteOnly));
-    QTextStream(&file) << "Changes made" << endl;
+    QTextStream(&file) << "Changes made" << Qt::endl;
 
     Test::refresh(view);
 

--- a/test/amend.cpp
+++ b/test/amend.cpp
@@ -1,5 +1,6 @@
 #include "Test.h"
 
+#include "qtsupport.h"
 #include "git/Signature.h"
 #include "git/Reference.h"
 #include "git/Tree.h"

--- a/test/index.cpp
+++ b/test/index.cpp
@@ -44,7 +44,7 @@ void TestIndex::stageAddition() {
   // Add file and refresh.
   QFile file(mRepo->workdir().filePath("test"));
   QVERIFY(file.open(QFile::WriteOnly));
-  QTextStream(&file) << "This is a test." << endl;
+  QTextStream(&file) << "This is a test." << Qt::endl;
 
   RepoView *view = mWindow->currentView();
   refresh(view);
@@ -135,11 +135,11 @@ void TestIndex::stageDirectory() {
 
   QFile file1(dir.filePath("test1"));
   QVERIFY(file1.open(QFile::WriteOnly));
-  QTextStream(&file1) << "This is a test." << endl;
+  QTextStream(&file1) << "This is a test." << Qt::endl;
 
   QFile file2(dir.filePath("test2"));
   QVERIFY(file2.open(QFile::WriteOnly));
-  QTextStream(&file2) << "This is a test." << endl;
+  QTextStream(&file2) << "This is a test." << Qt::endl;
 
   RepoView *view = mWindow->currentView();
   refresh(view);

--- a/test/index.cpp
+++ b/test/index.cpp
@@ -7,6 +7,7 @@
 // Author: Jason Haslam
 //
 
+#include "qtsupport.h"
 #include "Test.h"
 #include "ui/DoubleTreeWidget.h"
 #include "ui/MainWindow.h"

--- a/test/merge.cpp
+++ b/test/merge.cpp
@@ -7,6 +7,7 @@
 // Author: Shane Gramlich
 //
 
+#include "qtsupport.h"
 #include "Test.h"
 #include "ui/MainWindow.h"
 #include "ui/DetailView.h"

--- a/test/merge.cpp
+++ b/test/merge.cpp
@@ -54,7 +54,7 @@ void TestMerge::firstCommit() {
   // Add file and refresh.
   QFile file(mRepo->workdir().filePath("test"));
   QVERIFY(file.open(QFile::WriteOnly));
-  QTextStream(&file) << "This will be a test." << endl;
+  QTextStream(&file) << "This will be a test." << Qt::endl;
 
   RepoView *view = mWindow->currentView();
   refresh(view);
@@ -92,7 +92,7 @@ void TestMerge::secondCommit() {
 
   QFile file(mRepo->workdir().filePath("test"));
   QVERIFY(file.open(QFile::WriteOnly));
-  QTextStream(&file) << "This is a conflict." << endl;
+  QTextStream(&file) << "This is a conflict." << Qt::endl;
 
   refresh(view);
 
@@ -130,7 +130,7 @@ void TestMerge::thirdCommit() {
 
   QFile file(mRepo->workdir().filePath("test"));
   QVERIFY(file.open(QFile::WriteOnly));
-  QTextStream(&file) << "This is a test." << endl;
+  QTextStream(&file) << "This is a test." << Qt::endl;
 
   refresh(view);
 


### PR DESCRIPTION
This PR fixes all warnings (mostly deprecations) in the codebase when building against QT5.15 using both `clang` and `gcc`.

It also ensures the codebase can still be compiled with versions of QT prior to 5.14 via a new compatibility header file `qtsupport.h` and, where that was not possible, via alternate code compilation paths via a #if..else..endif. The latter approach was required for the `QSet` initializer.

Out-of-scope:
* deprecations/warnings in the dependencies

Changes:
* add default to switch statements throwing an exception on unhandled case. This removes `control reaches end of non-void function` in many functions.
* fix QT5.14 deprecations, which will also make it easier to move to QT6
  - fix QSet initialization
  - rename `endl` -> `Qt::endl`
  - rename `QString::SkipEmptyParts` -> `Qt::SkipEmptyParts`
  - and more...
* Scintilla editor 
  - add missing `override`
  - replace deprecated functions
* Settings
  - fix deprecated QDir assignment
  - code-style: replace assignment with initializers (to match QDir in this file)

NOTE: did not fix the deprecated usage of QProcess, as that requires a bit more throught as to how we should handle the list of configured commands and their arguments.

Testing:
* The unit tests pass.
* anecdotal (ie, own usage) testing showed no issues.