### PR TITLE
Compact commit list: move commit message closer to commit graph

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Scientific Toolworks, Inc.
-Copyright (c) 2021-2023 Gittyup contributors
+Copyright (c) 2021-2024 Gittyup contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ branch. Create pull requests against the `master` branch. Follow the
 [seven guidelines](https://chris.beams.io/posts/git-commit/) to writing a
 great commit message.
 
-Prior to committing a change, please use `cl-format.sh` to ensure your code
+Prior to committing a change, please use `cl-fmt.sh` to ensure your code
 adheres to the formatting conventions for this project. You can also use the
 `setup-env.sh` script to install a pre-commit hook which will automatically
 run `clang-format` against all modified files.

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -829,6 +829,20 @@ public:
           rect.setWidth(rect.width() - timestampWidth - constants.hMargin);
         }
 
+        // Draw Name.
+        if (showAuthor) {
+          QString name = commit.author().name() + "  ";
+          painter->save();
+          QFont bold = opt.font;
+          bold.setBold(true);
+          painter->setFont(bold);
+          painter->drawText(rect, Qt::AlignRight, name);
+          painter->restore();
+          const QFontMetrics boldFm(bold);
+          rect.setWidth(rect.width() - boldFm.horizontalAdvance(name) -
+                        constants.hMargin);
+        }
+
         // Calculate remaining width for the references.
         QRect ref = rect;
         int refsWidth = ref.width() - minWidthDesc;
@@ -846,20 +860,6 @@ public:
         if (!refs.isEmpty())
           badgesWidth = Badge::paint(painter, refs, ref, &opt, Qt::AlignLeft);
         rect.setX(badgesWidth); // Comes right after the badges
-
-        // Draw Name.
-        if (showAuthor) {
-          QString name = commit.author().name();
-          painter->save();
-          QFont bold = opt.font;
-          bold.setBold(true);
-          painter->setFont(bold);
-          painter->drawText(rect, Qt::AlignLeft, name);
-          painter->restore();
-          const QFontMetrics boldFm(bold);
-          rect.setX(rect.x() + boldFm.horizontalAdvance(name) +
-                    constants.hMargin);
-        }
 
         // Draw message.
         painter->save();


### PR DESCRIPTION
In the compact commit list, I moved the author name to the right-side of the commit list window.  This gets the commit message closer to the commit graph.  I thought this would make the compact commit list easier to read.

[moved-name.webm](https://github.com/Murmele/Gittyup/assets/3083835/cfe3f240-20a3-43cc-9d7c-17a0d7e99ebb)
