### PR TITLE
fix cdUp logic

### DIFF
--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -154,8 +154,7 @@ Repository::operator git_repository *() const { return d->repo; }
 
 QDir Repository::dir(bool includeGitFolder) const {
   QDir dir(git_repository_path(d->repo));
-  if (!includeGitFolder) {
-    assert(dir.dirName() == ".git");
+  if (!includeGitFolder && dir.dirName() == ".git") {
     if (!dir.cdUp()) {
       assert(false); // must be done explicit, because in release build the
                      // assert will not be executed, so assert(dir.cdUp()) does


### PR DESCRIPTION
Closes #731.

I did not change the ``assert(false)`` part although I do not really understand why it is here : [Qt](https://doc.qt.io/qt-5/qdir.html#cdUp) says that the logical operation of moving up is just not done if the parent directory does not exist, so even in the rare case of ``/.git``, we could just keep running or display a warning.