### PR TITLE
fix Win64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,19 +143,17 @@ jobs:
             cmake_env: {}
             pack: 1
 
-          #- name: win64
-          #  os: windows-latest
-          #  ninja_platform: win
-          #  qt_platform: windows
-          #  qt_arch: win64_msvc2019_64
-          #  openssl_arch: VC-WIN64A
-          #  msvc_arch: x64
-          #  cmake_flags: "-DUSE_SYSTEM_QT=OFF -DUSE_SYSTEM_LIBSSH2=OFF -DUSE_BUNDLED_ZLIB=1 -DUSE_SSH:STRING=localbuild -DUSE_SYSTEM_OPENSSL=OFF"
-          #  cmake_env:
-          #    CMAKE_RC_FLAGS: "/C 1252"
-          #    CC: clang
-          #    CXX: clang++
-          #  pack: 1
+          - name: win64
+            os: windows-latest
+            ninja_platform: win
+            qt_platform: windows
+            qt_arch: win64_msvc2019_64
+            openssl_arch: VC-WIN64A
+            msvc_arch: x64
+            cmake_flags: "-DUSE_SYSTEM_QT=OFF -DUSE_SYSTEM_LIBSSH2=OFF -DUSE_BUNDLED_ZLIB=1 -DUSE_SSH:STRING=localbuild -DUSE_SYSTEM_OPENSSL=OFF -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl"
+            cmake_env:
+              CMAKE_RC_FLAGS: "/C 1252"
+            pack: 1
 
     steps:
       # otherwise the testcases will fail, because signature is invalid
@@ -230,6 +228,38 @@ jobs:
           mkdir -p build/release
           cd build/release
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DUPDATE_TRANSLATIONS=ON -DGITTYUP_CI_TESTS=ON ${{ env.CMAKE_FLAGS }} ${{ matrix.env.cmake_flags }} ../..
+
+      - name: Fix libssh2 import lib name (Windows)
+        if: matrix.env.ninja_platform == 'win'
+        shell: pwsh
+        run: |
+          $searchRoot = "build/release/dep/libssh2"
+          $libssh2Candidates = Get-ChildItem -Path $searchRoot -Recurse -File -Filter "libssh2.lib" -ErrorAction SilentlyContinue
+          $ssh2Candidates = Get-ChildItem -Path $searchRoot -Recurse -File -Filter "ssh2.lib" -ErrorAction SilentlyContinue
+
+          if ($libssh2Candidates) {
+            foreach ($lib in $libssh2Candidates) {
+              $ssh2 = Join-Path $lib.DirectoryName "ssh2.lib"
+              if (-not (Test-Path $ssh2)) {
+                Copy-Item -Path $lib.FullName -Destination $ssh2
+                Write-Host "Created compatibility import library: $ssh2"
+              } else {
+                Write-Host "Compatibility import library already exists: $ssh2"
+              }
+            }
+          } elseif ($ssh2Candidates) {
+            foreach ($lib in $ssh2Candidates) {
+              $libssh2 = Join-Path $lib.DirectoryName "libssh2.lib"
+              if (-not (Test-Path $libssh2)) {
+                Copy-Item -Path $lib.FullName -Destination $libssh2
+                Write-Host "Created compatibility import library: $libssh2"
+              } else {
+                Write-Host "Compatibility import library already exists: $libssh2"
+              }
+            }
+          } else {
+            Write-Warning "No libssh2/ssh2 import library found under $searchRoot. Continuing without compatibility copy."
+          }
 
       - name: Build Information
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,6 +215,18 @@ jobs:
         if: matrix.env.ninja_platform == 'win'
         uses: ilammy/setup-nasm@v1.2.0
 
