### PR TITLE
Fix a re-entrancy issue in the DiffView code

### DIFF
--- a/src/ui/DiffView/DiffView.cpp
+++ b/src/ui/DiffView/DiffView.cpp
@@ -20,6 +20,7 @@
 #include <QScrollBar>
 #include <QPushButton>
 #include <QMimeData>
+#include <QScopedValueRollback>
 
 namespace {
 
@@ -198,11 +199,13 @@ void DiffView::setDiff(const git::Diff &diff) {
           fetchMore();
       }));
 
-  mConnections.append(
-      connect(scrollBar, &QScrollBar::rangeChanged, [this](int min, int max) {
+  mConnections.append(connect(
+      scrollBar, &QScrollBar::rangeChanged, this,
+      [this](int min, int max) {
         if (max - min < this->widget()->height() / 2 && canFetchMore())
           fetchMore();
-      }));
+      },
+      Qt::QueuedConnection));
 
   // Request comments for this diff.
   if (Repository *remoteRepo = view->remoteRepo()) {
@@ -380,6 +383,10 @@ bool DiffView::canFetchMore() {
  * use a while loop with canFetchMore() to get all
  */
 void DiffView::fetchMore(int fetchWidgets) {
+  if (mFetching)
+    return;
+  QScopedValueRollback rollback(mFetching, true);
+
   QVBoxLayout *layout = static_cast<QVBoxLayout *>(widget()->layout());
 
   // Add widgets.
@@ -400,9 +407,6 @@ void DiffView::fetchMore(int fetchWidgets) {
              height() / 2) ||
             fetchAll)) {
       addedWidgets += lastFile->fetchMore(fetchAll ? -1 : 1);
-
-      // Load hunk(s) and update scrollbar
-      QApplication::processEvents();
 
       // Running the eventloop may trigger a view refresh
       if (mFiles.isEmpty())

--- a/src/ui/DiffView/DiffView.cpp
+++ b/src/ui/DiffView/DiffView.cpp
@@ -383,7 +383,10 @@ bool DiffView::canFetchMore() {
  * use a while loop with canFetchMore() to get all
  */
 void DiffView::fetchMore(int fetchWidgets) {
-  if (mFetching)
+  // Back out early if we're reentrant or lazy loading isn't triggered
+  if (mFetching ||
+      (verticalScrollBar()->maximum() - verticalScrollBar()->value() >
+       height() / 2))
     return;
   QScopedValueRollback rollback(mFetching, true);
 
@@ -402,20 +405,12 @@ void DiffView::fetchMore(int fetchWidgets) {
   bool fetchFiles = true;
   if (!mFiles.isEmpty()) {
     FileWidget *lastFile = mFiles.last();
-    while (lastFile->canFetchMore() &&
-           ((verticalScrollBar()->maximum() - verticalScrollBar()->value() <
-             height() / 2) ||
-            fetchAll)) {
-      addedWidgets += lastFile->fetchMore(fetchAll ? -1 : 1);
-
-      // Running the eventloop may trigger a view refresh
-      if (mFiles.isEmpty())
-        return;
+    if (lastFile->canFetchMore()) {
+      addedWidgets += lastFile->fetchMore(fetchAll ? -1 : fetchWidgets);
     }
 
     // Stop loading files
-    if (verticalScrollBar()->maximum() - verticalScrollBar()->value() >
-        height() / 2)
+    if (fetchAll == false && addedWidgets >= fetchWidgets)
       fetchFiles = false;
   }
 

--- a/src/ui/DiffView/DiffView.h
+++ b/src/ui/DiffView/DiffView.h
@@ -138,6 +138,7 @@ private:
   Account::CommitComments mComments;
 
   bool mEnabled{true};
+  bool mFetching{false};
   DiffTreeModel *mDiffTreeModel{nullptr};
   QWidget *mParent{nullptr};
   QVBoxLayout *mFileWidgetLayout{nullptr};


### PR DESCRIPTION
Related to #944 

It seems like dropping the `QApplication::processEvents();` is the way to go here. That and queuing the callbacks seems to fix the problem. I'm not entirely sure if `mFetching` is even needed, but it's there just in case. I'm not sure what kind of side-effects this potentially could have.

@Murmele From the code, it looks like you added this at some point. Is there a concrete need to actually process events within fetchMore or is it acceptable post-pone the processing? To me it seems to work fine without the call at least, but maybe there's a corner case I'm not aware of here.

Fixes #946 

Edit:
This also fixes #619 and #553 