### PR TITLE
Fix incorrect read and write of git hash to ids file

### DIFF
--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -69,7 +69,7 @@ void Index::reset() {
   QFile idFile(dir.filePath(kIdFile));
   if (idFile.open(QIODevice::ReadOnly)) {
     while (idFile.bytesAvailable() > 0)
-      mIds.append(idFile.read(GIT_OID_SHA1));
+      mIds.append(idFile.read(GIT_OID_SHA1_SIZE));
   }
 
   // Read dictionary.
@@ -142,7 +142,7 @@ bool Index::write(PostingMap map) {
 
   // Write id file.
   foreach (const git::Id &id, mIds)
-    idFile.write(id.toByteArray(), GIT_OID_SHA1);
+    idFile.write(id.toByteArray(), GIT_OID_SHA1_SIZE);
 
   // Merge new entries into existing postings file.
   // Write dictionary and postings files in lockstep.


### PR DESCRIPTION
This has such a dramatic effect on the indexer performance, that I'm honestly questioning whether this breaks anything, but from what I can tell, this should be a very valid fix.

Essentially, what I've been observing is that the indexer files under `.git/gittyup/index` grows each time the indexer runs. The core root of that is that new entries are written to the ids file each time, which are then causing additional entries in the remaining files. From what I can tell, this goes back to an incorrect read and write of the SHA1 hash. It's 20 bytes, but since `GIT_OID_SHA1` is used as the length parameter, only a single byte is read and written. This means that next time the indexer runs, it can't match ids from the file with the ids it gets during runtime. Fixing this results in the indexer basically taking no time to run on already indexed repos.

A side-effect of this is that since the file grows, it proves that the code doesn't discard unmatched ids. I've not attempted to fix that.

It's quite likely that this fixes, or at the very least improves, issues such as #861, #776, #767 since I suspect they are trigged by long-term use and multiple restarts of gittyup