+      # CPack uses NSIS on Windows (see pack/CMakeLists.txt); runners do not ship makensis.
+      - name: Install NSIS for CPack
+        if: matrix.env.ninja_platform == 'win'
+        shell: pwsh
+        run: |
+          choco install nsis -y
+          $nsis = @(
+            'C:\Program Files (x86)\NSIS',
+            'C:\Program Files\NSIS'
+          ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if ($nsis) { Add-Content $env:GITHUB_PATH $nsis }
+
       - name: Build OpenSSL (Windows)
         if: matrix.env.ninja_platform == 'win'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
     name: Formatting Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Run clang-format style check for C/C++/Protobuf programs.
-      uses: jidicula/clang-format-action@v4.8.0
+      uses: jidicula/clang-format-action@v4.18.0
       with:
         clang-format-version: '13'
         exclude-regex: 'dep'
@@ -54,16 +54,16 @@ jobs:
 
     # https://stackoverflow.com/questions/60916931/github-action-does-the-if-have-an-else
     - name: Determine flatpak release branch
-      uses: haya14busa/action-cond@v1
       id: flatpak_release_branch
-      with:
-        cond: ${{ env.IS_RELEASE }}
-        if_true: 'stable'
-        if_false: 'development'
-
+      run: |
+        if [ "${{ env.IS_RELEASE }}" = "true" ]; then
+          echo "value=stable" >> "$GITHUB_OUTPUT"
+        else
+          echo "value=development" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Replace git tag by the commit id on which it runs
       if: github.ref_type != 'tag'
@@ -108,7 +108,7 @@ jobs:
         branch: ${{ steps.flatpak_release_branch.outputs.value }}
 
     - name: Publish build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         path: Gittyup.flatpak
         name: GittyupFlatpak
@@ -162,17 +162,17 @@ jobs:
           git config --global user.name "Your Name"
           git config --global user.email "youremail@yourdomain.com"
           git config --list
+      # Use GITHUB_ENV (allenevans/set-env no longer accepts CMAKE_FLAGS; triggers workflow annotations).
       - name: Configure development build
         if: github.ref_type != 'tag'
-        uses: allenevans/set-env@c4f231179ef63887be707202a295d9cb1c687eb9
-        with:
-          CMAKE_FLAGS: '-DDEV_BUILD="${{ github.ref_name }}"'
+        shell: bash
+        run: |
+          echo "CMAKE_FLAGS=-DDEV_BUILD=\"${{ github.ref_name }}\"" >> "$GITHUB_ENV"
 
       - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Initialize Submodules
-        uses: snickerbockers/submodules-init@v4
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Install Perl
         if: matrix.env.ninja_platform == 'win'
@@ -188,7 +188,7 @@ jobs:
           sudo apt-get -y install libssh2-1-dev
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@v4.3.0
         timeout-minutes: 10
         with:
           version: ${{ matrix.qt.version }}
@@ -199,7 +199,7 @@ jobs:
           modules: qtwebengine
 
       - name: Install Ninja
-        uses: seanmiddleditch/gha-setup-ninja@v4
+        uses: seanmiddleditch/gha-setup-ninja@v6
         with:
           version: 1.11.1
           platform: ${{ matrix.env.ninja_platform }}
@@ -207,7 +207,7 @@ jobs:
 
       - name: Setup MSVC environment
         if: matrix.env.ninja_platform == 'win'
-        uses: seanmiddleditch/gha-setup-vsdevenv@v3
+        uses: seanmiddleditch/gha-setup-vsdevenv@v5
         with:
           arch: ${{ matrix.env.msvc_arch }}
 
@@ -299,7 +299,7 @@ jobs:
 
       - name: Publish build artifacts
         if: matrix.env.pack
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: build/release/pack/Gittyup-*
           name: Gittyup ${{ matrix.env.name }}
@@ -307,7 +307,7 @@ jobs:
       # Publish only once!
       - name: Publish version file
         if: matrix.env.ninja_platform == 'linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: build/release/Version.txt
           name: Gittyup-VERSION
@@ -319,10 +319,11 @@ jobs:
 
       - name: Test
         if: matrix.env.ninja_platform != 'win' && matrix.env.ninja_platform != 'mac'
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          working-directory: build/release
-          run: ninja check --verbose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+          cd build/release
+          xvfb-run -a ninja check --verbose
 
       - name: Test (Windows)
         if: matrix.env.ninja_platform == 'win'
@@ -370,15 +371,16 @@ jobs:
 
       - name: Publish Appimage
         if: matrix.env.ninja_platform == 'linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: build/release/Gittyup*.AppImage
           name: GittyupAppImage
 
   publish:
-    # https://github.com/marvinpinto/actions/issues/177
     needs: [flatpak, build]
     runs-on: ubuntu-latest # does not matter which
+    permissions:
+      contents: write
     # a prerelase is created when pushing to master
     # a release is created when a tag will be set
     # last condition is the same as IS_RELEASE,
@@ -387,57 +389,73 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' || (github.event_name == 'push' && github.ref_type == 'tag' && startswith(github.ref_name, 'gittyup_v'))  }}
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
-    
+
       # version is exported from cmake to file
       - name: Retrieve version
-        run: |
-          echo "::set-output name=VERSION::$(cat artifacts/Gittyup-VERSION/Version.txt)"
         id: version
+        run: |
+          echo "VERSION=$(cat artifacts/Gittyup-VERSION/Version.txt)" >> "$GITHUB_OUTPUT"
 
-      - name: Update GitHub release (latest tag)
-        uses: marvinpinto/action-automatic-releases@latest
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: true
-          title: 'Latest Build (Development)'
-          automatic_release_tag: 'development'
-          files: |
-            **/artifacts/GittyupFlatpak/*.flatpak
-            **/artifacts/GittyupAppImage/Gittyup*.AppImage
-
-          # Currently disabled, because we have problems with the theme
-          # **/artifacts/Gittyup win64/Gittyup*.exe
-          # **/artifacts/Gittyup macos/Gittyup*.dmg
+      # gh CLI avoids deprecated Node-based release actions (e.g. marvinpinto/action-automatic-releases).
+      - name: Update GitHub release (development)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          flatpaks=(artifacts/GittyupFlatpak/*.flatpak)
+          appimages=(artifacts/GittyupAppImage/Gittyup*.AppImage)
+          files=("${flatpaks[@]}" "${appimages[@]}")
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No Flatpak or AppImage assets to upload."
+            exit 1
+          fi
+          if ! gh release view development >/dev/null 2>&1; then
+            gh release create development \
+              --prerelease \
+              --title "Latest Build (Development)" \
+              --target "${{ github.sha }}" \
+              "${files[@]}"
+          else
+            gh release upload development "${files[@]}" --clobber
+          fi
 
       - name: Update GitHub release (version tag)
-        uses: marvinpinto/action-automatic-releases@latest
-        if: ${{ env.IS_RELEASE == 'true'}}
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: false
-          title: Gittyup Release ${{ steps.version.outputs.VERSION }}
-          automatic_release_tag: ${{ github.ref_name }}
-          files: |
-            **/artifacts/GittyupFlatpak/*.flatpak
-            **/artifacts/GittyupAppImage/Gittyup*.AppImage
+        if: ${{ env.IS_RELEASE == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          TAG="${{ github.ref_name }}"
+          flatpaks=(artifacts/GittyupFlatpak/*.flatpak)
+          appimages=(artifacts/GittyupAppImage/Gittyup*.AppImage)
+          files=("${flatpaks[@]}" "${appimages[@]}")
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No Flatpak or AppImage assets to upload."
+            exit 1
+          fi
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --title "Gittyup Release ${{ steps.version.outputs.VERSION }}" \
+              --target "${{ github.sha }}" \
+              "${files[@]}"
+          else
+            gh release upload "$TAG" "${files[@]}" --clobber
+          fi
 
-          # Currently disabled, because we have problems with the theme
-          # **/artifacts/Gittyup win64/Gittyup*.exe
-          # **/artifacts/Gittyup macos/Gittyup*.dmg
-
-      # needed otherwise the docs folder is not available     
+      # needed otherwise the docs folder is not available
       - name: Checkout repository
-        if: ${{ env.IS_RELEASE == 'true'}}
-        uses: actions/checkout@v3
+        if: ${{ env.IS_RELEASE == 'true' }}
+        uses: actions/checkout@v6
 
-      # update github pages only if it is a release 
+      # update github pages only if it is a release
       - name: Deploy Github pages
-        if: ${{ env.IS_RELEASE  == 'true'}}
-        uses: JamesIves/github-pages-deploy-action@v4.4.0
+        if: ${{ env.IS_RELEASE == 'true' }}
+        uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: docs # The folder the action should deploy.
-...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,37 +241,6 @@ jobs:
           cd build/release
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DUPDATE_TRANSLATIONS=ON -DGITTYUP_CI_TESTS=ON ${{ env.CMAKE_FLAGS }} ${{ matrix.env.cmake_flags }} ../..
 
-      - name: Fix libssh2 import lib name (Windows)
-        if: matrix.env.ninja_platform == 'win'
-        shell: pwsh
-        run: |
-          $searchRoot = "build/release/dep/libssh2"
-          $libssh2Candidates = Get-ChildItem -Path $searchRoot -Recurse -File -Filter "libssh2.lib" -ErrorAction SilentlyContinue
-          $ssh2Candidates = Get-ChildItem -Path $searchRoot -Recurse -File -Filter "ssh2.lib" -ErrorAction SilentlyContinue
-
-          if ($libssh2Candidates) {
-            foreach ($lib in $libssh2Candidates) {
-              $ssh2 = Join-Path $lib.DirectoryName "ssh2.lib"
-              if (-not (Test-Path $ssh2)) {
-                Copy-Item -Path $lib.FullName -Destination $ssh2
-                Write-Host "Created compatibility import library: $ssh2"
-              } else {
-                Write-Host "Compatibility import library already exists: $ssh2"
-              }
-            }
-          } elseif ($ssh2Candidates) {
-            foreach ($lib in $ssh2Candidates) {
-              $libssh2 = Join-Path $lib.DirectoryName "libssh2.lib"
-              if (-not (Test-Path $libssh2)) {
-                Copy-Item -Path $lib.FullName -Destination $libssh2
-                Write-Host "Created compatibility import library: $libssh2"
-              } else {
-                Write-Host "Compatibility import library already exists: $libssh2"
-              }
-            }
-          } else {
-            Write-Warning "No libssh2/ssh2 import library found under $searchRoot. Continuing without compatibility copy."
-          }
 
       - name: Build Information
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,26 +197,6 @@ else()
 endif()
 
 add_subdirectory(dep)
-
-# Ensure both import-library names are available for Windows builds that use
-# bundled libssh2; different consumers may look for either ssh2.lib or
-# libssh2.lib.
-if(WIN32
-   AND NOT USE_SYSTEM_LIBSSH2
-   AND TARGET libssh2_shared)
-  add_custom_command(
-    TARGET libssh2_shared
-    POST_BUILD
-    COMMAND
-      ${CMAKE_COMMAND} -E copy_if_different
-      "$<TARGET_LINKER_FILE:libssh2_shared>"
-      "$<TARGET_LINKER_FILE_DIR:libssh2_shared>/ssh2.lib"
-    COMMAND
-      ${CMAKE_COMMAND} -E copy_if_different
-      "$<TARGET_LINKER_FILE:libssh2_shared>"
-      "$<TARGET_LINKER_FILE_DIR:libssh2_shared>/libssh2.lib"
-    COMMENT "Ensuring both ssh2.lib and libssh2.lib import libs exist")
-endif()
 add_subdirectory(src)
 add_subdirectory(l10n)
 add_subdirectory(pack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,22 @@ else()
 endif()
 
 add_subdirectory(dep)
+
+# Ensure both import-library names are available for Windows builds that use
+# bundled libssh2; different consumers may look for either ssh2.lib or
+# libssh2.lib.
+if(WIN32 AND NOT USE_SYSTEM_LIBSSH2 AND TARGET libssh2_shared)
+  add_custom_command(
+    TARGET libssh2_shared
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_LINKER_FILE:libssh2_shared>"
+            "$<TARGET_LINKER_FILE_DIR:libssh2_shared>/ssh2.lib"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_LINKER_FILE:libssh2_shared>"
+            "$<TARGET_LINKER_FILE_DIR:libssh2_shared>/libssh2.lib"
+    COMMENT "Ensuring both ssh2.lib and libssh2.lib import libs exist")
+endif()
 add_subdirectory(src)
 add_subdirectory(l10n)
 add_subdirectory(pack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,16 +201,20 @@ add_subdirectory(dep)
 # Ensure both import-library names are available for Windows builds that use
 # bundled libssh2; different consumers may look for either ssh2.lib or
 # libssh2.lib.
-if(WIN32 AND NOT USE_SYSTEM_LIBSSH2 AND TARGET libssh2_shared)
+if(WIN32
+   AND NOT USE_SYSTEM_LIBSSH2
+   AND TARGET libssh2_shared)
   add_custom_command(
     TARGET libssh2_shared
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "$<TARGET_LINKER_FILE:libssh2_shared>"
-            "$<TARGET_LINKER_FILE_DIR:libssh2_shared>/ssh2.lib"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "$<TARGET_LINKER_FILE:libssh2_shared>"
-            "$<TARGET_LINKER_FILE_DIR:libssh2_shared>/libssh2.lib"
+    COMMAND
+      ${CMAKE_COMMAND} -E copy_if_different
+      "$<TARGET_LINKER_FILE:libssh2_shared>"
+      "$<TARGET_LINKER_FILE_DIR:libssh2_shared>/ssh2.lib"
+    COMMAND
+      ${CMAKE_COMMAND} -E copy_if_different
+      "$<TARGET_LINKER_FILE:libssh2_shared>"
+      "$<TARGET_LINKER_FILE_DIR:libssh2_shared>/libssh2.lib"
     COMMENT "Ensuring both ssh2.lib and libssh2.lib import libs exist")
 endif()
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.12)
+# 3.19+: install(FILES $<TARGET_FILE:...>) in pack/CMakeLists.txt (libssh2.dll).
+cmake_minimum_required(VERSION 3.19)
 project(Gittyup)
 
 # Set name and version.

--- a/dep/git/CMakeLists.txt
+++ b/dep/git/CMakeLists.txt
@@ -24,7 +24,11 @@ if(NOT USE_SYSTEM_GIT)
   if(APPLE)
     add_helper(osxkeychain "-framework Security")
   elseif(WIN32)
-    add_helper(wincred)
+    # The bundled wincred helper uses GNU C attributes and does not compile
+    # cleanly with cl.exe. Skip it for MSVC-based CI builds.
+    if(NOT MSVC)
+      add_helper(wincred)
+    endif()
   else()
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(LIBSECRET IMPORTED_TARGET libsecret-1)

--- a/dep/libssh2/CMakeLists.txt
+++ b/dep/libssh2/CMakeLists.txt
@@ -11,6 +11,18 @@ else()
       OFF
       CACHE BOOL "" FORCE)
 
+  # Gittyup sets BUILD_SHARED_LIBS OFF at the top level; Qt may also set this
+  # cache variable. Bundled libssh2 still needs a Windows DLL + import libs for
+  # pack/CMakeLists.txt and the ssh2.lib/libssh2.lib copy in libssh2/src.
+  if(WIN32)
+    set(BUILD_STATIC_LIBS
+        ON
+        CACHE BOOL "Build libssh2 static library" FORCE)
+    set(BUILD_SHARED_LIBS
+        ON
+        CACHE BOOL "Build libssh2 shared library" FORCE)
+  endif()
+
   add_subdirectory(libssh2)
 
   set(LIBSSH2_FOUND

--- a/pack/CMakeLists.txt
+++ b/pack/CMakeLists.txt
@@ -3,12 +3,22 @@ set(RSRC_DIR ${CMAKE_SOURCE_DIR}/rsrc)
 
 set(MAC $<PLATFORM_ID:Darwin>)
 
+# Windows packaging is x64-only. (CMake's WIN32 is true for any Windows ABI,
+# including obsolete 32-bit toolchains.)
+set(GITTYUP_PACK_WIN64 OFF)
+if(WIN32)
+  if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+    message(FATAL_ERROR "Gittyup packaging: Windows is 64-bit (x64) only.")
+  endif()
+  set(GITTYUP_PACK_WIN64 ON)
+endif()
+
 # Install Qt plugins.
 set(QT_PLUGINS QJpegPlugin)
 
 if(APPLE)
   set(QT_PLUGINS ${QT_PLUGINS} QCocoaIntegrationPlugin QMacStylePlugin)
-elseif(WIN32)
+elseif(GITTYUP_PACK_WIN64)
   set(QT_PLUGINS ${QT_PLUGINS} QWindowsIntegrationPlugin
                  QWindowsVistaStylePlugin)
 else()
@@ -16,7 +26,7 @@ else()
                  QComposePlatformInputContextPlugin)
 endif()
 
-if(WIN32)
+if(GITTYUP_PACK_WIN64)
   set(INSTALL_LIBDIR ${CMAKE_INSTALL_BINDIR})
 elseif(NOT APPLE)
   set(INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
@@ -53,7 +63,7 @@ elseif(NOT USE_SYSTEM_QT)
         WORLD_EXECUTE
       COMPONENT ${GITTYUP_NAME})
 
-    if(WIN32)
+    if(GITTYUP_PACK_WIN64)
       # Copy into build dir.
       execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PLUGIN}
                               ${CMAKE_BINARY_DIR}/${PLUGIN_PATH})
@@ -98,7 +108,7 @@ elseif(NOT USE_SYSTEM_QT)
         PATTERN "Headers" EXCLUDE
         PATTERN ".DS_Store" EXCLUDE)
     else()
-      if(WIN32)
+      if(GITTYUP_PACK_WIN64)
         get_filename_component(TARGET_NAME ${QT_LIBRARY} NAME)
 
         # Copy into build dir.
@@ -124,7 +134,7 @@ elseif(NOT USE_SYSTEM_QT)
         COMPONENT ${GITTYUP_NAME}
         RENAME ${TARGET_NAME})
 
-      if(NOT WIN32)
+      if(NOT GITTYUP_PACK_WIN64)
         # Delete runpath.
         install(CODE "execute_process(COMMAND chrpath --delete
             \${CMAKE_INSTALL_PREFIX}/${TARGET_NAME}
@@ -137,12 +147,8 @@ endif()
 # Install SSL libraries.
 if(NOT APPLE)
   if(NOT USE_SYSTEM_OPENSSL)
-    if(WIN32)
-      if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-        set(SSL_LIB_SUFFIX "-3-x64.dll")
-      else()
-        set(SSL_LIB_SUFFIX "-3.dll")
-      endif()
+    if(GITTYUP_PACK_WIN64)
+      set(SSL_LIB_SUFFIX "-3-x64.dll")
     else()
       set(SSL_LIB_SUFFIX ".so.3")
     endif()
@@ -169,7 +175,27 @@ if(NOT APPLE)
     endforeach()
   endif()
 
-  if(WIN32 OR APPLE)
+  # libssh2 (submodule) installs its DLL without COMPONENT ${GITTYUP_NAME};
+  # CPack only installs that component, so ship the DLL from Gittyup's pack
+  # rules.
+  if(GITTYUP_PACK_WIN64
+     AND NOT USE_SYSTEM_LIBSSH2
+     AND TARGET libssh2_shared)
+    install(
+      FILES $<TARGET_FILE:libssh2_shared>
+      DESTINATION ${INSTALL_LIBDIR}
+      PERMISSIONS
+        OWNER_READ
+        OWNER_WRITE
+        OWNER_EXECUTE
+        GROUP_READ
+        GROUP_EXECUTE
+        WORLD_READ
+        WORLD_EXECUTE
+      COMPONENT ${GITTYUP_NAME})
+  endif()
+
+  if(GITTYUP_PACK_WIN64 OR APPLE)
     # Install config files.
     set(QT_CONF ${CONF_DIR}/qt.conf)
     install(
@@ -212,7 +238,7 @@ if(APPLE)
   set(CPACK_DMG_VOLUME_NAME ${GITTYUP_NAME})
   set(CPACK_DMG_DS_STORE ${RSRC_DIR}/DS_Store)
   set(CPACK_DMG_BACKGROUND_IMAGE ${RSRC_DIR}/dmg-background.png)
-elseif(WIN32)
+elseif(GITTYUP_PACK_WIN64)
   set(CPACK_GENERATOR NSIS)
   set(CPACK_NSIS_CREATE_ICONS_EXTRA
       "CreateShortCut \
@@ -222,23 +248,13 @@ elseif(WIN32)
   set(CPACK_NSIS_EXECUTABLES_DIRECTORY ${CMAKE_INSTALL_BINDIR})
   set(CPACK_NSIS_MUI_FINISHPAGE_RUN ${GITTYUP_EXECUTABLE_NAME}.exe)
 
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    install(
-      FILES ${RSRC_DIR}/vcredist_x64.exe
-      DESTINATION .
-      COMPONENT ${GITTYUP_NAME})
-    set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
-        "ExecWait '\\\"$INSTDIR\\\\vcredist_x64.exe\\\" /q /norestart'")
-    set(PLATFORM "-win64")
-  else()
-    install(
-      FILES ${RSRC_DIR}/vcredist_x86.exe
-      DESTINATION .
-      COMPONENT ${GITTYUP_NAME})
-    set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
-        "ExecWait '\\\"$INSTDIR\\\\vcredist_x86.exe\\\" /q /norestart'")
-    set(PLATFORM "-win32")
-  endif()
+  install(
+    FILES ${RSRC_DIR}/vcredist_x64.exe
+    DESTINATION .
+    COMPONENT ${GITTYUP_NAME})
+  set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
+      "ExecWait '\\\"$INSTDIR\\\\vcredist_x64.exe\\\" /q /norestart'")
+  set(PLATFORM "-win64")
 else()
   set(CPACK_GENERATOR TGZ)
 endif()
@@ -256,7 +272,7 @@ set(CPACK_INSTALL_CMAKE_PROJECTS ${CMAKE_BINARY_DIR} ${GITTYUP_NAME}
                                  ${GITTYUP_NAME} /)
 
 # Add Context Menu Shortcuts
-if(WIN32)
+if(GITTYUP_PACK_WIN64)
   set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
       "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}
     WriteRegStr HKCR 'Directory\\\\Background\\\\shell\\\\Gittyup' '' 'Open with Gittyup'
@@ -270,7 +286,7 @@ if(WIN32)
       "${CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS}
     DeleteRegKey HKCR 'Directory\\\\Background\\\\shell\\\\Gittyup'
     DeleteRegKey HKCR 'Directory\\\\shell\\\\Gittyup'")
-endif(WIN32)
+endif()
 
 set(CPACK_PACKAGE_FILE_NAME ${PACKAGE_FILE_NAME})
 set(CPACK_PACKAGE_DIRECTORY ${CMAKE_BINARY_DIR}/pack)
@@ -280,7 +296,7 @@ set(CPACK_PACKAGE_VERSION_MAJOR ${GITTYUP_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${GITTYUP_VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${GITTYUP_VERSION_PATCH})
 
-if(WIN32)
+if(GITTYUP_PACK_WIN64)
   set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE.md)
 else()
   install(
@@ -292,7 +308,7 @@ endif()
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 include(CPack)
 
-if(WIN32)
+if(GITTYUP_PACK_WIN64)
   set(PACKAGE_DIR ${CMAKE_BINARY_DIR}/${PACKAGE_FILE_NAME})
 
   # Add target to package and sign executable.

--- a/pack/CMakeLists.txt
+++ b/pack/CMakeLists.txt
@@ -175,9 +175,12 @@ if(NOT APPLE)
     endforeach()
   endif()
 
-  # libssh2 (submodule) installs its DLL without COMPONENT ${GITTYUP_NAME}; CPack
-  # only installs that component, so ship the DLL from Gittyup's pack rules.
-  if(GITTYUP_PACK_WIN64 AND NOT USE_SYSTEM_LIBSSH2 AND TARGET libssh2_shared)
+  # libssh2 (submodule) installs its DLL without COMPONENT ${GITTYUP_NAME};
+  # CPack only installs that component, so ship the DLL from Gittyup's pack
+  # rules.
+  if(GITTYUP_PACK_WIN64
+     AND NOT USE_SYSTEM_LIBSSH2
+     AND TARGET libssh2_shared)
     install(
       FILES $<TARGET_FILE:libssh2_shared>
       DESTINATION ${INSTALL_LIBDIR}

--- a/pack/CMakeLists.txt
+++ b/pack/CMakeLists.txt
@@ -175,12 +175,9 @@ if(NOT APPLE)
     endforeach()
   endif()
 
-  # libssh2 (submodule) installs its DLL without COMPONENT ${GITTYUP_NAME};
-  # CPack only installs that component, so ship the DLL from Gittyup's pack
-  # rules.
-  if(GITTYUP_PACK_WIN64
-     AND NOT USE_SYSTEM_LIBSSH2
-     AND TARGET libssh2_shared)
+  # libssh2 (submodule) installs its DLL without COMPONENT ${GITTYUP_NAME}; CPack
+  # only installs that component, so ship the DLL from Gittyup's pack rules.
+  if(GITTYUP_PACK_WIN64 AND NOT USE_SYSTEM_LIBSSH2 AND TARGET libssh2_shared)
     install(
       FILES $<TARGET_FILE:libssh2_shared>
       DESTINATION ${INSTALL_LIBDIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,15 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-add_compile_options(-Werror=switch)
+if(NOT MSVC)
+  add_compile_options(-Werror=switch)
+endif()
 # Uncomment to compile with more warnings add_compile_options(-Wall) Uncomment
 # to compile with even more warnings add_compile_options(-Wextra) TODO:
 # currently there are too many unused parameters which overwhelms the warning
 # output with `-Wall`. So let's leave fixing these for later.
-add_compile_options(-Wno-unused-parameter)
+if(NOT MSVC)
+  add_compile_options(-Wno-unused-parameter)
+endif()
 
 add_subdirectory(util)
 add_subdirectory(cli)

--- a/src/git/Id.cpp
+++ b/src/git/Id.cpp
@@ -84,6 +84,8 @@ uint8_t Id::getSize(const git_oid_t type) {
   }
 }
 
-uint qHash(const Id &key) { return qHash(key.toByteArray()); }
+uint qHash(const Id &key) {
+  return static_cast<uint>(qHash(key.toByteArray()));
+}
 
 } // namespace git

--- a/src/git/Patch.cpp
+++ b/src/git/Patch.cpp
@@ -163,8 +163,8 @@ Patch::LineStats Patch::lineStats() const {
   git_patch_line_stats(&context, &additions, &deletions, d.data());
 
   LineStats stats;
-  stats.additions = additions;
-  stats.deletions = deletions;
+  stats.additions = static_cast<int>(additions);
+  stats.deletions = static_cast<int>(deletions);
   return stats;
 }
 
@@ -193,7 +193,7 @@ int Patch::count() const {
   if (isConflicted())
     return mConflicts.size();
 
-  return git_patch_num_hunks(d.data());
+  return static_cast<int>(git_patch_num_hunks(d.data()));
 }
 
 QByteArray Patch::header(int hidx) const {
@@ -202,7 +202,10 @@ QByteArray Patch::header(int hidx) const {
 
   const git_diff_hunk *hunk = nullptr;
   int result = git_patch_get_hunk(&hunk, nullptr, d.data(), hidx);
-  return (GIT_OK == result) ? hunk->header : QByteArray();
+  if (GIT_OK != result)
+    return QByteArray();
+
+  return QByteArray(hunk->header);
 }
 
 const git_diff_hunk *Patch::header_struct(int hidx) const {
@@ -218,7 +221,7 @@ int Patch::lineCount(int hidx) const {
   if (isConflicted())
     return mConflicts.at(hidx).lines.size();
 
-  return git_patch_num_lines_in_hunk(d.data(), hidx);
+  return static_cast<int>(git_patch_num_lines_in_hunk(d.data(), hidx));
 }
 
 char Patch::lineOrigin(int hidx, int ln) const {

--- a/src/git/Rebase.cpp
+++ b/src/git/Rebase.cpp
@@ -25,8 +25,8 @@ Rebase::Rebase(git_repository *repo, git_rebase *rebase,
     : mRepo(repo), d(rebase, git_rebase_free), mOverrideUser(overrideUser),
       mOverrideEmail(overrideEmail) {}
 
-int Rebase::count() const {
-  return static_cast<int>(git_rebase_operation_entrycount(d.data()));
+size_t Rebase::count() const {
+  return git_rebase_operation_entrycount(d.data());
 }
 
 size_t Rebase::currentIndex() const {

--- a/src/git/Rebase.cpp
+++ b/src/git/Rebase.cpp
@@ -25,7 +25,9 @@ Rebase::Rebase(git_repository *repo, git_rebase *rebase,
     : mRepo(repo), d(rebase, git_rebase_free), mOverrideUser(overrideUser),
       mOverrideEmail(overrideEmail) {}
 
-int Rebase::count() const { return git_rebase_operation_entrycount(d.data()); }
+int Rebase::count() const {
+  return static_cast<int>(git_rebase_operation_entrycount(d.data()));
+}
 
 size_t Rebase::currentIndex() const {
   return git_rebase_operation_current(d.data());
@@ -80,7 +82,7 @@ Commit Rebase::commit(const QString &message) {
       return Commit();
 
     // Look up the existing commit.
-    int index = git_rebase_operation_current(ptr);
+    size_t index = git_rebase_operation_current(ptr);
     git_rebase_operation *op = git_rebase_operation_byindex(ptr, index);
 
     git_commit *commit = nullptr;

--- a/src/git/Rebase.h
+++ b/src/git/Rebase.h
@@ -26,7 +26,7 @@ class Rebase {
 public:
   bool isValid() const { return !d.isNull(); }
 
-  int count() const;
+  size_t count() const;
   size_t currentIndex() const;
   const git_rebase_operation *operation(size_t index);
   Commit commitToRebase() const;

--- a/src/index/Indexer/indexer.cpp
+++ b/src/index/Indexer/indexer.cpp
@@ -14,13 +14,16 @@
 #include <sys/socket.h>
 #include <sys/time.h>
 #else
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #include <dbghelp.h>
 #include <strsafe.h>
 
-static LPTOP_LEVEL_EXCEPTION_FILTER defaultFilter = nullptr;
+LPTOP_LEVEL_EXCEPTION_FILTER defaultFilter = nullptr;
 
-static LONG WINAPI exceptionFilter(PEXCEPTION_POINTERS info) {
+LONG WINAPI exceptionFilter(PEXCEPTION_POINTERS info) {
   // Protect against reentering.
   static bool entered = false;
   if (entered)

--- a/src/index/Indexer/main.cpp
+++ b/src/index/Indexer/main.cpp
@@ -29,9 +29,15 @@
 #ifndef Q_OS_WIN
 #include <sys/resource.h>
 #else
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #include <dbghelp.h>
 #include <strsafe.h>
+
+extern LPTOP_LEVEL_EXCEPTION_FILTER defaultFilter;
+LONG WINAPI exceptionFilter(PEXCEPTION_POINTERS info);
 #endif
 
 namespace {

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -458,7 +458,7 @@ int lexemeText(lua_State *L) {
 QByteArray kind(TextEditor *editor, int style) {
   uintptr_t ptr = editor->privateLexerCall(style, 0);
   QByteArray name(reinterpret_cast<char *>(ptr));
-  return name.endsWith("_whitespace") ? "whitespace" : name;
+  return name.endsWith("_whitespace") ? QByteArrayLiteral("whitespace") : name;
 }
 
 int lexemeKind(lua_State *L) {

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -1458,7 +1458,9 @@ void RepoView::rebaseCommitInvalid(const git::Rebase rebase) {
 void RepoView::rebaseAboutToRebase(const git::Rebase rebase,
                                    const git::Commit before, int currIndex) {
   QString beforeText = before.link();
-  QString step = tr("%1/%2").arg(currIndex).arg(rebase.count());
+  QString step =
+      tr("%1/%2").arg(currIndex).arg(
+          QString::number(static_cast<unsigned long long>(rebase.count())));
   QString text = tr("%1 - %2").arg(step, beforeText);
   mRebase->addEntry(text, tr("Apply"));
 }
@@ -1478,7 +1480,9 @@ void RepoView::rebaseCommitSuccess(const git::Rebase rebase,
                                    const git::Commit before,
                                    const git::Commit after, int currIndex) {
   QString beforeText = before.link();
-  QString step = tr("%1/%2").arg(currIndex).arg(rebase.count());
+  QString step =
+      tr("%1/%2").arg(currIndex).arg(
+          QString::number(static_cast<unsigned long long>(rebase.count())));
   auto *lastEntry = mRebase->lastEntry();
   if (lastEntry) {
     lastEntry->setText(


### PR DESCRIPTION
## Summary

- Stabilized the Windows CI build path and packaging flow.
- Fixed Windows/MSVC compatibility and compile issues in CMake and source.
- Resolved `libssh2` integration issues (`libssh2` vs `ssh2` import-lib naming).
- Added NSIS installation in CI so CPack can produce Windows installers.
- Ensured Windows packaging includes required `libssh2.dll` runtime dependency.
- Cleaned up workflow deprecations/annotations (including `set-output` replacement).

