### PR TITLE
Fix crash while loading hunks

### DIFF
--- a/src/ui/DiffView/DiffView.cpp
+++ b/src/ui/DiffView/DiffView.cpp
@@ -376,7 +376,8 @@ bool DiffView::canFetchMore() {
 
 class Guard {
 public:
-  Guard(bool& variable, bool initValue): m_variable(variable), m_initValue(initValue) {
+  Guard(bool &variable, bool initValue)
+      : m_variable(variable), m_initValue(initValue) {
     m_variable = m_initValue;
     // qDebug() << "Guarding variable" << m_variable;
   }
@@ -384,8 +385,9 @@ public:
     m_variable = !m_initValue;
     // qDebug() << "Releasing variable" << m_variable;
   }
+
 private:
-  bool& m_variable;
+  bool &m_variable;
   bool m_initValue;
 };
 
@@ -397,7 +399,8 @@ private:
 void DiffView::fetchMore(int fetchWidgets) {
   if (mFetchMoreInProgress) {
     mCancelFetchMore = true;
-    // We cannot wait here because then processEvents() from below will never return
+    // We cannot wait here because then processEvents() from below will never
+    // return
     return;
   }
   auto g = Guard(mFetchMoreInProgress, true);

--- a/src/ui/DiffView/DiffView.cpp
+++ b/src/ui/DiffView/DiffView.cpp
@@ -374,12 +374,34 @@ bool DiffView::canFetchMore() {
          mFiles.size() < mDiffTreeModel->fileCount(dtw->selectedIndex());
 }
 
+class Guard {
+public:
+  Guard(bool& variable, bool initValue): m_variable(variable), m_initValue(initValue) {
+    m_variable = m_initValue;
+    // qDebug() << "Guarding variable" << m_variable;
+  }
+  ~Guard() {
+    m_variable = !m_initValue;
+    // qDebug() << "Releasing variable" << m_variable;
+  }
+private:
+  bool& m_variable;
+  bool m_initValue;
+};
+
 /*!
  * \brief DiffView::fetchMore
  * Fetch maxNewFiles more patches
  * use a while loop with canFetchMore() to get all
  */
 void DiffView::fetchMore(int fetchWidgets) {
+  if (mFetchMoreInProgress) {
+    mCancelFetchMore = true;
+    // We cannot wait here because then processEvents() from below will never return
+    return;
+  }
+  auto g = Guard(mFetchMoreInProgress, true);
+
   QVBoxLayout *layout = static_cast<QVBoxLayout *>(widget()->layout());
 
   // Add widgets.
@@ -403,6 +425,9 @@ void DiffView::fetchMore(int fetchWidgets) {
 
       // Load hunk(s) and update scrollbar
       QApplication::processEvents();
+      if (mCancelFetchMore) {
+        return;
+      }
 
       // Running the eventloop may trigger a view refresh
       if (mFiles.isEmpty())

--- a/src/ui/DiffView/DiffView.h
+++ b/src/ui/DiffView/DiffView.h
@@ -141,6 +141,9 @@ private:
   DiffTreeModel *mDiffTreeModel{nullptr};
   QWidget *mParent{nullptr};
   QVBoxLayout *mFileWidgetLayout{nullptr};
+
+  bool mFetchMoreInProgress{false};
+  bool mCancelFetchMore{false};
 };
 
 #endif


### PR DESCRIPTION
Reason: When calling QApplication::processEvents() all events are processed also user inputs which might lead to change the diff while we are reading the hunks which leads to a clear of the files where the fetchMore is currently working on it which is not correct and leads to undefined behaviour