### PR TITLE
Add backend support for SHA256 repos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ option(USE_SYSTEM_LUA "Use the system-wide Lua installation" OFF)
 option(USE_SYSTEM_HUNSPELL "Use the system-wide hunspell installation" OFF)
 option(USE_SYSTEM_CMARK "Use the system-wide cmark installation" OFF)
 option(ENABLE_TESTS "Enable Gittyup Unittests" ON)
+option(ENABLE_SHA256 "Enable SHA256 support within Gittyup" ON)
 
 set(LUA_MODULES_PATH
     CACHE
@@ -146,7 +147,9 @@ if(DEBUG_FLATPAK)
   add_compile_definitions(DEBUG_FLATPAK)
 endif()
 
-add_compile_definitions(GIT_EXPERIMENTAL_SHA256)
+if(ENABLE_SHA256)
+  add_compile_definitions(GIT_EXPERIMENTAL_SHA256)
+endif()
 
 include(GNUInstallDirs) # Defines some variables as BINDIR, LIBDIR, ...
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,8 @@ if(DEBUG_FLATPAK)
   add_compile_definitions(DEBUG_FLATPAK)
 endif()
 
+add_compile_definitions(GIT_EXPERIMENTAL_SHA256)
+
 include(GNUInstallDirs) # Defines some variables as BINDIR, LIBDIR, ...
 
 set(QT_TRANSLATIONS_DIR "${Qt6_DIR}/../../../translations")

--- a/src/git/Id.cpp
+++ b/src/git/Id.cpp
@@ -13,12 +13,6 @@
 
 namespace git {
 
-namespace {
-
-const Id kInvalidId(QByteArray(GIT_OID_SHA1_SIZE, -1), GIT_OID_SHA1);
-
-} // namespace
-
 Id::Id() {
 #ifdef GIT_EXPERIMENTAL_SHA256
   d.type = 0;
@@ -52,13 +46,7 @@ Id::operator const git_oid *() const { return &d; }
 
 bool Id::isNull() const { return git_oid_is_zero(&d); }
 
-bool Id::isValid() const {
-  return
-#ifdef GIT_EXPERIMENTAL_SHA256
-      d.type != 0 &&
-#endif
-      !git_oid_equal(&d, kInvalidId);
-}
+bool Id::isValid() const { return isNull() == false; }
 
 QString Id::toString() const { return toByteArray().toHex(); }
 
@@ -72,8 +60,6 @@ bool Id::operator<(const Id &rhs) const { return (git_oid_cmp(&d, rhs) < 0); }
 bool Id::operator==(const Id &rhs) const { return git_oid_equal(&d, rhs); }
 
 bool Id::operator!=(const Id &rhs) const { return !git_oid_equal(&d, rhs); }
-
-Id Id::invalidId() { return kInvalidId; }
 
 uint8_t Id::getSize() const {
 #ifdef GIT_EXPERIMENTAL_SHA256

--- a/src/git/Id.cpp
+++ b/src/git/Id.cpp
@@ -15,14 +15,24 @@ namespace git {
 
 namespace {
 
-const Id kInvalidId = QByteArray(GIT_OID_SHA1_SIZE, -1);
+const Id kInvalidId(QByteArray(GIT_OID_SHA1_SIZE, -1), GIT_OID_SHA1);
 
 } // namespace
 
-Id::Id() { memset(d.id, 0, GIT_OID_SHA1_SIZE); }
+Id::Id() {
+#ifdef GIT_EXPERIMENTAL_SHA256
+  d.type = 0;
+#endif
+  memset(d.id, 0, GIT_OID_MAX_SIZE);
+}
 
-Id::Id(const QByteArray &id) {
+Id::Id(const QByteArray &id, git_oid_t type) {
+#ifdef GIT_EXPERIMENTAL_SHA256
+  git_oid_from_raw(&d, reinterpret_cast<const unsigned char *>(id.constData()),
+                   type);
+#else
   git_oid_fromraw(&d, reinterpret_cast<const unsigned char *>(id.constData()));
+#endif
 }
 
 Id::Id(const git_oid &id) { git_oid_cpy(&d, &id); }
@@ -31,7 +41,10 @@ Id::Id(const git_oid *id) {
   if (id) {
     git_oid_cpy(&d, id);
   } else {
-    memset(d.id, 0, GIT_OID_SHA1_SIZE);
+#ifdef GIT_EXPERIMENTAL_SHA256
+    d.type = 0;
+#endif
+    memset(d.id, 0, GIT_OID_MAX_SIZE);
   }
 }
 
@@ -39,13 +52,19 @@ Id::operator const git_oid *() const { return &d; }
 
 bool Id::isNull() const { return git_oid_is_zero(&d); }
 
-bool Id::isValid() const { return !git_oid_equal(&d, kInvalidId); }
+bool Id::isValid() const {
+  return
+#ifdef GIT_EXPERIMENTAL_SHA256
+      d.type != 0 &&
+#endif
+      !git_oid_equal(&d, kInvalidId);
+}
 
 QString Id::toString() const { return toByteArray().toHex(); }
 
 QByteArray Id::toByteArray() const {
   const char *data = reinterpret_cast<const char *>(d.id);
-  return QByteArray::fromRawData(data, GIT_OID_SHA1_SIZE);
+  return QByteArray::fromRawData(data, getSize());
 }
 
 bool Id::operator<(const Id &rhs) const { return (git_oid_cmp(&d, rhs) < 0); }
@@ -55,6 +74,29 @@ bool Id::operator==(const Id &rhs) const { return git_oid_equal(&d, rhs); }
 bool Id::operator!=(const Id &rhs) const { return !git_oid_equal(&d, rhs); }
 
 Id Id::invalidId() { return kInvalidId; }
+
+uint8_t Id::getSize() const {
+#ifdef GIT_EXPERIMENTAL_SHA256
+  return Id::getSize(static_cast<git_oid_t>(d.type));
+#else
+  return GIT_OID_SHA1_SIZE;
+#endif
+}
+
+uint8_t Id::getSize(const git_oid_t type) {
+  switch (type) {
+#ifdef GIT_EXPERIMENTAL_SHA256
+    case GIT_OID_SHA256:
+      return GIT_OID_SHA256_SIZE;
+#endif
+
+    case GIT_OID_SHA1:
+      return GIT_OID_SHA1_SIZE;
+
+    default:
+      return 0;
+  }
+}
 
 uint qHash(const Id &key) { return qHash(key.toByteArray()); }
 

--- a/src/git/Id.h
+++ b/src/git/Id.h
@@ -33,7 +33,6 @@ public:
   bool operator==(const Id &rhs) const;
   bool operator!=(const Id &rhs) const;
 
-  static Id invalidId();
   uint8_t getSize() const;
   static uint8_t getSize(const git_oid_t type);
 

--- a/src/git/Id.h
+++ b/src/git/Id.h
@@ -19,7 +19,7 @@ namespace git {
 class Id {
 public:
   Id();
-  Id(const QByteArray &id);
+  Id(const QByteArray &id, git_oid_t type);
   Id(const git_oid &id);
   Id(const git_oid *id);
 
@@ -34,6 +34,8 @@ public:
   bool operator!=(const Id &rhs) const;
 
   static Id invalidId();
+  uint8_t getSize() const;
+  static uint8_t getSize(const git_oid_t type);
 
 private:
   operator const git_oid *() const;

--- a/src/git/Index.h
+++ b/src/git/Index.h
@@ -81,7 +81,8 @@ private:
 
   Id headId(const QString &path, uint32_t *mode = nullptr) const;
   Id indexId(const QString &path, uint32_t *mode = nullptr) const;
-  Id workdirId(const QString &path, uint32_t *mode = nullptr) const;
+  std::optional<Id> workdirId(const QString &path,
+                              uint32_t *mode = nullptr) const;
 
   QSharedPointer<Data> d;
 

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -110,6 +110,7 @@ QMap<git_repository *, QWeakPointer<Repository::Data>> Repository::registry;
 Repository::Data::Data(git_repository *repo)
     : repo(repo), notifier(new RepositoryNotifier) {
   // Load starred commits.
+  git_oid_t hash_type = git_repository_oid_type(repo);
   QDir dir(git_repository_path(repo));
   QFile file(appDir(dir).filePath(kStarFile));
   if (!file.open(QIODevice::ReadOnly))
@@ -120,7 +121,7 @@ Repository::Data::Data(git_repository *repo)
     return;
 
   foreach (const QByteArray &id, ids.split('\n'))
-    starredCommits.insert(QByteArray::fromHex(id));
+    starredCommits.insert(git::Id(QByteArray::fromHex(id), hash_type));
 }
 
 Repository::Data::~Data() {
@@ -200,6 +201,10 @@ Config Repository::appConfig() const {
   QString path = appDir().filePath(kConfigFile);
   config.addFile(path, GIT_CONFIG_LEVEL_LOCAL, d->repo);
   return config;
+}
+
+git_oid_t Repository::oidType() const {
+  return git_repository_oid_type(d->repo);
 }
 
 bool Repository::isBare() const { return git_repository_is_bare(d->repo); }

--- a/src/git/Repository.h
+++ b/src/git/Repository.h
@@ -85,6 +85,9 @@ public:
   Config gitConfig() const;
   Config appConfig() const;
 
+  // OID type
+  git_oid_t oidType() const;
+
   // bare
   bool isBare() const;
 

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -64,12 +64,15 @@ void Index::reset() {
   mIds.clear();
   mDict.clear();
 
+  git_oid_t id_type = mRepo.oidType();
+  uint8_t id_size = git::Id::getSize(id_type);
+
   // Read already indexed ids.
   QDir dir = indexDir();
   QFile idFile(dir.filePath(kIdFile));
   if (idFile.open(QIODevice::ReadOnly)) {
     while (idFile.bytesAvailable() > 0)
-      mIds.append(idFile.read(GIT_OID_SHA1_SIZE));
+      mIds.append(git::Id(idFile.read(id_size), id_type));
   }
 
   // Read dictionary.
@@ -142,7 +145,7 @@ bool Index::write(PostingMap map) {
 
   // Write id file.
   foreach (const git::Id &id, mIds)
-    idFile.write(id.toByteArray(), GIT_OID_SHA1_SIZE);
+    idFile.write(id.toByteArray(), id.getSize());
 
   // Merge new entries into existing postings file.
   // Write dictionary and postings files in lockstep.


### PR DESCRIPTION
This adds the non-GUI aspects of #860. This is pretty straightforward except for the validity of the Id object. It seems like the Id object has been abused for error handling by setting a specific value that in principle, to my knowledge, _is_ valid. I've thus ditched `kInvalidId` and replaced it with use of `std::optional`. That still leaves `Id::isValid` which I honestly find a bit fishy. My assumption, which seems supported by the existence and usage of `git_oid_is_zero` and corresponding usage of it in libgit2 examples etc., is that an all-zero Id is a place-holder Id and thus not valid. This is also supported within the existing Gittyup/Gitahead code base https://github.com/Murmele/Gittyup/blob/fa59b6632ba59ce3f3bd9e8786417f3ae2cb6412/src/git/Index.cpp#L155

At some point, `Id::isValid` must have checked against something other than an all -1 bytes Id, otherwise this code would never hit (which is does after my modifications)
https://github.com/Murmele/Gittyup/blob/fa59b6632ba59ce3f3bd9e8786417f3ae2cb6412/src/git/Index.cpp#L112

So my conclusion is that `Id::isValid` can be mapped checking for a non-zero Id. This works fine and the tests pass as well.