### PR TITLE
Replace uncached revwalk with a cached one for dramatically better performance in Commit::description

### DIFF
--- a/src/git/Commit.cpp
+++ b/src/git/Commit.cpp
@@ -82,22 +82,19 @@ QString Commit::description() const {
   if (it != candidates.constEnd())
     return it->name();
 
-  // Walk parents.
-  QList<Commit> commits = parents();
-  while (!commits.isEmpty()) {
-    QSet<Commit> parents;
-    foreach (const Commit &commit, commits) {
-      auto it = candidates.constFind(commit.id());
-      if (it != candidates.constEnd())
-        return QString("%1 +%2").arg(it->name()).arg(difference(commit));
+  // Walk through parent commits to find one of the candiates
+  RevWalk walk = walker(GIT_SORT_TOPOLOGICAL);
+  if (!walk.isValid())
+    return QString();
 
-      foreach (const Commit &parent, commit.parents())
-        parents.insert(parent);
-    }
-
-    commits = parents.values();
+  Commit commit = walk.next();
+  while (commit.isValid()) {
+    auto it = candidates.constFind(commit.id());
+    if (it != candidates.constEnd())
+      return QString("%1 +%2").arg(it->name()).arg(difference(commit));
+    else
+      commit = walk.next();
   }
-
   return QString();
 }
 


### PR DESCRIPTION
Commit::description implements a very naive, uncached search for the distance to any tags. This is extremely slow on large repos with large distances to any tag. The Unreal Engine repo is one such example where I gave up checking how long it took after 3 minutes. In libgit2 there's revwalk functionality. This is cached and performs dramatically better. For the same Unreal Engine repo, it's now possible to display the distance to a tag within a few seconds.

For reference, the distance I tested with is 197234 (it's an old clone, so today's number might be far larger), so this performance issue won't show up in the vast majority of repos.

Fixes #878 