### PR TITLE
Show advanced by default in new branch dialog

### DIFF
--- a/src/dialogs/NewBranchDialog.cpp
+++ b/src/dialogs/NewBranchDialog.cpp
@@ -53,7 +53,6 @@ NewBranchDialog::NewBranchDialog(const git::Repository &repo,
   form->addRow(tr("Advanced:"), expand);
 
   QWidget *advanced = new QWidget(this);
-  advanced->setVisible(false);
 
   QFormLayout *advancedForm = new QFormLayout(advanced);
   advancedForm->setContentsMargins(-1, 0, 0, 0);


### PR DESCRIPTION
Show advanced options by default. Previously hidden, but doesn't really save screen space and is annoying for users who use this functionality twenty times a day.