### PR TITLE
remove id because otherwise a cyclic dependency is created

### DIFF
--- a/rsrc/linux/com.github.Murmele.Gittyup.appdata.xml.in
+++ b/rsrc/linux/com.github.Murmele.Gittyup.appdata.xml.in
@@ -46,7 +46,6 @@
 
   <provides>
     <binary>gittyup</binary>
-    <id>com.github.Murmele.Gittyup</id>
   </provides>
 
   <releases>


### PR DESCRIPTION
https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/ 
Error message during flatpak build on flathub:
```{
    "errors": [
        "appstream-failed-validation"
    ],
    "warnings": [
        "appstream-summary-too-long"
    ],
    "appstream": [
        "W: com.github.Murmele.Gittyup:49: circular-component-relation"
    ],
    "message": "Please consult the documentation at https://docs.flathub.org/docs/for-app-authors/linter"
}
```