### PR TITLE
Set head/stash reference after pop/drop stash

### DIFF
--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -2122,6 +2122,13 @@ void RepoView::dropStash(int index) {
   LogEntry *entry = addLogEntry(msg(commit), tr("Drop Stash"));
   if (!mRepo.dropStash(index))
     error(entry, tr("drop stash"), commit.link());
+
+  if (mRepo.stashes().size() == 0) {
+    // switch back to head when there are no stashes left
+    mCommits->setReference(mRepo.head());
+  } else {
+    mCommits->setReference(mRepo.stashRef());
+  }
 }
 
 void RepoView::popStash(int index) {
@@ -2135,7 +2142,12 @@ void RepoView::popStash(int index) {
     return;
   }
 
-  refresh(false);
+  if (mRepo.stashes().size() == 0) {
+    // switch back to head when there are no stashes left
+    mCommits->setReference(mRepo.head());
+  } else {
+    mCommits->setReference(mRepo.stashRef());
+  }
 }
 
 void RepoView::promptToAddTag(const git::Commit &commit) {

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -2141,10 +2141,8 @@ void RepoView::popStash(int index) {
     error(entry, tr("pop stash"), commit.link());
     return;
   }
-  if (mRepo.stashes().size() == 0) {
-    // switch back to head when there are no stashes left
-    mCommits->setReference(mRepo.head());
-  }
+  // switch back to head
+  selectReference(mRepo.head());
 }
 
 void RepoView::promptToAddTag(const git::Commit &commit) {

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -2141,13 +2141,7 @@ void RepoView::popStash(int index) {
     error(entry, tr("pop stash"), commit.link());
     return;
   }
-
-  if (mRepo.stashes().size() == 0) {
-    // switch back to head when there are no stashes left
-    mCommits->setReference(mRepo.head());
-  } else {
-    mCommits->setReference(mRepo.stashRef());
-  }
+  refresh(false);
 }
 
 void RepoView::promptToAddTag(const git::Commit &commit) {
@@ -2809,6 +2803,7 @@ void RepoView::refresh(bool restoreSelection) {
     dtw->setDiffCounter();
   }
   if (mRepo.head().isValid()) {
+    mCommits->setReference(mRepo.head());
     DebugRefresh("Head name: " << mRepo.head().name());
   } else {
     DebugRefresh("Head invalid");

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -2141,7 +2141,10 @@ void RepoView::popStash(int index) {
     error(entry, tr("pop stash"), commit.link());
     return;
   }
-  refresh(false);
+  if (mRepo.stashes().size() == 0) {
+    // switch back to head when there are no stashes left
+    mCommits->setReference(mRepo.head());
+  }
 }
 
 void RepoView::promptToAddTag(const git::Commit &commit) {
@@ -2803,7 +2806,6 @@ void RepoView::refresh(bool restoreSelection) {
     dtw->setDiffCounter();
   }
   if (mRepo.head().isValid()) {
-    mCommits->setReference(mRepo.head());
     DebugRefresh("Head name: " << mRepo.head().name());
   } else {
     DebugRefresh("Head invalid");

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -2143,6 +2143,7 @@ void RepoView::popStash(int index) {
   }
   // switch back to head
   selectReference(mRepo.head());
+  selectFirstCommit();
 }
 
 void RepoView::promptToAddTag(const git::Commit &commit) {


### PR DESCRIPTION
Fixes the issue  "Dropping multiple stashs in a row segfaults #637". The cause of the crash was that the commit list was not properly updated after pop/drop stash actions.  With this change the commit list is updated or when the stash gets empty (after last pop/drop)  then the head is selected as current reference.