### PR TITLE
Fix formatting in Indexer and enable Windows builds

### DIFF
--- a/src/index/Indexer/indexer.cpp
+++ b/src/index/Indexer/indexer.cpp
@@ -19,53 +19,53 @@
 #include <strsafe.h>
 
 namespace {
-	static LPTOP_LEVEL_EXCEPTION_FILTER defaultFilter = nullptr;
+  static LPTOP_LEVEL_EXCEPTION_FILTER defaultFilter = nullptr;
 
-	static LONG WINAPI exceptionFilter(PEXCEPTION_POINTERS info) {
-	  // Protect against reentering.
-	  static bool entered = false;
-	  if (entered)
-		ExitProcess(1);
-	  entered = true;
+  static LONG WINAPI exceptionFilter(PEXCEPTION_POINTERS info) {
+    // Protect against reentering.
+    static bool entered = false;
+    if (entered)
+      ExitProcess(1);
+    entered = true;
 
-	  // Write dump file.
-	  SYSTEMTIME localTime;
-	  GetLocalTime(&localTime);
+    // Write dump file.
+    SYSTEMTIME localTime;
+    GetLocalTime(&localTime);
 
-	  wchar_t temp[MAX_PATH];
-	  GetTempPath(MAX_PATH, temp);
+    wchar_t temp[MAX_PATH];
+    GetTempPath(MAX_PATH, temp);
 
-	  wchar_t dir[MAX_PATH];
-	  const wchar_t *gittyup_name = L"%sGittyup";
-	  StringCchPrintf(dir, MAX_PATH, gittyup_name, temp);
-	  CreateDirectory(dir, NULL);
+    wchar_t dir[MAX_PATH];
+    const wchar_t *gittyup_name = L"%sGittyup";
+    StringCchPrintf(dir, MAX_PATH, gittyup_name, temp);
+    CreateDirectory(dir, NULL);
 
-	  wchar_t fileName[MAX_PATH];
-	  const wchar_t *s = L"%s\\%s-%s-%04d%02d%02d-%02d%02d%02d-%ld-%ld.dmp";
-	  StringCchPrintf(fileName, MAX_PATH, s, dir, "indexer", GITTYUP_VERSION,
-					  localTime.wYear, localTime.wMonth, localTime.wDay,
-					  localTime.wHour, localTime.wMinute, localTime.wSecond,
-					  GetCurrentProcessId(), GetCurrentThreadId());
+    wchar_t fileName[MAX_PATH];
+    const wchar_t *s = L"%s\\%s-%s-%04d%02d%02d-%02d%02d%02d-%ld-%ld.dmp";
+    StringCchPrintf(fileName, MAX_PATH, s, dir, "indexer", GITTYUP_VERSION,
+                    localTime.wYear, localTime.wMonth, localTime.wDay,
+                    localTime.wHour, localTime.wMinute, localTime.wSecond,
+                    GetCurrentProcessId(), GetCurrentThreadId());
 
-	  HANDLE dumpFile =
-		  CreateFile(fileName, GENERIC_READ | GENERIC_WRITE,
-					 FILE_SHARE_WRITE | FILE_SHARE_READ, 0, CREATE_ALWAYS, 0, 0);
+    HANDLE dumpFile =
+        CreateFile(fileName, GENERIC_READ | GENERIC_WRITE,
+                   FILE_SHARE_WRITE | FILE_SHARE_READ, 0, CREATE_ALWAYS, 0, 0);
 
-	  MINIDUMP_EXCEPTION_INFORMATION expParam;
-	  expParam.ThreadId = GetCurrentThreadId();
-	  expParam.ExceptionPointers = info;
-	  expParam.ClientPointers = TRUE;
+    MINIDUMP_EXCEPTION_INFORMATION expParam;
+    expParam.ThreadId = GetCurrentThreadId();
+    expParam.ExceptionPointers = info;
+    expParam.ClientPointers = TRUE;
 
-	  MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), dumpFile,
-						MiniDumpWithDataSegs, &expParam, NULL, NULL);
+    MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), dumpFile,
+                      MiniDumpWithDataSegs, &expParam, NULL, NULL);
 
-	  return defaultFilter ? defaultFilter(info) : EXCEPTION_CONTINUE_SEARCH;
-	}
+    return defaultFilter ? defaultFilter(info) : EXCEPTION_CONTINUE_SEARCH;
+  }
 } // namespace
 
 // Install exception filter.
 void installExceptionFilter() {
-	defaultFilter = SetUnhandledExceptionFilter(&exceptionFilter);
+  defaultFilter = SetUnhandledExceptionFilter(&exceptionFilter);
 }
 #endif
 

