### PR TITLE
Execute cdUp always

### DIFF
--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -156,7 +156,11 @@ QDir Repository::dir(bool includeGitFolder) const {
   QDir dir(git_repository_path(d->repo));
   if (!includeGitFolder) {
     assert(dir.dirName() == ".git");
-    assert(dir.cdUp());
+    if (!dir.cdUp()) {
+      assert(false); // must be done explicit, because in release build the
+                     // assert will not be executed, so assert(dir.cdUp()) does
+                     // not work in release build
+    }
   }
   return dir;
 }


### PR DESCRIPTION
In Debug mode the asserts are activated, but in Release mode not. In this case in the release build the cdUp will just be ignored.