### PR TITLE
Make CommitList display "Working tree clean"

### DIFF
--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -149,6 +149,17 @@ public:
     resetWalker();
   }
 
+  bool is_working_tree_clean(void) const {
+    if (mStatus.isRunning()) {
+      return false;
+    }
+    git::Diff stat = status();
+    if (!stat.isValid()) {
+      return true;
+    }
+    return stat.count() == 0;
+  }
+
   void suppressResetWalker(bool suppress) { mSuppressResetWalker = suppress; }
 
   bool isResetWalkerSuppressed() { return mSuppressResetWalker; }
@@ -321,17 +332,19 @@ public:
 
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const {
     const Row &row = mRows.at(index.row());
-    bool status = !row.commit.isValid();
+    bool commit_is_valid = row.commit.isValid();
+
     switch (role) {
       case Qt::DisplayRole:
-        if (!status)
+        if (commit_is_valid)
           return QVariant();
-
-        return mStatus.isFinished() ? tr("Uncommitted changes")
-                                    : tr("Checking for uncommitted changes");
+        if (!mStatus.isFinished())
+          return tr("Checking for uncommitted changes");
+        return is_working_tree_clean() ? tr("Working tree clean")
+                                       : tr("Uncommitted changes");
 
       case Qt::FontRole: {
-        if (!status)
+        if (commit_is_valid)
           return QVariant();
 
         QFont font = static_cast<QWidget *>(QObject::parent())->font();
@@ -340,19 +353,19 @@ public:
       }
 
       case Qt::TextAlignmentRole:
-        if (!status)
+        if (commit_is_valid)
           return QVariant();
 
         return QVariant(Qt::AlignHCenter | Qt::AlignVCenter);
 
       case Qt::DecorationRole:
-        if (!status)
+        if (commit_is_valid)
           return QVariant();
 
         return mStatus.isFinished() ? QVariant() : mProgress;
 
       case CommitList::Role::DiffRole: {
-        if (status)
+        if (!commit_is_valid)
           return QVariant::fromValue(this->status());
 
         bool ignoreWhitespace = Settings::instance()->isWhitespaceIgnored();
@@ -362,7 +375,7 @@ public:
       }
 
       case CommitList::Role::CommitRole:
-        return status ? QVariant() : QVariant::fromValue(row.commit);
+        return commit_is_valid ? QVariant::fromValue(row.commit) : QVariant();
 
       case CommitList::Role::GraphRole: {
         QVariantList columns;


### PR DESCRIPTION
When there are no changes in the working directory, the top placeholder commit says "Working tree clean".

I added a function `bool is_working_tree_clean(void) const` in `class CommitModel : public QAbstractListModel`.  Is there a better place to put this function?  I'm a C++ beginner.  I was trying to figure out how to access the `is_working_tree_clean()` function in other places in `CommitList.cpp` but couldn't figure out a clean way to do it...

![image](https://github.com/Murmele/Gittyup/assets/3083835/8e9c6fc5-ddde-42a0-8844-70bda5090a4a)

