### PR TITLE
Rebase: Use original commit message as default message

### DIFF
--- a/src/ui/DetailView.cpp
+++ b/src/ui/DetailView.cpp
@@ -500,6 +500,7 @@ DetailView::DetailView(const git::Repository &repo, QWidget *parent)
   mDetail->setVisible(false);
   layout->addWidget(mDetail);
 
+  // Shown when a commit is selected
   mDetail->addWidget(new CommitDetail(this));
 
   mAuthorLabel = new QLabel(this);
@@ -508,6 +509,7 @@ DetailView::DetailView(const git::Repository &repo, QWidget *parent)
           &DetailView::authorLinkActivated);
   updateAuthor();
 
+  // Shown when the working directory is dirty
   mCommitEditor = new CommitEditor(repo, this);
 
   auto editorFrame = new QWidget(this);

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -1465,6 +1465,9 @@ void RepoView::rebaseConflict(const git::Rebase rebase) {
   if (mRebase) {
     mRebase->addEntry(tr("Please resolve conflicts before continue"),
                       tr("Conflict"));
+    mDetails->setCommitMessage(rebase.commitToRebase()
+                                   .message(git::Commit::SubstituteEmoji)
+                                   .trimmed());
   }
   refresh(false);
 }


### PR DESCRIPTION
Currently a new message will be generated which is not desired in the most cases