### PR TITLE
Feature/rename branch menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ build
 CMakeLists.txt.user
 cmake-build-debug/
 cmake-build-release/
+build
 .idea/
+.venv

--- a/cl-fmt.sh
+++ b/cl-fmt.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "`dirname "$0"`"
 
 # Variable that will hold the name of the clang-format command
@@ -7,12 +8,11 @@ FMT=""
 
 FOLDERS=("./src" "./test")
 
-# Some distros just call it clang-format. Others (e.g. Ubuntu) are insistent
-# that the version number be part of the command. We prefer clang-format if
-# that's present, otherwise we work backwards from highest version to lowest
-# version but at least 13.
-for clangfmt in clang-format{,-{1,2,3}{9,8,7,6,5,4,3}}; do
-    if which "$clangfmt" &>/dev/null; then
+# We specifically require clang-format v13. Some distros include the version
+# number in the name, others don't. Prefer the specifically-named version.
+for clangfmt in clang-format-13 clang-format
+do
+    if command -v "$clangfmt" &>/dev/null; then
         FMT="$clangfmt"
         break
     fi
@@ -22,6 +22,14 @@ done
 if [ -z "$FMT" ]; then
     echo "failed to find clang-format"
     exit 1
+fi
+
+# Check we have v13 of clang-format
+VERSION=`$FMT --version | grep -Po 'version\s\K(\d+)'`
+if [ "$VERSION" != "13" ]; then
+	echo "Found clang-format v$VERSION, but v13 is required. Please install v13 of clang-format and try again."
+	echo "On Debian-derived distributions, this can be done via: apt install clang-format-13"
+	exit 1
 fi
 
 function format() {
@@ -41,9 +49,18 @@ for dir in ${FOLDERS[@]}; do
     fi
 done
 
+# Format cmake files
+# NOTE: requires support for python venv; on Debian-like distros, this can be
+# installed using apt install python3-venv
 echo "Start formatting cmake files"
-pip install cmake-format==0.6.13
+CMAKE_FORMAT=${SCRIPT_DIR}/.venv/bin/cmake-format
+if [ ! -f "$CMAKE_FORMAT" ]; then
+	pushd ${SCRIPT_DIR}
+	python3 -m venv .venv
+	.venv/bin/pip install cmake-format==0.6.13
+	popd
+fi
 find . \
     \( -type d -path './test/dep/*' -prune \) \
     -o \( -type d -path './dep/*/*' -prune \) \
-    -o \( -name CMakeLists.txt -exec cmake-format --in-place {} + \)
+    -o \( -name CMakeLists.txt -exec "$CMAKE_FORMAT" --in-place {} + \)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,14 @@ Description
 
 #### Added
 
+* UI(Commit List): Added a right-click menu entry to rename branches.
+* UI(Main Menu): Added a menu-entry to rename the current branch.
+
 #### Changed
+
+* UI(Commit List): Collapse multiple branch and tag right-click menu entries
+                   into submenus. This affects the checkout and delete operations.
+* Fix(Build System): Force usage of clang-format v13 to ensure consistent formatting.
 
 ----
 

--- a/src/dialogs/CMakeLists.txt
+++ b/src/dialogs/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
   RebaseConflictDialog.cpp
   RemoteDialog.cpp
   RemoteTableModel.cpp
+  RenameBranchDialog.cpp
   SettingsDialog.cpp
   StartDialog.cpp
   SubmoduleDelegate.cpp

--- a/src/dialogs/RenameBranchDialog.cpp
+++ b/src/dialogs/RenameBranchDialog.cpp
@@ -28,6 +28,8 @@ RenameBranchDialog::RenameBranchDialog(const git::Repository &repo,
   setAttribute(Qt::WA_DeleteOnClose);
 
   mName = new QLineEdit(branch.name(), this);
+  mName->setSizePolicy(QSizePolicy::Ignored,QSizePolicy::Preferred);
+  mName->setMinimumWidth(QFontMetrics(mName->font()).averageCharWidth() * 40);
 
   QFormLayout *form = new QFormLayout;
   form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);

--- a/src/dialogs/RenameBranchDialog.cpp
+++ b/src/dialogs/RenameBranchDialog.cpp
@@ -1,6 +1,3 @@
-//
-//          Copyright (c) 2023, Scientific Toolworks, Inc.
-//
 // This software is licensed under the MIT License. The LICENSE.md file
 // describes the conditions under which this software may be distributed.
 //

--- a/src/dialogs/RenameBranchDialog.cpp
+++ b/src/dialogs/RenameBranchDialog.cpp
@@ -25,7 +25,7 @@ RenameBranchDialog::RenameBranchDialog(const git::Repository &repo,
   setAttribute(Qt::WA_DeleteOnClose);
 
   mName = new QLineEdit(branch.name(), this);
-  mName->setSizePolicy(QSizePolicy::Ignored,QSizePolicy::Preferred);
+  mName->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
   mName->setMinimumWidth(QFontMetrics(mName->font()).averageCharWidth() * 40);
 
   QFormLayout *form = new QFormLayout;
@@ -51,9 +51,8 @@ RenameBranchDialog::RenameBranchDialog(const git::Repository &repo,
   });
 
   // Perform the rename when the button is clicked
-  connect(rename, &QPushButton::clicked, [this, branch] {
-    git::Branch(branch).rename(mName->text());
-  });
+  connect(rename, &QPushButton::clicked,
+          [this, branch] { git::Branch(branch).rename(mName->text()); });
 }
 
 QString RenameBranchDialog::name() const { return mName->text(); }

