### PR TITLE
faster submodule update

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ How to Build
 **Initialize Submodules**
 
     git submodule init
-    git submodule update
+    git submodule update --depth 1
 
 **Build OpenSSL**
 


### PR DESCRIPTION
Submodules like `git` contain too much change history, which is not necessary to compile the program.   
Speeding up the setup significantly as well as saving space on the device is important.