### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/dep/lua/lua-5.4.0/src/ldebug.c
+++ b/dep/lua/lua-5.4.0/src/ldebug.c
@@ -787,6 +787,8 @@ l_noret luaG_runerror (lua_State *L, const char *fmt, ...) {
 ** previous instruction 'oldpc'.
 */
 static int changedline (const Proto *p, int oldpc, int newpc) {
+  if (p->lineinfo == NULL)  /* no debug information? */
+    return 0;
   while (oldpc++ < newpc) {
     if (p->lineinfo[oldpc] != 0)
       return (luaG_getfuncline(p, oldpc - 1) != luaG_getfuncline(p, newpc));


### PR DESCRIPTION
Hi there,

I identified another potential vulnerability in a clone function changedline() in `dep/lua/lua-5.4.0/src/ldebug.c` sourced from [lua/lua](https://github.com/lua/lua). This issue, originally reported in [CVE-2020-24369](https://nvd.nist.gov/vuln/detail/CVE-2020-24369), was resolved in the repository via this commit https://github.com/lua/lua/commit/ae5b5ba529753c7a653901ffc29b5ea24c3fdf3a.

This PR applies the corresponding patch to handle potential null pointer dereference in this codebase.

Please review at your convenience. Thank you!