--- a/src/index/Indexer/indexer.cpp
+++ b/src/index/Indexer/indexer.cpp
@@ -19,48 +19,48 @@
 #include <strsafe.h>
 
 namespace {
-  static LPTOP_LEVEL_EXCEPTION_FILTER defaultFilter = nullptr;
+static LPTOP_LEVEL_EXCEPTION_FILTER defaultFilter = nullptr;
 
-  static LONG WINAPI exceptionFilter(PEXCEPTION_POINTERS info) {
-    // Protect against reentering.
-    static bool entered = false;
-    if (entered)
-      ExitProcess(1);
-    entered = true;
+static LONG WINAPI exceptionFilter(PEXCEPTION_POINTERS info) {
+  // Protect against reentering.
+  static bool entered = false;
+  if (entered)
+    ExitProcess(1);
+  entered = true;
 
-    // Write dump file.
-    SYSTEMTIME localTime;
-    GetLocalTime(&localTime);
+  // Write dump file.
+  SYSTEMTIME localTime;
+  GetLocalTime(&localTime);
 
-    wchar_t temp[MAX_PATH];
-    GetTempPath(MAX_PATH, temp);
+  wchar_t temp[MAX_PATH];
+  GetTempPath(MAX_PATH, temp);
 
-    wchar_t dir[MAX_PATH];
-    const wchar_t *gittyup_name = L"%sGittyup";
-    StringCchPrintf(dir, MAX_PATH, gittyup_name, temp);
-    CreateDirectory(dir, NULL);
+  wchar_t dir[MAX_PATH];
+  const wchar_t *gittyup_name = L"%sGittyup";
+  StringCchPrintf(dir, MAX_PATH, gittyup_name, temp);
+  CreateDirectory(dir, NULL);
 
-    wchar_t fileName[MAX_PATH];
-    const wchar_t *s = L"%s\\%s-%s-%04d%02d%02d-%02d%02d%02d-%ld-%ld.dmp";
-    StringCchPrintf(fileName, MAX_PATH, s, dir, "indexer", GITTYUP_VERSION,
-                    localTime.wYear, localTime.wMonth, localTime.wDay,
-                    localTime.wHour, localTime.wMinute, localTime.wSecond,
-                    GetCurrentProcessId(), GetCurrentThreadId());
+  wchar_t fileName[MAX_PATH];
+  const wchar_t *s = L"%s\\%s-%s-%04d%02d%02d-%02d%02d%02d-%ld-%ld.dmp";
+  StringCchPrintf(fileName, MAX_PATH, s, dir, "indexer", GITTYUP_VERSION,
+                  localTime.wYear, localTime.wMonth, localTime.wDay,
+                  localTime.wHour, localTime.wMinute, localTime.wSecond,
+                  GetCurrentProcessId(), GetCurrentThreadId());
 
-    HANDLE dumpFile =
-        CreateFile(fileName, GENERIC_READ | GENERIC_WRITE,
-                   FILE_SHARE_WRITE | FILE_SHARE_READ, 0, CREATE_ALWAYS, 0, 0);
+  HANDLE dumpFile =
+      CreateFile(fileName, GENERIC_READ | GENERIC_WRITE,
+                 FILE_SHARE_WRITE | FILE_SHARE_READ, 0, CREATE_ALWAYS, 0, 0);
 
-    MINIDUMP_EXCEPTION_INFORMATION expParam;
-    expParam.ThreadId = GetCurrentThreadId();
-    expParam.ExceptionPointers = info;
-    expParam.ClientPointers = TRUE;
+  MINIDUMP_EXCEPTION_INFORMATION expParam;
+  expParam.ThreadId = GetCurrentThreadId();
+  expParam.ExceptionPointers = info;
+  expParam.ClientPointers = TRUE;
 
-    MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), dumpFile,
-                      MiniDumpWithDataSegs, &expParam, NULL, NULL);
+  MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), dumpFile,
+                    MiniDumpWithDataSegs, &expParam, NULL, NULL);
 
-    return defaultFilter ? defaultFilter(info) : EXCEPTION_CONTINUE_SEARCH;
-  }
+  return defaultFilter ? defaultFilter(info) : EXCEPTION_CONTINUE_SEARCH;
+}
 } // namespace
 
 // Install exception filter.
@@ -204,9 +204,11 @@ bool Indexer::start() {
 #ifndef Q_OS_WIN
   int numGabbers = std::min(4, std::max(1, QThread::idealThreadCount() / 2));
 #else
-  // TODO: Why do I there is a min/max macro defined here which conflicts with the std::min/max?
-  // C:\Program Files (x86)\Windows Kits\10\\include\10.0.26100.0\\shared\minwindef.h:197:29: note: expanded from macro 'min'
-  // 197 | #define min(a,b)            (((a) < (b)) ? (a) : (b))
+  // TODO: Why do I there is a min/max macro defined here which conflicts with
+  // the std::min/max? C:\Program Files (x86)\Windows
+  // Kits\10\\include\10.0.26100.0\\shared\minwindef.h:197:29: note: expanded
+  // from macro 'min' 197 | #define min(a,b)            (((a) < (b)) ? (a) :
+  // (b))
   int numGabbers = min(4, max(1, QThread::idealThreadCount() / 2));
 #endif
   int numWorkers = QThread::idealThreadCount();


### PR DESCRIPTION
This PR fixes the formatting issues in PR #908 and ensures the Windows build passes the style check. I noticed that the Windows binary was missing in the v2.0.0 release and that PR #908 addresses this but has some CI failures.