### PR TITLE
fix(mac): correct Finder service method name to openInGittyup

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -175,4 +175,5 @@ WhitespaceSensitiveMacros:
   - NS_SWIFT_NAME
   - CF_SWIFT_NAME
 ...
-
+---
+Language:        ObjC

--- a/src/app/Application_mac.mm
+++ b/src/app/Application_mac.mm
@@ -9,20 +9,19 @@
 
 #include "Application.h"
 #include "ui/MainWindow.h"
-#include <QUrl>
 #import <AppKit/AppKit.h>
+#include <QUrl>
 
 @interface Launcher : NSObject
 - (void)openInGittyup:(NSPasteboard *)pboard
-  userData:(NSString *)userData
-  error:(NSString **)error;
+             userData:(NSString *)userData
+                error:(NSString **)error;
 @end
 
 @implementation Launcher
-- (void)openInGitAhead:(NSPasteboard *)pboard
-  userData:(NSString *)userData
-  error:(NSString **)error
-{
+- (void)openInGittyup:(NSPasteboard *)pboard
+             userData:(NSString *)userData
+                error:(NSString **)error {
   NSArray *classes = [NSArray arrayWithObject:[NSURL class]];
   NSDictionary *options = [NSDictionary dictionary];
   NSArray *urls = [pboard readObjectsForClasses:classes options:options];
@@ -32,8 +31,7 @@
 }
 @end
 
-void Application::registerService()
-{
+void Application::registerService() {
   Launcher *launcher = [[Launcher alloc] init];
   [[NSApplication sharedApplication] setServicesProvider:launcher];
 }


### PR DESCRIPTION
- The @implementation block referenced openInGitAhead (the legacy GitAhead method name) while the @interface declared openInGittyup, causing the "Open in Gittyup" Finder service to never be registered. Consequently, couldn't use "Services > Open in Gittyup" to open a repo from a Finder window.

- Also add ObjC language block to .clang-format so clang-format accepts .mm files without error.