### PR TITLE
macos-latest is now the arm64 version, but we wanna build against x86_64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
             cmake_env: {}
 
           - name: macos
-            os: macos-latest
+            os: macos-latest-large
             ninja_platform: mac
             qt_platform: mac
             openssl_arch: darwin64-x86_64-cc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
             cmake_env: {}
 
           - name: macos
-            os: macos-latest-large
+            os: macos-12
             ninja_platform: mac
             qt_platform: mac
             openssl_arch: darwin64-x86_64-cc


### PR DESCRIPTION
Description: Because openssl uses it
https://github.com/actions/runner-images/tree/main

fixes: #756