### PR TITLE
Fix painfully slow refresh in repos with uncommitted large binary files

### DIFF
--- a/src/conf/Constants.h
+++ b/src/conf/Constants.h
@@ -1,0 +1,14 @@
+//
+//          Copyright (c) 2026
+//
+// This software is licensed under the MIT License. The LICENSE.md file
+// describes the conditions under which this software may be distributed.
+//
+// Author: Alf Henrik Sauge
+//
+// This file contains application wide constants
+
+#include <cstdint>
+
+/// @brief Number of bytes to read to determine if a file is binary or not
+const std::size_t kMaxReadBinary = 64 * 1024;

--- a/src/ui/BlameEditor.cpp
+++ b/src/ui/BlameEditor.cpp
@@ -12,6 +12,7 @@
 #include "FindWidget.h"
 #include "MenuBar.h"
 #include "RepoView.h"
+#include "conf/Constants.h"
 #include "editor/TextEditor.h"
 #include "git/Blame.h"
 #include "git/Blob.h"
@@ -32,7 +33,6 @@
 namespace {
 
 const QString kSplitterKey = QString("blamesplitter");
-const size_t kMaxReadBinary = 64 * 1024;
 
 class BlameCallbacks : public git::Blame::Callbacks {
 public:

--- a/src/ui/BlameEditor.cpp
+++ b/src/ui/BlameEditor.cpp
@@ -32,6 +32,7 @@
 namespace {
 
 const QString kSplitterKey = QString("blamesplitter");
+const size_t kMaxReadBinary = 64 * 1024;
 
 class BlameCallbacks : public git::Blame::Callbacks {
 public:
@@ -142,10 +143,14 @@ bool BlameEditor::load(const QString &name, const git::Blob &blob,
     if (!file.open(QFile::ReadOnly))
       return false;
 
-    content = file.readAll();
+    // Limit the read to kMaxReadBinary to determine if the file is binary
+    content = file.read(kMaxReadBinary);
     git::Buffer buffer(content.constData(), content.length());
     if (buffer.isBinary())
       return false;
+    // Okay, not a binary file. Now we need to grab the rest if needed
+    else if (content.length() == kMaxReadBinary)
+      content = file.readAll();
   }
 
   // Set editor text.

--- a/src/ui/DiffView/FileWidget.cpp
+++ b/src/ui/DiffView/FileWidget.cpp
@@ -354,7 +354,8 @@ FileWidget::FileWidget(DiffView *view, const git::Diff &diff,
   if (patch.isUntracked()) {
     QFile dev(path);
     if (dev.open(QFile::ReadOnly)) {
-      QByteArray content = dev.readAll();
+      // Limit the read to 64KiB to determine if the file is binary or not
+      QByteArray content = dev.read(64 * 1024);
       git::Buffer buffer(content.constData(), content.length());
       binary = buffer.isBinary();
     }

--- a/src/ui/DiffView/FileWidget.cpp
+++ b/src/ui/DiffView/FileWidget.cpp
@@ -7,6 +7,7 @@
 #include "FileLabel.h"
 #include "HunkWidget.h"
 #include "Images.h"
+#include "conf/Constants.h"
 #include "conf/Settings.h"
 #include "git/Commit.h"
 #include "git/Patch.h"
@@ -354,8 +355,9 @@ FileWidget::FileWidget(DiffView *view, const git::Diff &diff,
   if (patch.isUntracked()) {
     QFile dev(path);
     if (dev.open(QFile::ReadOnly)) {
-      // Limit the read to 64KiB to determine if the file is binary or not
-      QByteArray content = dev.read(64 * 1024);
+      // Limit the read to kMaxReadBinary number of bytes to determine if the
+      // file is binary or not
+      QByteArray content = dev.read(kMaxReadBinary);
       git::Buffer buffer(content.constData(), content.length());
       binary = buffer.isBinary();
     }


### PR DESCRIPTION
This is a partial port of https://github.com/gitahead/gitahead/pull/601

I've tested with a 2.5GiB file uncommitted in the repo, and the refresh is pretty decent. Without the fix, Gittyup would just sit there and chew RAM and CPU like crazy. I'm sure it would result in an OOM crash eventually, but I didn't wait for that. This is quite simply night and day difference.

This partially addresses #652 and #765, and might help #523 