### PR TITLE
Add Hotkeys for Navigating CommitList

### DIFF
--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -28,6 +28,7 @@
 #include "git/Signature.h"
 #include "git/TagRef.h"
 #include "git/Tree.h"
+#include "ui/HotkeyManager.h"
 #include <QAbstractListModel>
 #include <QApplication>
 #include <QMenu>
@@ -1168,6 +1169,12 @@ public:
 
 } // namespace
 
+static Hotkey prevCommitHotKey = HotkeyManager::registerHotkey(
+    "J", "commitList/prevCommit", "CommitList/PrevCommit");
+
+static Hotkey nextCommitHotKey = HotkeyManager::registerHotkey(
+    "K", "commitList/nextCommit", "CommitList/NextCommit");
+
 CommitList::CommitList(Index *index, QWidget *parent)
     : QListView(parent), mIndex(index) {
   Theme *theme = Application::theme();
@@ -1222,6 +1229,18 @@ CommitList::CommitList(Index *index, QWidget *parent)
 
   connect(this, &CommitList::entered,
           [this](const QModelIndex &index) { update(index); });
+
+  QShortcut *shortcut = new QShortcut(this);
+  prevCommitHotKey.use(shortcut);
+  connect(shortcut, &QShortcut::activated, [this] {
+    printf("prevCommit\n");
+  });
+
+  shortcut = new QShortcut(this);
+  nextCommitHotKey.use(shortcut);
+  connect(shortcut, &QShortcut::activated, [this] {
+    printf("nextCommit\n");
+  });
 
 #ifdef Q_OS_MAC
   QFont font = this->font();

--- a/src/ui/CommitList.h
+++ b/src/ui/CommitList.h
@@ -47,6 +47,7 @@ public:
   void selectReference(const git::Reference &ref);
   void resetSelection(bool spontaneous = false);
   void selectFirstCommit(bool spontaneous = false);
+  void selectCommitRelative(int offset);
   bool selectRange(const QString &range, const QString &file = QString(),
                    bool spontaneous = false);
   void suppressResetWalker(bool suppress);

--- a/src/ui/DiffView/DiffView.cpp
+++ b/src/ui/DiffView/DiffView.cpp
@@ -15,6 +15,7 @@
 #include "CommentWidget.h"
 #include "ui/DiffTreeModel.h"
 #include "ui/DoubleTreeWidget.h"
+#include "ui/HotkeyManager.h"
 #include "git/Tree.h"
 #include <QScrollBar>
 #include <QPushButton>
@@ -46,6 +47,12 @@ bool copy(const QString &source, const QDir &targetDir) {
 }
 
 } // namespace
+
+static Hotkey moveHalfPageDownHotKey = HotkeyManager::registerHotkey(
+    "d", "diffView/moveHalfPageDownHotKey", "DiffView/Move Half Page Down");
+
+static Hotkey moveHalfPageUpHotKey = HotkeyManager::registerHotkey(
+    "u", "diffView/moveHalfPageUpHotKey", "DiffView/Move Half Page Up");
 
 DiffView::DiffView(const git::Repository &repo, QWidget *parent)
     : QScrollArea(parent), mParent(parent) {
@@ -84,6 +91,14 @@ DiffView::DiffView(const git::Repository &repo, QWidget *parent)
                 fetchMore();
             });
   }
+
+  QShortcut *shortcut = new QShortcut(this);
+  moveHalfPageDownHotKey.use(shortcut);
+  connect(shortcut, &QShortcut::activated, [this] { moveHalfPageDown(); });
+
+  shortcut = new QShortcut(this);
+  moveHalfPageUpHotKey.use(shortcut);
+  connect(shortcut, &QShortcut::activated, [this] { moveHalfPageUp(); });
 }
 
 DiffView::~DiffView() {}
@@ -512,4 +527,14 @@ void DiffView::indexChanged(const QStringList &paths) {
   //                file->updateHunks(stagedPatch);
   //        }
   //    }
+}
+
+void DiffView::moveHalfPageDown() { moveRelative(height() / 2); }
+
+void DiffView::moveHalfPageUp() { moveRelative(-height() / 2); }
+
+void DiffView::moveRelative(int pixelsDown) {
+  int oldPosition = verticalScrollBar()->sliderPosition();
+  int newPosition = oldPosition + pixelsDown;
+  verticalScrollBar()->setSliderPosition(newPosition);
 }

--- a/src/ui/DiffView/DiffView.h
+++ b/src/ui/DiffView/DiffView.h
@@ -103,6 +103,9 @@ public:
   void diffTreeModelDataChanged(const QModelIndex &topLeft,
                                 const QModelIndex &bottomRight,
                                 const QVector<int> &roles);
+  void moveHalfPageDown();
+  void moveHalfPageUp();
+  void moveRelative(int pixelsDown);
 
 signals:
   void diagnosticAdded(TextEditor::DiagnosticKind kind);


### PR DESCRIPTION
Those familiar with vim-keybindings will like the default shortcut keys.  The arrow keys still work, and the keyboard shortcuts are configurable of course.