### PR TITLE
Fix commit highlighting

### DIFF
--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -635,9 +635,6 @@ public:
         Settings::instance()->value(Setting::Id::ShowCommitsId, true).toBool();
     LayoutConstants constants = layoutConstants(compact);
 
-    // Draw background.
-    QStyledItemDelegate::paint(painter, opt, index);
-
     bool active = (opt.state & QStyle::State_Active);
     bool selected = (opt.state & QStyle::State_Selected);
     auto group = active ? QPalette::Active : QPalette::Inactive;
@@ -646,9 +643,15 @@ public:
     QPalette palette = Application::theme()->commitList();
     QColor text = palette.color(group, textRole);
     QColor bright = palette.color(group, brightRole);
+    QColor highlight = palette.color(group, QPalette::Highlight);
 
     painter->save();
     painter->setRenderHints(QPainter::Antialiasing);
+
+    // Draw background.
+    if (selected) {
+      painter->fillRect(opt.rect, highlight);
+    }
 
     // Draw busy indicator.
     if (opt.features & QStyleOptionViewItem::HasDecoration) {

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -787,7 +787,16 @@ public:
     // Draw content.
     git::Commit commit =
         index.data(CommitList::Role::CommitRole).value<git::Commit>();
-    if (commit.isValid()) {
+    if (!commit.isValid()) {
+      // special case for uncommitted changes
+      QString message = index.model()->data(index).toString();
+      painter->save();
+      QFont italic = opt.font;
+      italic.setItalic(true);
+      painter->setFont(italic);
+      painter->drawText(opt.rect, Qt::AlignCenter, message);
+      painter->restore();
+    } else {
       const QFontMetrics &fm = opt.fontMetrics;
       QRect star = rect;
 


### PR DESCRIPTION
This fixes #699.

I tried for hours, but couldn't figure out how to prevent Qt from highlighting extra things unnecessarily.  So I decided to highlight selected commits using `painter->fillRect`.  Usually I don't like to re-implement basic library features, but since the rendering of CommitList is already 95% hand-rolled, this solution seems acceptable.

`QStyledItemDelegate::paint(painter, opt, index);` has been removed, and `CommitDelegate` is now 100% responsible for drawing the commit list.