### PR TITLE
Add macOS Apple Silicon build matrix entry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,15 @@ jobs:
             cmake_env: {}
             pack: 1
 
+          - name: macos-arm64
+            os: macos-15
+            ninja_platform: mac
+            qt_platform: mac
+            openssl_arch: darwin64-arm64-cc
+            cmake_flags: "-DUSE_SYSTEM_LIBSSH2=OFF -DUSE_SSH:STRING=localbuild -DUSE_SYSTEM_QT=OFF -DCMAKE_OSX_ARCHITECTURES=arm64"
+            cmake_env: {}
+            pack: 1
+
           - name: win64
             os: windows-latest
             ninja_platform: win
@@ -377,9 +386,10 @@ jobs:
           shopt -s nullglob
           flatpaks=(artifacts/GittyupFlatpak/*.flatpak)
           appimages=(artifacts/GittyupAppImage/Gittyup*.AppImage)
-          files=("${flatpaks[@]}" "${appimages[@]}")
+          macos=(artifacts/Gittyup\ macos/Gittyup-* artifacts/Gittyup\ macos-arm64/Gittyup-*)
+          files=("${flatpaks[@]}" "${appimages[@]}" "${macos[@]}")
           if [ ${#files[@]} -eq 0 ]; then
-            echo "No Flatpak or AppImage assets to upload."
+            echo "No Flatpak, AppImage, or macOS assets to upload."
             exit 1
           fi
           if ! gh release view development >/dev/null 2>&1; then
@@ -402,9 +412,10 @@ jobs:
           TAG="${{ github.ref_name }}"
           flatpaks=(artifacts/GittyupFlatpak/*.flatpak)
           appimages=(artifacts/GittyupAppImage/Gittyup*.AppImage)
-          files=("${flatpaks[@]}" "${appimages[@]}")
+          macos=(artifacts/Gittyup\ macos/Gittyup-* artifacts/Gittyup\ macos-arm64/Gittyup-*)
+          files=("${flatpaks[@]}" "${appimages[@]}" "${macos[@]}")
           if [ ${#files[@]} -eq 0 ]; then
-            echo "No Flatpak or AppImage assets to upload."
+            echo "No Flatpak, AppImage, or macOS assets to upload."
             exit 1
           fi
           if ! gh release view "$TAG" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Add a macOS Apple Silicon entry to the existing build matrix in `.github/workflows/build.yml`.
- Use GitHub's arm64 macOS runner with `CMAKE_OSX_ARCHITECTURES=arm64`.
- Keep the existing macOS libssh2 configuration by using `USE_SSH:STRING=localbuild`.
- Include both Intel and Apple Silicon macOS packages in the release upload file list.

## Validation
- Parsed `.github/workflows/build.yml` locally with Ruby YAML.
- Locally corrected the Apple Silicon configure command after confirming `USE_SSH:STRING=localbuild` is required to avoid the libssh2 resolution error.
- GitHub Actions previously passed for the macOS arm64 matrix entry.

## Notes
- This replaces the earlier standalone Apple Silicon workflow approach and keeps macOS packaging inside the existing workflow.