--- a/src/dialogs/RenameBranchDialog.cpp
+++ b/src/dialogs/RenameBranchDialog.cpp
@@ -1,0 +1,60 @@
+//
+//          Copyright (c) 2023, Scientific Toolworks, Inc.
+//
+// This software is licensed under the MIT License. The LICENSE.md file
+// describes the conditions under which this software may be distributed.
+//
+// Author: Michael WERLE
+//
+
+#include "RenameBranchDialog.h"
+#include "git/Branch.h"
+#include "ui/ExpandButton.h"
+#include "ui/ReferenceList.h"
+#include "ui/RepoView.h"
+#include <QApplication>
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+RenameBranchDialog::RenameBranchDialog(const git::Repository &repo,
+                                       const git::Branch &branch,
+                                       QWidget *parent)
+    : QDialog(parent) {
+  Q_ASSERT(branch.isValid() && branch.isLocalBranch());
+  setAttribute(Qt::WA_DeleteOnClose);
+
+  mName = new QLineEdit(branch.name(), this);
+
+  QFormLayout *form = new QFormLayout;
+  form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
+  form->addRow(tr("Name:"), mName);
+
+  QDialogButtonBox *buttons = new QDialogButtonBox(this);
+  buttons->addButton(QDialogButtonBox::Cancel);
+  QPushButton *rename =
+      buttons->addButton(tr("Rename Branch"), QDialogButtonBox::AcceptRole);
+  rename->setEnabled(false);
+  connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+  connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+  QVBoxLayout *layout = new QVBoxLayout(this);
+  layout->addLayout(form);
+  layout->addWidget(buttons);
+
+  // Update button when name text changes.
+  connect(mName, &QLineEdit::textChanged, [repo, rename](const QString &text) {
+    rename->setEnabled(git::Branch::isNameValid(text) &&
+                       !repo.lookupBranch(text, GIT_BRANCH_LOCAL).isValid());
+  });
+
+  // Perform the rename when the button is clicked
+  connect(rename, &QPushButton::clicked, [this, branch] {
+    git::Branch(branch).rename(mName->text());
+  });
+}
+
+QString RenameBranchDialog::name() const { return mName->text(); }

--- a/src/dialogs/RenameBranchDialog.h
+++ b/src/dialogs/RenameBranchDialog.h
@@ -1,0 +1,37 @@
+//
+//          Copyright (c) 2016, Scientific Toolworks, Inc.
+//
+// This software is licensed under the MIT License. The LICENSE.md file
+// describes the conditions under which this software may be distributed.
+//
+// Author: Jason Haslam
+//
+
+#ifndef RENAMEBRANCHDIALOG_H
+#define RENAMEBRANCHDIALOG_H
+
+#include "git/Branch.h"
+#include <QDialog>
+
+class QLineEdit;
+
+namespace git {
+class Reference;
+class Repository;
+} // namespace git
+
+class RenameBranchDialog : public QDialog {
+  Q_OBJECT
+
+public:
+  RenameBranchDialog(const git::Repository &repo,
+                  const git::Branch &branch,
+                  QWidget *parent = nullptr);
+
+  QString name() const;
+
+private:
+  QLineEdit *mName;
+};
+
+#endif

