### PR TITLE
Improve multi-threading behaviour of indexer

### DIFF
--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -124,7 +124,7 @@ bool Index::remove() {
   return true;
 }
 
-bool Index::write(PostingMap map) {
+bool Index::write(const PostingMap &map) {
   if (map.isEmpty())
     return false;
 

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -91,7 +91,7 @@ public:
   void reset();
   void clean();
   bool remove();
-  bool write(PostingMap map);
+  bool write(const PostingMap &map);
 
   QList<git::Commit> commits(const QString &filter) const;
   QList<git::Commit> commits(const QList<Posting> &postings) const;

--- a/src/index/WorkerQueue.h
+++ b/src/index/WorkerQueue.h
@@ -1,0 +1,69 @@
+//
+//          Copyright (c) 2025
+//
+// This software is licensed under the MIT License. The LICENSE.md file
+// describes the conditions under which this software may be distributed.
+//
+// Author: Alf Henrik Sauge
+//
+
+#ifndef WORKERQUEUE_H
+#define WORKERQUEUE_H
+
+#include <QMutex>
+#include <QMutexLocker>
+#include <QQueue>
+#include <QWaitCondition>
+
+template <class T> class WorkerQueue : public QObject {
+private:
+  const qsizetype mMaxSize;
+  QQueue<T> mQueue;
+  QMutex mMutex;
+  QWaitCondition mNotEmpty;
+  QWaitCondition mNotFull;
+  QWaitCondition mEmpty;
+  volatile bool mStop = false;
+
+public:
+  WorkerQueue(QObject *parent = nullptr)
+      : QObject(parent), mMaxSize(std::numeric_limits<qsizetype>::max()) {}
+  WorkerQueue(qsizetype maxSize, QObject *parent = nullptr)
+      : QObject(parent), mMaxSize(maxSize) {}
+
+  void stop() {
+    mStop = true;
+    mNotEmpty.wakeAll();
+    mEmpty.wakeAll();
+  }
+  void enqueue(T &&item) {
+    QMutexLocker lock(&mMutex);
+    while (mQueue.size() == mMaxSize && !mStop)
+      mNotFull.wait(&mMutex);
+    mQueue.enqueue(std::move(item));
+    mNotEmpty.wakeOne();
+  }
+
+  void awaitEmpty() {
+    QMutexLocker lock(&mMutex);
+    while (mQueue.empty() == false && !mStop)
+      mEmpty.wait(&mMutex);
+  }
+
+  std::optional<T> dequeue() {
+    QMutexLocker lock(&mMutex);
+    while (mQueue.empty() && !mStop)
+      mNotEmpty.wait(&mMutex);
+    if (mStop)
+      return std::nullopt;
+    else {
+      T item = std::move(mQueue.dequeue());
+      mNotFull.wakeOne();
+      if (mQueue.size() == 0)
+        mEmpty.wakeAll();
+      return item;
+    }
+  }
+};
+
+#endif


### PR DESCRIPTION
There's a lot to unwind here, but essentially this is implementing point 4 in #876 and tries to work around point 2 a bit.

To summarise, these are the issues tackled

1. The prior code is doing a lot in sequence. The fetching and writing are all done single-threaded. I've not changed that, but essentially made it run in parallel with the processing threads.
2. Extracting the git diff is so expensive that it's worth running in a separate thread
3. It seems that too many threads accessing libgit2 will essentially block threads giving zero return. On the machines I've tested (AMD Ryzen 9 5950X, and some laptop Intel Core i7), this limit seems to be around 4 cores. There's still only 4 threads significantly accessing libgit2, but on top of this the one thread per cpu thread is spawned to do processing that is assumed to be far less impacted by libgit2 single-threaded nature. This means that the code will over-commit resources, but so far I fail to spot any performance impact even when running this with it forced to 2 or 4 CPU threads.

I've tried to limit the amount of code that's touched here. Essentially the prior workflow is kept, but split up into separate threads with queues between them for synchronisation. The queues have a max size to not bloat things up, and they do work. Sadly with a large enough repository, you can see the threads stalling, waiting for the results to be written to disk. This means that I'm quite confident that this will work on machines with less than 9 cores.

As for performance, this is what I see on my machine indexing Yocto / Poky (by no means accurate numbers, but just to give an idea of the improvement)
```
Before:
real    1m53,593s
user    8m8,761s
sys     1m42,714s

After:
real    1m2,234s
user    4m26,652s
sys     0m27,288s
```
This indicates about 45% decrease in execution time, both in real time and CPU time. There's a massive 73% decrease in sys time since the code no longer hammers the read-write lock in the libgit2 cache system.

To conclude, even though there are more threads spawned than CPU threads, this doesn't use all CPU cores, but by limiting the libgit2 access to fewer threads, this so far improves performance in all scenarios (likely irrespective of CPU thread count) by running single-threaded operations in parallel with the processing. If we want to make it use all CPU cores, I believe libgit2 needs some attention to improve the multi-threading support.