### PR TITLE
Remove call to resetSelection inducing a redundant RepoView::diffSelected call

### DIFF
--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -1212,10 +1212,6 @@ CommitList::CommitList(Index *index, QWidget *parent)
   CommitModel *model = static_cast<CommitModel *>(mModel);
   connect(model, &CommitModel::statusFinished, [this, model](bool visible) {
     mRestoreSelection = true; // Reset to default
-    // Fake a selection notification if the diff is visible and selected.
-    // FIXME: Should we reference `model` or `this->mModel` here?
-    if (visible && selectionModel()->isSelected(mModel->index(0, 0)))
-      resetSelection();
 
     // Select the first commit if the selection was cleared.
     if (selectedIndexes().isEmpty())
@@ -1389,7 +1385,6 @@ bool CommitList::selectRange(const QString &range, const QString &file,
   // Try to select the "status" index.
   QModelIndex index = model()->index(0, 0);
   if (range == "status" && !index.data(CommitRole).isValid()) {
-    selectFirstCommit();
     return true;
   }
 
@@ -1771,7 +1766,8 @@ void CommitList::restoreSelection() {
   // Restore selection.
   DebugRefresh(mSelectedRange);
   if (!mRestoreSelection ||
-      (!mSelectedRange.isEmpty() && !selectRange(mSelectedRange))) {
+      (!mSelectedRange.isEmpty() && mSelectedRange != "status" &&
+       !selectRange(mSelectedRange))) {
     DebugRefresh("Failed to restore");
     emit diffSelected(git::Diff());
   }


### PR DESCRIPTION
The call seems to be required to counteract an unnecessary selectFirstCommit call in selectRange. This is in turn necessary due to missing handling of uncommitted changes. Thus, by handling this when we restore selection, we can avoid the duplicate calls.

This scales with the complexity of the commit loaded, or alternatively the uncommitted changes when they are viewed. The 2nd call to RepoView::diffSelected is cheaper, but on my machine still takes 10+ms. On a more complex uncommitted change set, I saw ~70ms. Since the calls run on the GUI thread, this blocks the GUI for that amount of time.

Edit:
I've tried to test this quite extensively. The same behaviour is observed for the following case
- Refresh on commit
- Refresh on uncommitted changes
- Discarding files, sections, and lines
- Committing files, sections, and lines
- Modifications to uncommitted file
- Modifications in new file
- Reverting changes outside Gittyup
- Selecting a two commits
- Selecting a commit and uncommitted changes