### PR TITLE
Add caching of settings

### DIFF
--- a/src/conf/Settings.cpp
+++ b/src/conf/Settings.cpp
@@ -60,31 +60,36 @@ Settings::Settings(QObject *parent) : QObject(parent) {
   map[kTranslationLanguage] = QVariant(Languages::system);
   mDefaults[kTranslation] = map;
   mDefaults[kTranslation].toMap()[kTranslationLanguage] = Languages::system;
-  mCurrentMap = mDefaults;
 }
 
 QString Settings::group() const { return mGroup.join("/"); }
 
-QVariant Settings::value(const QString &key) const {
+QVariant Settings::value(const QString &key) {
   return value(key, defaultValue(key));
 }
 
-QVariant Settings::value(const QString &key,
-                         const QVariant &defaultValue) const {
-  QSettings settings;
-  settings.beginGroup(group());
-  QVariant result(settings.value(key, defaultValue));
-  settings.endGroup();
-  return result;
+QVariant Settings::value(const QString &key, const QVariant &defaultValue) {
+  auto iter = mCache.find(key);
+  if (iter != mCache.end()) {
+    return *iter;
+  } else {
+    QSettings settings;
+    settings.beginGroup(group());
+    QVariant result(settings.value(key, defaultValue));
+    settings.endGroup();
+    mCache[key] = result;
+    return result;
+  }
 }
 
 QVariant Settings::defaultValue(const QString &key) const {
-  return lookup(mCurrentMap, key);
+  return lookup(mDefaults, key);
 }
 
 void Settings::setValue(const QString &key, const QVariant &value,
                         bool refresh) {
   QSettings settings;
+  mCache[key] = value;
   settings.beginGroup(group());
   if (value == defaultValue(key)) {
     if (settings.contains(key)) {
@@ -100,11 +105,9 @@ void Settings::setValue(const QString &key, const QVariant &value,
   settings.endGroup();
 }
 
-QVariant Settings::value(Setting::Id id) const {
-  return value(Setting::key(id));
-}
+QVariant Settings::value(Setting::Id id) { return value(Setting::key(id)); }
 
-QVariant Settings::value(Setting::Id id, const QVariant &defaultValue) const {
+QVariant Settings::value(Setting::Id id, const QVariant &defaultValue) {
   return value(Setting::key(id), defaultValue);
 }
 
@@ -154,7 +157,7 @@ QString Settings::kind(const QString &filename) {
   return lexers.value(key).toMap().value("name").toString();
 }
 
-bool Settings::prompt(Prompt::Kind kind) const {
+bool Settings::prompt(Prompt::Kind kind) {
   return value(promptKey(kind)).toBool();
 }
 
@@ -190,27 +193,23 @@ void Settings::setHotkey(const QString &action, const QString &hotkey) {
   setValue("hotkeys/" + action, hotkey);
 }
 
-QString Settings::hotkey(const QString &action) const {
+QString Settings::hotkey(const QString &action) {
   return value("hotkeys/" + action, "").toString();
 }
 
-bool Settings::isTextEditorWrapLines() const {
-  return value(kWrapLines).toBool();
-}
+bool Settings::isTextEditorWrapLines() { return value(kWrapLines).toBool(); }
 
 void Settings::setTextEditorWrapLines(bool wrap) {
   setValue(kWrapLines, wrap, true);
 }
 
-bool Settings::isWhitespaceIgnored() const {
-  return value(kIgnoreWsKey).toBool();
-}
+bool Settings::isWhitespaceIgnored() { return value(kIgnoreWsKey).toBool(); }
 
 void Settings::setWhitespaceIgnored(bool ignored) {
   setValue(kIgnoreWsKey, ignored, true);
 }
 
-QString Settings::lastPath() const { return value(kLastPathKey).toString(); }
+QString Settings::lastPath() { return value(kLastPathKey).toString(); }
 
 void Settings::setLastPath(const QString &lastPath) {
   setValue(kLastPathKey, lastPath);

--- a/src/conf/Settings.h
+++ b/src/conf/Settings.h
@@ -20,8 +20,8 @@ class Settings : public QObject {
   Q_OBJECT
 
 public:
-  QVariant value(Setting::Id id) const;
-  QVariant value(Setting::Id id, const QVariant &defaultValue) const;
+  QVariant value(Setting::Id id);
+  QVariant value(Setting::Id id, const QVariant &defaultValue);
   void setValue(Setting::Id id, const QVariant &value);
 
   // Look up lexer name by file name.
@@ -29,23 +29,23 @@ public:
   QString kind(const QString &filename);
 
   // prompt dialogs
-  bool prompt(Prompt::Kind kind) const;
+  bool prompt(Prompt::Kind kind);
   void setPrompt(Prompt::Kind kind, bool prompt);
   QString promptDescription(Prompt::Kind kind) const;
 
   void setHotkey(const QString &action, const QString &hotkey);
-  QString hotkey(const QString &action) const;
+  QString hotkey(const QString &action);
 
   // wrap lines in TextEditor in DiffView
-  bool isTextEditorWrapLines() const;
+  bool isTextEditorWrapLines();
   void setTextEditorWrapLines(bool wrapLines);
 
   // ignore whitespace
-  bool isWhitespaceIgnored() const;
+  bool isWhitespaceIgnored();
   void setWhitespaceIgnored(bool ignored);
 
   // last repository path
-  QString lastPath() const;
+  QString lastPath();
   void setLastPath(const QString &lastPath);
 
   // settings directories
@@ -73,15 +73,15 @@ private:
 
   QString group() const;
 
-  QVariant value(const QString &key) const;
-  QVariant value(const QString &key, const QVariant &defaultValue) const;
+  QVariant value(const QString &key);
+  QVariant value(const QString &key, const QVariant &defaultValue);
   QVariant defaultValue(const QString &key) const;
   void setValue(const QString &key, const QVariant &value,
                 bool refresh = false);
 
   QStringList mGroup;
   QVariantMap mDefaults;
-  QVariantMap mCurrentMap;
+  QVariantMap mCache;
 };
 
 #endif


### PR DESCRIPTION
This fixes a performance regression introduced in #664.
The underlying code creates a QSettings object for each request, resulting in excessive file reads and slow-downs. By caching the value the cost of running `RepoView::diffSelected` is reduced by 10+ms (it seems to scale with the complexity of the commit)