--- a/src/dialogs/RenameBranchDialog.h
+++ b/src/dialogs/RenameBranchDialog.h
@@ -1,10 +1,7 @@
-//
-//          Copyright (c) 2016, Scientific Toolworks, Inc.
-//
 // This software is licensed under the MIT License. The LICENSE.md file
 // describes the conditions under which this software may be distributed.
 //
-// Author: Jason Haslam
+// Author: Michael WERLE
 //
 
 #ifndef RENAMEBRANCHDIALOG_H

--- a/src/dialogs/RenameBranchDialog.h
+++ b/src/dialogs/RenameBranchDialog.h
@@ -21,9 +21,8 @@ class RenameBranchDialog : public QDialog {
   Q_OBJECT
 
 public:
-  RenameBranchDialog(const git::Repository &repo,
-                  const git::Branch &branch,
-                  QWidget *parent = nullptr);
+  RenameBranchDialog(const git::Repository &repo, const git::Branch &branch,
+                     QWidget *parent = nullptr);
 
   QString name() const;
 

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -1506,6 +1506,14 @@ void CommitList::contextMenuEvent(QContextMenuEvent *event) {
           menu.addAction(tr("Delete Tag %1").arg(ref.name()),
                          [view, ref] { view->promptToDeleteTag(ref); });
         }
+        if (ref.isLocalBranch()) {
+          if (separator) {
+            menu.addSeparator();
+            separator = false;
+          }
+          menu.addAction(tr("Rename Branch %1").arg(ref.name()),
+                          [view, ref] { view->promptToRenameBranch(ref); });
+        }
         if (ref.isLocalBranch() && (view->repo().head().name() != ref.name())) {
           if (separator) {
             menu.addSeparator();

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -1520,42 +1520,39 @@ void CommitList::contextMenuEvent(QContextMenuEvent *event) {
         menu.addSeparator();
       }
       // rename branches
+      QMenu *submenu = &menu;
+      QString entryName(tr("Rename Branch %1"));
       if(rename_branches.count() > 1) {
-        auto renameMenu = menu.addMenu(tr("Rename Branch"));
-        for(const git::Reference &ref : rename_branches) {
-          renameMenu->addAction(ref.name(), [view, ref] { 
-                                view->promptToRenameBranch(ref); });
-        }
-      } else if(rename_branches.count() > 0) {
-        const git::Reference &ref(rename_branches.first());
-        menu.addAction(tr("Rename Branch %1").arg(ref.name()),
-                       [view, ref] { view->promptToRenameBranch(ref); });
+        submenu = menu.addMenu(tr("Rename Branch"));
+        entryName = QString("%1");
+      }
+      for(const git::Reference &ref : rename_branches) {
+        submenu->addAction(entryName.arg(ref.name()),
+                           [view, ref] { view->promptToRenameBranch(ref); });
       }
 
       // Delete branches
+      submenu = &menu;
+      entryName = tr("Delete Branch %1");
       if(delete_branches.count() > 1) {
-        auto deleteMenu = menu.addMenu(tr("Delete Branch"));
-        for(const git::Reference &ref : delete_branches) {
-          deleteMenu->addAction(ref.name(), [view, ref] { 
-                                view->promptToDeleteBranch(ref); });
-        }
-      } else if(delete_branches.count() > 0) {
-        const git::Reference &ref(rename_branches.first());
-        menu.addAction(tr("Delete Branch %1").arg(ref.name()),
-                       [view, ref] { view->promptToDeleteBranch(ref); });
+        submenu = menu.addMenu(tr("Delete Branch"));
+        entryName = QString("%1");
+      }
+      for(const git::Reference &ref : delete_branches) {
+        submenu->addAction(entryName.arg(ref.name()),
+                           [view, ref] { view->promptToDeleteBranch(ref); });
       }
 
       // Delete tags
+      submenu = &menu;
+      entryName = tr("Delete Tag %1");
       if(tags.count() > 1) {
-        auto deleteMenu = menu.addMenu(tr("Delete Tag"));
-        for(const git::Reference &ref : tags) {
-          deleteMenu->addAction(ref.name(), [view, ref] { 
-                                view->promptToDeleteTag(ref); });
-        }
-      } else if(tags.count() > 0) {
-        const git::Reference &ref(tags.first());
-        menu.addAction(tr("Delete Tag %1").arg(ref.name()),
-                       [view, ref] { view->promptToDeleteTag(ref); });
+        submenu = menu.addMenu(tr("Delete Tag"));
+        entryName = QString("%1");
+      }
+      for(const git::Reference &ref : tags) {
+        submenu->addAction(entryName.arg(ref.name()),
+                           [view, ref] { view->promptToDeleteTag(ref); });
       }
       menu.addSeparator();
 
@@ -1614,24 +1611,25 @@ void CommitList::contextMenuEvent(QContextMenuEvent *event) {
       menu.addSeparator();
 
       git::Reference head = view->repo().head();
-      QMenu *checkoutMenu = &menu;
+      submenu = &menu;
+      entryName = tr("Checkout %1");
       if(all_branches.count() > 1) {
-        checkoutMenu = menu.addMenu(tr("Checkout"));
+        submenu = menu.addMenu(tr("Checkout"));
+        entryName = QString("%1");
       }
-      //foreach (const git::Reference &ref, commit.refs()) {
       for( const git::Reference &ref : all_branches) {
         if (ref.isLocalBranch()) {
           QAction *checkout =
-              checkoutMenu->addAction(tr("Checkout %1").arg(ref.name()),
-                             [view, ref] { view->checkout(ref); });
+              submenu->addAction(entryName.arg(ref.name()),
+                                 [view, ref] { view->checkout(ref); });
 
           checkout->setEnabled(head.isValid() &&
                                head.qualifiedName() != ref.qualifiedName() &&
                                !view->repo().isBare());
         } else if (ref.isRemoteBranch()) {
           QAction *checkout =
-              checkoutMenu->addAction(tr("Checkout %1").arg(ref.name()),
-                             [view, ref] { view->checkout(ref); });
+              submenu->addAction(entryName.arg(ref.name()),
+                                 [view, ref] { view->checkout(ref); });
 
           // Calculate local branch name in the same way as checkout() does
           QString local = ref.name().section('/', 1);

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -1430,15 +1430,15 @@ void CommitList::setModel(QAbstractItemModel *model) {
 /// A single item is added directly to the menu, whereas multiple items will
 /// be added to a sub-menu.
 static void addMenuEntries(QMenu &menu, const QString &operation,
-                           const QList<git::Reference>& items,
-                           std::function<void(const git::Reference&)>action) {
+                           const QList<git::Reference> &items,
+                           std::function<void(const git::Reference &)> action) {
   QMenu *submenu = &menu;
   QString entryName(operation + " %1");
-  if(items.count() > 1) {
+  if (items.count() > 1) {
     submenu = menu.addMenu(operation);
     entryName = QString("%1");
   }
-  for(const git::Reference &ref : items) {
+  for (const git::Reference &ref : items) {
     submenu->addAction(entryName.arg(ref.name()),
                        [action, ref] { action(ref); });
   }
@@ -1520,31 +1520,35 @@ void CommitList::contextMenuEvent(QContextMenuEvent *event) {
       QList<git::Reference> tags;
       QList<git::Reference> delete_branches;
       QList<git::Reference> all_branches; // used later
-      for(const git::Reference &ref : commit.refs()) {
-        if(ref.isTag()) {
+      for (const git::Reference &ref : commit.refs()) {
+        if (ref.isTag()) {
           tags.append(ref);
-        } else if(ref.isBranch()) {
+        } else if (ref.isBranch()) {
           all_branches.append(ref);
-          if(ref.isLocalBranch()) {
+          if (ref.isLocalBranch()) {
             rename_branches.append(ref);
-            if(view->repo().head().name() != ref.name()) {
+            if (view->repo().head().name() != ref.name()) {
               delete_branches.append(ref);
             }
           }
         }
       }
 
-      if(rename_branches.count() > 0 || delete_branches.count() > 0 || tags.count() > 0) {
+      if (rename_branches.count() > 0 || delete_branches.count() > 0 ||
+          tags.count() > 0) {
         menu.addSeparator();
       }
       addMenuEntries(menu, tr("Rename Branch"), rename_branches,
-                     std::bind(&RepoView::promptToRenameBranch, view, std::placeholders::_1));
+                     std::bind(&RepoView::promptToRenameBranch, view,
+                               std::placeholders::_1));
 
       addMenuEntries(menu, tr("Delete Branch"), delete_branches,
-                     std::bind(&RepoView::promptToDeleteBranch, view, std::placeholders::_1));
+                     std::bind(&RepoView::promptToDeleteBranch, view,
+                               std::placeholders::_1));
 
-      addMenuEntries(menu, tr("Delete Tag"), tags,
-                     std::bind(&RepoView::promptToDeleteTag, view, std::placeholders::_1));
+      addMenuEntries(
+          menu, tr("Delete Tag"), tags,
+          std::bind(&RepoView::promptToDeleteTag, view, std::placeholders::_1));
       menu.addSeparator();
 
       menu.addAction(tr("Merge..."), [view, commit] {
@@ -1604,23 +1608,21 @@ void CommitList::contextMenuEvent(QContextMenuEvent *event) {
       git::Reference head = view->repo().head();
       auto submenu = &menu;
       auto entryName = tr("Checkout %1");
-      if(all_branches.count() > 1) {
+      if (all_branches.count() > 1) {
         submenu = menu.addMenu(tr("Checkout"));
         entryName = QString("%1");
       }
-      for( const git::Reference &ref : all_branches) {
+      for (const git::Reference &ref : all_branches) {
         if (ref.isLocalBranch()) {
-          QAction *checkout =
-              submenu->addAction(entryName.arg(ref.name()),
-                                 [view, ref] { view->checkout(ref); });
+          QAction *checkout = submenu->addAction(
+              entryName.arg(ref.name()), [view, ref] { view->checkout(ref); });
 
           checkout->setEnabled(head.isValid() &&
                                head.qualifiedName() != ref.qualifiedName() &&
                                !view->repo().isBare());
         } else if (ref.isRemoteBranch()) {
-          QAction *checkout =
-              submenu->addAction(entryName.arg(ref.name()),
-                                 [view, ref] { view->checkout(ref); });
+          QAction *checkout = submenu->addAction(
+              entryName.arg(ref.name()), [view, ref] { view->checkout(ref); });
 
           // Calculate local branch name in the same way as checkout() does
           QString local = ref.name().section('/', 1);

--- a/src/ui/MenuBar.cpp
+++ b/src/ui/MenuBar.cpp
@@ -192,6 +192,9 @@ static Hotkey configureBranchesHotkey = HotkeyManager::registerHotkey(
 static Hotkey newBranchHotkey =
     HotkeyManager::registerHotkey(nullptr, "branch/new", "Branch/New");
 
+static Hotkey renameBranchHotkey =
+    HotkeyManager::registerHotkey(nullptr, "branch/rename", "Branch/Rename");
+
 static Hotkey checkoutCurrentHotkey = HotkeyManager::registerHotkey(
     "Ctrl+Shift+Alt+H", "branch/checkoutCurrent", "Branch/Checkout Current");
 
@@ -640,6 +643,11 @@ MenuBar::MenuBar(QWidget *parent) : QMenuBar(parent) {
   connect(mNewBranch, &QAction::triggered,
           [this] { view()->promptToCreateBranch(); });
 
+  mRenameBranch = branch->addAction(tr("Rename Branch"));
+  renameBranchHotkey.use(mRenameBranch);
+  connect(mRenameBranch, &QAction::triggered, [this] {
+    this->view()->promptToRenameBranch(this->view()->reference()); });
+
   branch->addSeparator();
 
   mCheckoutCurrent = branch->addAction(tr("Checkout Current"));
@@ -1050,6 +1058,7 @@ void MenuBar::updateBranch() {
   mCheckoutCurrent->setEnabled(ref.isValid() && head.isValid() &&
                                ref.qualifiedName() != head.qualifiedName());
   mCheckout->setEnabled(head.isValid() && !view->repo().isBare());
+  mRenameBranch->setEnabled(ref.isLocalBranch());
   mNewBranch->setEnabled(head.isValid());
 
   mMerge->setEnabled(head.isValid());

--- a/src/ui/MenuBar.cpp
+++ b/src/ui/MenuBar.cpp
@@ -646,7 +646,8 @@ MenuBar::MenuBar(QWidget *parent) : QMenuBar(parent) {
   mRenameBranch = branch->addAction(tr("Rename Branch"));
   renameBranchHotkey.use(mRenameBranch);
   connect(mRenameBranch, &QAction::triggered, [this] {
-    this->view()->promptToRenameBranch(this->view()->reference()); });
+    this->view()->promptToRenameBranch(this->view()->reference());
+  });
 
   branch->addSeparator();
 

--- a/src/ui/MenuBar.h
+++ b/src/ui/MenuBar.h
@@ -116,6 +116,7 @@ private:
   QAction *mNewBranch;
   QAction *mCheckoutCurrent;
   QAction *mCheckout;
+  QAction *mRenameBranch;
   QAction *mMerge;
   QAction *mRebase;
   QAction *mSquash;

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -33,6 +33,7 @@
 #include "dialogs/NewBranchDialog.h"
 #include "dialogs/RebaseConflictDialog.h"
 #include "dialogs/RemoteDialog.h"
+#include "dialogs/RenameBranchDialog.h"
 #include "dialogs/SettingsDialog.h"
 #include "dialogs/TagDialog.h"
 #include "editor/TextEditor.h"
@@ -2048,6 +2049,13 @@ git::Branch RepoView::createBranch(const QString &name,
 void RepoView::promptToDeleteBranch(const git::Reference &ref) {
   DeleteBranchDialog *dialog = new DeleteBranchDialog(ref, this);
   dialog->setAttribute(Qt::WA_DeleteOnClose);
+  dialog->open();
+}
+
+void RepoView::promptToRenameBranch(const git::Branch &branch) {
+  Q_ASSERT(branch.isValid() && branch.isLocalBranch());
+  RenameBranchDialog *dialog = new RenameBranchDialog(mRepo, branch, this);
+  // The dialog contains the code which performs the rename
   dialog->open();
 }
 

--- a/src/ui/RepoView.h
+++ b/src/ui/RepoView.h
@@ -251,6 +251,7 @@ public:
                            const git::Branch &upstream = git::Branch(),
                            bool checkout = false, bool force = false);
   void promptToDeleteBranch(const git::Reference &ref);
+  void promptToRenameBranch(const git::Branch &branch);
 
   // stash
   void promptToStash();

--- a/test/Setting.cpp
+++ b/test/Setting.cpp
@@ -23,9 +23,7 @@ private:
 
   template <class T, typename TId> QStringList settingsKeys() {
     QStringList settingsKeys;
-    foreach (const TId id, ids<TId>()) {
-      settingsKeys.append(T::key(id));
-    }
+    foreach (const TId id, ids<TId>()) { settingsKeys.append(T::key(id)); }
     return settingsKeys;
   }
 

--- a/test/Setting.cpp
+++ b/test/Setting.cpp
@@ -23,7 +23,9 @@ private:
 
   template <class T, typename TId> QStringList settingsKeys() {
     QStringList settingsKeys;
-    foreach (const TId id, ids<TId>()) { settingsKeys.append(T::key(id)); }
+    foreach (const TId id, ids<TId>()) {
+      settingsKeys.append(T::key(id));
+    }
     return settingsKeys;
   }
 


### PR DESCRIPTION
Adds a right-click menu item to the Commit List to rename branches.
Also adds a menu item to rename the current branch in the main menu's "Branch" submenu.

Yes, this functionality is already available in the "MENU->Branch->Configure Branches" dialog, but this is something I semi-regularly use and it actually took me some time to discover the functionality in the dialog, especially since clicking on the branch name does not work reliably to edit it.

I feel that by adding it to the right-click menu it is much more discoverable.

I also refactored  the menu so that the "Delete Branch", "Delete Tag", and "Checkout" menu items turn into sub-menus when there are several references on a commit, making the menu more manageable. Again, this is something I encounter a bit in the repos I work with.