### PR TITLE
Enable testing from the root of the build folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,5 +202,6 @@ add_subdirectory(l10n)
 add_subdirectory(pack)
 
 if(ENABLE_TESTS)
+  enable_testing()
   add_subdirectory(test)
 endif()

--- a/README.md
+++ b/README.md
@@ -200,8 +200,7 @@ adheres to the formatting conventions for this project. You can also use the
 run `clang-format` against all modified files.
 
 Prior to pushing a change, please ensure you run the unit tests to avoid any
-regressions. These are found in `<build-dir>/test` and can be run using
-`ctest`.
+regressions. These are run using `ctest` in `<build-dir>`.
 
 License
 -------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,8 +66,6 @@ add_custom_target(
   COMMENT "Running tests..."
   USES_TERMINAL)
 
-enable_testing()
-
 # Add test library.
 set(CMAKE_DISABLE_TESTING ON)
 add_subdirectory(dep/zip)


### PR DESCRIPTION
This is a quality of life thing whilst developing. There's no need to require running `ctest` from the test folder. It can just as easily run in the root build folder.

This is also what I'd expect as default behaviour