### PR TITLE
Prevent Uncommitted Changes from being shown when ShowCleanStatus is false

### DIFF
--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -239,7 +239,7 @@ public:
     git::Config config = mRepo.appConfig();
     mRefsAll = config.value<bool>("commit.refs.all", true);
     mSortDate = config.value<bool>("commit.sort.date", true);
-    mShowCleanStatus = config.value<bool>("commit.show.status", false);
+    mShowCleanStatus = config.value<bool>("commit.show.status", true);
     mGraphVisible = config.value<bool>("commit.graph.visible", true);
 
     if (walk)

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -186,8 +186,8 @@ public:
 
     // Update status row.
     bool head = (!mRef.isValid() || mRef.isHead());
-    bool valid = (mCleanStatus || !mStatus.isFinished() || status().isValid());
-    if (head && valid && mPathspec.isEmpty()) {
+    bool valid = (!mStatus.isFinished() || status().isValid());
+    if (mShowCleanStatus && head && valid && mPathspec.isEmpty()) {
       QVector<Column> row;
       if (mGraphVisible && mRef.isValid() && mStatus.isFinished()) {
         row.append({Segment(Bottom, kTaintedColor), Segment(Dot, QColor())});
@@ -239,7 +239,7 @@ public:
     git::Config config = mRepo.appConfig();
     mRefsAll = config.value<bool>("commit.refs.all", true);
     mSortDate = config.value<bool>("commit.sort.date", true);
-    mCleanStatus = config.value<bool>("commit.status.clean", false);
+    mShowCleanStatus = config.value<bool>("commit.show.status", false);
     mGraphVisible = config.value<bool>("commit.graph.visible", true);
 
     if (walk)
@@ -559,7 +559,7 @@ private:
   bool mSuppressResetWalker{false};
   bool mRefsAll = true;
   bool mSortDate = true;
-  bool mCleanStatus = true;
+  bool mShowCleanStatus = true;
   bool mGraphVisible = true;
 };
 

--- a/src/ui/CommitToolBar.cpp
+++ b/src/ui/CommitToolBar.cpp
@@ -25,7 +25,7 @@ namespace {
 const QString kRefsKey = "commit.refs.all";
 const QString kSortKey = "commit.sort.date";
 const QString kGraphKey = "commit.graph.visible";
-const QString kStatusKey = "commit.status.clean";
+const QString kStatusKey = "commit.show.status";
 const QString kStyleSheet = "QToolBar {"
                             "  border: none"
                             "}"

--- a/src/ui/CommitToolBar.cpp
+++ b/src/ui/CommitToolBar.cpp
@@ -155,7 +155,7 @@ CommitToolBar::CommitToolBar(QWidget *parent) : QToolBar(parent) {
 
   QAction *status = menu->addAction(tr("Show Clean Status"));
   status->setCheckable(true);
-  status->setChecked(config.value<bool>(kStatusKey, false));
+  status->setChecked(config.value<bool>(kStatusKey, true));
   connect(status, &QAction::triggered, [this](bool checked) {
     RepoView *view = RepoView::parentView(this);
     view->repo().appConfig().setValue(kStatusKey, checked);


### PR DESCRIPTION
Previously, it was possible for the _Uncommitted Changes_ row to be appended to the `CommitList` even if the "Show Clean Status" option had been unchecked.  This commit prevents that from happening.

This closes #711.