### PR TITLE
move flatpak manifest into the repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,49 +67,43 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Clone flatpak manifest from Flathub
-      uses: GuillaumeFalourd/clone-github-repo-action@v2
-      with:
-        owner: 'flathub'
-        repository: 'com.github.Murmele.Gittyup'
-
     - name: Replace git tag by the commit id on which it runs
       if: github.ref_type != 'tag'
       run: >
-        sed -i 's@tag: .*@commit: "${{ (github.event.pull_request && github.event.pull_request.head.sha) || github.sha }}"@' com.github.Murmele.Gittyup/com.github.Murmele.Gittyup.yml
+        sed -i 's@tag: .*@commit: "${{ (github.event.pull_request && github.event.pull_request.head.sha) || github.sha }}"@' com.github.Murmele.Gittyup.yml
 
     - name: Use correct git tag
       if: github.ref_type == 'tag'
       run: >
-        sed -i 's@tag: .*$@tag: "${{ github.ref_name }}"@' com.github.Murmele.Gittyup/com.github.Murmele.Gittyup.yml
+        sed -i 's@tag: .*$@tag: "${{ github.ref_name }}"@' com.github.Murmele.Gittyup.yml
 
     - name: Replace source url
       run: >
-        sed -i "s@url: .*Gittyup.git@url: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY@" com.github.Murmele.Gittyup/com.github.Murmele.Gittyup.yml
+        sed -i "s@url: .*Gittyup.git@url: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY@" com.github.Murmele.Gittyup.yml
 
     - name: Add dev build marker to cmake options
       if: github.ref_type != 'tag'
       run: >
-        sed -i 's@config-opts: \["\(.*\)"\]@config-opts: ["\1", "-DDEV_BUILD=${{ github.ref_name }}"]@' com.github.Murmele.Gittyup/com.github.Murmele.Gittyup.yml
+        sed -i 's@config-opts: \["\(.*\)"\]@config-opts: ["\1", "-DDEV_BUILD=${{ github.ref_name }}"]@' com.github.Murmele.Gittyup.yml
 
     - name: Replace desktop file name suffix
       if: github.ref_type != 'tag'
       run: >
-        sed -i 's@desktop-file-name-suffix: ""@desktop-file-name-suffix: " (Development)"@' com.github.Murmele.Gittyup/com.github.Murmele.Gittyup.yml
+        sed -i 's@desktop-file-name-suffix: ""@desktop-file-name-suffix: " (Development)"@' com.github.Murmele.Gittyup.yml
 
     - name: Enable automatic update
       if: github.ref_type != 'tag'
       run: >
-        sed -i 's@-DENABLE_UPDATE_OVER_GUI=OFF@-DENABLE_UPDATE_OVER_GUI=ON@' com.github.Murmele.Gittyup/com.github.Murmele.Gittyup.yml
+        sed -i 's@-DENABLE_UPDATE_OVER_GUI=OFF@-DENABLE_UPDATE_OVER_GUI=ON@' com.github.Murmele.Gittyup.yml
 
     - name: Show Flatpak manifest
-      run: cat com.github.Murmele.Gittyup/com.github.Murmele.Gittyup.yml
+      run: cat com.github.Murmele.Gittyup.yml
 
     - name: Build package
       uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
       with:
         bundle: Gittyup.flatpak
-        manifest-path: com.github.Murmele.Gittyup/com.github.Murmele.Gittyup.yml
+        manifest-path: com.github.Murmele.Gittyup.yml
         cache: false
         branch: ${{ steps.flatpak_release_branch.outputs.value }}
 

--- a/com.github.Murmele.Gittyup.yml
+++ b/com.github.Murmele.Gittyup.yml
@@ -1,0 +1,75 @@
+app-id: com.github.Murmele.Gittyup
+runtime: org.kde.Platform
+runtime-version: 5.15-21.08
+sdk: org.kde.Sdk
+command: gittyup
+desktop-file-name-suffix: "" # used to create development version
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --share=network
+  - --share=ipc
+  - --filesystem=home
+  - --filesystem=/tmp # Needed to store temporary files, which should be opened by external (non sandboxed) applications like kdiff3. Did not find another way to share a temporary file to the host (only creating a tmp folder in the home folder, I don't like)
+  # we use the keyring to store credentials
+  - --filesystem=xdg-run/keyring
+  # for git repos that require ssh keys
+  - --socket=ssh-auth
+  - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.Flatpak
+rename-icon: gittyup # Image will renamed to match the app-id konvention
+rename-desktop-file: gittyup.desktop
+rename-appdata-file: gittyup.appdata.xml
+
+build-options:
+  append-path: /usr/lib/sdk/golang/bin
+
+modules:
+  - name: git-lfs
+    buildsystem: simple
+    build-commands:
+      - PREFIX=${FLATPAK_DEST} ./install.sh
+    sources:
+      - type: archive
+        strip-components: 1
+        url: https://github.com/git-lfs/git-lfs/releases/download/v3.3.0/git-lfs-linux-amd64-v3.3.0.tar.gz
+        sha256: 6a4e6bd7d06d5c024bc70c8ee8c9da143ffc37d2646e252a17a6126d30cdebc1
+        only-arches: [x86_64]
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/git-lfs/git-lfs/releases/latest
+          url-query: .assets[] | select(.name=="git-lfs-linux-amd64-" + $version +
+            ".tar.gz") | .browser_download_url
+          version-query: .tag_name
+      - type: archive
+        strip-components: 1
+        url: https://github.com/git-lfs/git-lfs/releases/download/v3.3.0/git-lfs-linux-arm64-v3.3.0.tar.gz
+        sha256: e97c477981a9b6a40026cadc1bf005541d973fc32df2de2f398643b15df6b5c6
+        only-arches: [aarch64]
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/git-lfs/git-lfs/releases/latest
+          url-query: .assets[] | select(.name=="git-lfs-linux-arm64-" + $version +
+            ".tar.gz") | .browser_download_url
+          version-query: .tag_name
+
+  - name: git
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 $(which git) ${FLATPAK_DEST}/bin/
+      - install -Dm755 $(which git-cvsserver) ${FLATPAK_DEST}/bin/
+      - install -Dm755 $(which git-receive-pack) ${FLATPAK_DEST}/bin/
+      - install -Dm755 $(which git-shell) ${FLATPAK_DEST}/bin/
+      - install -Dm755 $(which git-upload-archive) ${FLATPAK_DEST}/bin/
+      - install -Dm755 $(which git-upload-pack) ${FLATPAK_DEST}/bin/
+
+  - name: Gittyup
+    buildsystem: cmake-ninja
+    config-opts: [-DCMAKE_BUILD_TYPE=Release, -DFLATPAK=ON, -DGENERATE_APPDATA=ON, -DENABLE_UPDATE_OVER_GUI=OFF]
+    builddir: true
+    sources:
+      - type: git
+        url: https://github.com/Murmele/Gittyup.git
+        tag: gittyup_v1.3.0


### PR DESCRIPTION
Reason: so it can be modified without any issues on the stable flatpak. After the release the package must be update in the flathub repository