### PR TITLE
Delay loading blame until we actually want to view it

### DIFF
--- a/src/editor/TextEditor.h
+++ b/src/editor/TextEditor.h
@@ -119,7 +119,13 @@ public:
     return QRect(pr.left, pr.top, pr.Width(), pr.Height());
   }
 
+  void showEvent(QShowEvent *event) override {
+    Scintilla::ScintillaIFace::showEvent(event);
+    emit onVisible();
+  }
+
 signals:
+  void onVisible();
   void settingsChanged();
   void highlightActivated(bool active);
   void diagnosticAdded(int line, const Diagnostic &diag);

--- a/src/ui/BlameEditor.cpp
+++ b/src/ui/BlameEditor.cpp
@@ -55,6 +55,7 @@ BlameEditor::BlameEditor(const git::Repository &repo, QWidget *parent)
           &BlameEditor::adjustLineMarginWidth);
   connect(mEditor, &TextEditor::settingsChanged, this,
           &BlameEditor::adjustLineMarginWidth);
+  connect(mEditor, &TextEditor::onVisible, this, &BlameEditor::startBlame);
 
   // Create blame margin.
   mMargin = new BlameMargin(mEditor, this);
@@ -117,7 +118,7 @@ QString BlameEditor::revision() const {
 }
 
 bool BlameEditor::load(const QString &name, const git::Blob &blob,
-                       const git::Commit &commit) {
+                       git::Commit commit) {
   // Clear content.
   clear();
 
@@ -157,11 +158,21 @@ bool BlameEditor::load(const QString &name, const git::Blob &blob,
   // Calculate blame.
   if (mRepo.isValid() && !content.isEmpty()) {
     mMargin->startBlame(name);
-    mBlame.setFuture(QtConcurrent::run(&git::Repository::blame, mRepo, name,
-                                       commit, mCallbacks.data()));
+    mPendingBlameCommit = commit;
+    if (mEditor->isVisible()) {
+      startBlame();
+    }
   }
 
   return true;
+}
+void BlameEditor::startBlame() {
+  if (mPendingBlameCommit.has_value()) {
+    mBlame.setFuture(QtConcurrent::run(&git::Repository::blame, mRepo, mName,
+                                       mPendingBlameCommit.value(),
+                                       mCallbacks.data()));
+    mPendingBlameCommit = std::nullopt;
+  }
 }
 
 void BlameEditor::cancelBlame() {
@@ -171,6 +182,7 @@ void BlameEditor::cancelBlame() {
     mBlame.waitForFinished();
   mBlame.setFuture(QFuture<git::Blame>());
   callbacks->setCanceled(false);
+  mPendingBlameCommit = std::nullopt;
 }
 
 void BlameEditor::save() {

--- a/src/ui/BlameEditor.h
+++ b/src/ui/BlameEditor.h
@@ -37,9 +37,9 @@ public:
   QList<TextEditor *> editors() override { return {mEditor}; }
   void ensureVisible(TextEditor *editor, int pos) override {}
 
-  bool load(const QString &name, const git::Blob &blob,
-            const git::Commit &commit);
+  bool load(const QString &name, const git::Blob &blob, git::Commit commit);
 
+  void startBlame();
   void cancelBlame();
 
   void save();
@@ -61,6 +61,7 @@ private:
   TextEditor *mEditor;
   FindWidget *mFind;
   BlameMargin *mMargin;
+  std::optional<git::Commit> mPendingBlameCommit;
 
   QString mName;
   QString mRevision;

--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -627,7 +627,7 @@ void DoubleTreeWidget::loadEditorContent(const QModelIndexList &indexes) {
                    : view->repo().lookupBlob(mDiff.id(idx, git::Diff::NewFile));
   }
 
-  mEditor->load(name, blob, commit);
+  mEditor->load(name, blob, std::move(commit));
 
   mDiffView->enable(true);
   mDiffView->updateFiles();


### PR DESCRIPTION
This makes browsing with the diff view open much faster. Additionally, this makes a huge impact on the user experience since you now see the slowdown in practice since you have to open the blame view to trigger loading the blame. In that mode, you can see that work is being done.