### PR TITLE
Add mmap based reading to speed up indexer

### DIFF
--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -1,5 +1,12 @@
-add_library(index GenericLexer.cpp Index.cpp IndexModel.cpp Lexer.cpp
-                  LPegLexer.cpp MmapFileReader.cpp Query.cpp)
+add_library(
+  index
+  GenericLexer.cpp
+  Index.cpp
+  IndexModel.cpp
+  Lexer.cpp
+  LPegLexer.cpp
+  MmapFileReader.cpp
+  Query.cpp)
 
 target_link_libraries(index conf git lpeg Qt6::Core Qt6::Concurrent)
 

--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(index GenericLexer.cpp Index.cpp IndexModel.cpp Lexer.cpp
-                  LPegLexer.cpp Query.cpp)
+                  LPegLexer.cpp MmapFileReader.cpp Query.cpp)
 
 target_link_libraries(index conf git lpeg Qt6::Core Qt6::Concurrent)
 

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -151,15 +151,11 @@ bool Index::write(PostingMap map) {
   QDataStream dictOut(&dictFile);
 
   // Open existing postings file.
-  QDataStream postIn;
-  QFile postInFile(dir.filePath(kPostFile));
-  if (postInFile.open(QIODevice::ReadOnly))
-    postIn.setDevice(&postInFile);
+  MmapFileReader postInFile(dir.filePath(kPostFile));
+  postInFile.open();
 
-  QDataStream proxIn;
-  QFile proxInFile(dir.filePath(kProxFile));
-  if (proxInFile.open(QIODevice::ReadOnly))
-    proxIn.setDevice(&proxInFile);
+  MmapFileReader proxInFile(dir.filePath(kProxFile));
+  proxInFile.open();
 
   // Create a copy of the existing dictionary.
   Dictionary dict = mDict;
@@ -181,15 +177,15 @@ bool Index::write(PostingMap map) {
     } else {
       // Read existing postings.
       key = it->key;
-      quint32 postCount = readVInt(postIn);
+      quint32 postCount = postInFile.readVInt();
       bool end = (newIt == newEnd || newIt.key() != it->key);
       postings.reserve(postCount + (!end ? newIt.value().size() : 0));
       for (quint32 i = 0; i < postCount; ++i) {
         quint32 proxPos;
         Posting posting;
-        posting.id = readVInt(postIn);
-        postIn >> posting.field >> proxPos;
-        readPositions(proxIn, posting.positions);
+        posting.id = postInFile.readVInt();
+        postInFile >> posting.field >> proxPos;
+        readPositions(proxInFile, posting.positions);
         postings.append(posting);
       }
 
@@ -272,29 +268,27 @@ QList<Index::Posting> Index::postings(const Term &term, bool positional) const {
     return QList<Posting>();
 
   QDir dir = indexDir();
-  QFile file(dir.filePath(kPostFile));
-  if (!file.open(QIODevice::ReadOnly))
+  MmapFileReader file(dir.filePath(kPostFile));
+  if (!file.open())
     return QList<Posting>();
 
-  QFile proxFile;
+  MmapFileReader proxFile(dir.filePath(kProxFile));
   if (positional) {
-    proxFile.setFileName(dir.filePath(kProxFile));
-    if (!proxFile.open(QIODevice::ReadOnly))
+    if (!proxFile.open())
       return QList<Posting>();
   }
 
   // Skip to the correct entry.
   file.seek(it->value);
-  QDataStream in(&file);
 
   // Read list.
   QList<Posting> postings;
-  quint32 postCount = readVInt(in);
+  quint32 postCount = file.readVInt();
   for (quint32 i = 0; i < postCount; ++i) {
     quint32 proxPos;
     Posting posting;
-    posting.id = readVInt(in);
-    in >> posting.field >> proxPos;
+    posting.id = file.readVInt();
+    file >> posting.field >> proxPos;
 
     // Filter by field.
     quint8 field = posting.field & 0x0F;
@@ -303,8 +297,7 @@ QList<Index::Posting> Index::postings(const Term &term, bool positional) const {
       // Load positions when needed.
       if (positional) {
         proxFile.seek(proxPos);
-        QDataStream proxIn(&proxFile);
-        readPositions(proxIn, posting.positions);
+        readPositions(proxFile, posting.positions);
       }
 
       postings.append(posting);
@@ -317,8 +310,8 @@ QList<Index::Posting> Index::postings(const Term &term, bool positional) const {
 QList<Index::Posting> Index::postings(const Predicate &pred,
                                       Field field) const {
   QDir dir = indexDir();
-  QFile file(dir.filePath(kPostFile));
-  if (!file.open(QIODevice::ReadOnly))
+  MmapFileReader file(dir.filePath(kPostFile));
+  if (!file.open())
     return QList<Posting>();
 
   QList<Posting> postings;
@@ -329,15 +322,14 @@ QList<Index::Posting> Index::postings(const Predicate &pred,
 
     // Skip to the correct entry.
     file.seek(word.value);
-    QDataStream in(&file);
 
     // Read list.
-    quint32 postCount = readVInt(in);
+    quint32 postCount = file.readVInt();
     for (quint32 i = 0; i < postCount; ++i) {
       quint32 proxPos;
       Posting posting;
-      posting.id = readVInt(in);
-      in >> posting.field >> proxPos;
+      posting.id = file.readVInt();
+      file >> posting.field >> proxPos;
 
       // Match field.
       quint8 postField = posting.field & 0x0F;
@@ -352,8 +344,8 @@ QList<Index::Posting> Index::postings(const Predicate &pred,
 
 QMap<Index::Field, QStringList> Index::fieldMap(const QString &prefix) const {
   QDir dir = indexDir();
-  QFile file(dir.filePath(kPostFile));
-  if (!file.open(QIODevice::ReadOnly))
+  MmapFileReader file(dir.filePath(kPostFile));
+  if (!file.open())
     return QMap<Field, QStringList>();
 
   Dictionary::const_iterator it = mDict.constBegin();
@@ -370,16 +362,15 @@ QMap<Index::Field, QStringList> Index::fieldMap(const QString &prefix) const {
   while (it != end) {
     // Skip to the correct entry.
     file.seek(it->value);
-    QDataStream in(&file);
 
     // Read list.
     QString name = it->key;
-    quint32 postCount = readVInt(in);
+    quint32 postCount = file.readVInt();
     for (quint32 i = 0; i < postCount; ++i) {
       quint8 field;
       quint32 proxPos;
-      readVInt(in); // Discard id.
-      in >> field >> proxPos;
+      file.readVInt(); // Discard id.
+      file >> field >> proxPos;
 
       QStringList &fieldList = map[static_cast<Field>(field & 0x0F)];
       if (fieldList.isEmpty() || fieldList.last() != name)
@@ -476,22 +467,6 @@ void Index::writeVersion() const {
     QDataStream(&file) << version();
 }
 
-// Use the same variable length VInt encoding as Lucene.
-quint32 Index::readVInt(QDataStream &in) {
-  // Read least significant byte.
-  quint8 byte;
-  in >> byte;
-  quint32 result = byte & 0x7F;
-
-  // Continue reading more significant bytes.
-  for (quint32 shift = 7; byte & 0x80; shift += 7) {
-    in >> byte;
-    result |= (byte & 0x7F) << shift;
-  }
-
-  return result;
-}
-
 void Index::writeVInt(QDataStream &out, quint32 arg) {
   // Write less significant bytes first.
   // Most significant bit is set.
@@ -506,13 +481,13 @@ void Index::writeVInt(QDataStream &out, quint32 arg) {
 }
 
 // Write deltas to minimize bytes per position.
-void Index::readPositions(QDataStream &in, QVector<quint32> &positions) {
+void Index::readPositions(MmapFileReader &in, QVector<quint32> &positions) {
   quint32 prev = 0;
-  quint32 count = readVInt(in);
+  quint32 count = in.readVInt();
   positions.reserve(count);
   for (quint32 i = 0; i < count; ++i) {
     // Convert to absolute from delta.
-    quint32 position = prev + readVInt(in);
+    quint32 position = prev + in.readVInt();
     positions.append(position);
     prev = position;
   }

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -12,6 +12,7 @@
 
 #include "git/Id.h"
 #include "git/Repository.h"
+#include "MmapFileReader.h"
 #include <QList>
 #include <QObject>
 #include <QVector>
@@ -113,11 +114,10 @@ public:
   static QString lockFile(const git::Repository &repo);
 
   // vint
-  static quint32 readVInt(QDataStream &in);
   static void writeVInt(QDataStream &out, quint32 arg);
 
   // positions
-  static void readPositions(QDataStream &in, QVector<quint32> &positions);
+  static void readPositions(MmapFileReader &in, QVector<quint32> &positions);
   static void writePositions(QDataStream &out,
                              const QVector<quint32> &positions);
 

--- a/src/index/MmapFileReader.cpp
+++ b/src/index/MmapFileReader.cpp
@@ -1,0 +1,52 @@
+//
+//          Copyright (c) 2025
+//
+// This software is licensed under the MIT License. The LICENSE.md file
+// describes the conditions under which this software may be distributed.
+//
+// Author: Alf Henrik Sauge
+//
+
+#include "MmapFileReader.h"
+#include <QIODevice>
+
+MmapFileReader::MmapFileReader(QString filepath)
+    : proxInFile(filepath), ptr(nullptr), end(nullptr) {}
+
+MmapFileReader::~MmapFileReader() { close(); }
+
+bool MmapFileReader::open() {
+  if (proxInFile.open(QIODevice::ReadOnly)) {
+    quint64 size = proxInFile.size();
+    data = proxInFile.map(0, size);
+    if (data == nullptr) {
+      throw std::runtime_error("Failed to map file");
+    }
+    ptr = data;
+    end = ptr + size;
+    return true;
+  }
+  return false;
+}
+
+void MmapFileReader::close() {
+  if (proxInFile.isOpen()) {
+    proxInFile.unmap(data);
+    proxInFile.close();
+  }
+}
+
+void MmapFileReader::seek(quint32 pos) { ptr = data + pos; }
+
+quint32 MmapFileReader::readVInt() {
+  quint32 result = 0;
+  quint32 shift = 0;
+  quint8 byte;
+
+  do {
+    byte = *ptr++;
+    result |= (byte & 0x7F) << shift;
+    shift += 7;
+  } while (byte & 0x80);
+  return result;
+}

--- a/src/index/MmapFileReader.h
+++ b/src/index/MmapFileReader.h
@@ -1,0 +1,53 @@
+//
+//          Copyright (c) 2025
+//
+// This software is licensed under the MIT License. The LICENSE.md file
+// describes the conditions under which this software may be distributed.
+//
+// Author: Alf Henrik Sauge
+//
+
+#ifndef MMAPFILEREADER_H
+#define MMAPFILEREADER_H
+
+#include <memory>
+#include <QFile>
+#include <QtEndian>
+
+/// @brief Reads file by memory mapping it and skipping all Qt layers to provide
+/// better performance
+class MmapFileReader : public QObject {
+private:
+  QFile proxInFile;
+  quint8 *data;
+  const quint8 *ptr;
+  const quint8 *end;
+
+public:
+  MmapFileReader(QString filepath);
+  ~MmapFileReader();
+  bool open();
+  void close();
+  void seek(quint32 pos);
+  quint32 readVInt();
+
+  template <class T> void read(T &value) {
+    std::memcpy(&value, ptr, sizeof(T));
+    ptr += sizeof(T);
+  }
+
+  MmapFileReader &operator>>(quint8 &obj) {
+    read(obj);
+    return *this;
+  }
+
+  MmapFileReader &operator>>(quint32 &obj) {
+    read(obj);
+    // Convert from big endian to machine endian to mimic default
+    //  QDataStream behaviour
+    obj = qFromBigEndian(obj);
+    return *this;
+  }
+};
+
+#endif


### PR DESCRIPTION
This implements point 1 in #868 by reading the more performance critical files memory mapped. The Qt data structures also is contributing to a slowdown, so this implements a more raw read of the data. Some simple benchmarks on my machine indicates 10-15% decrease in execution time