### PR TITLE
Add version requirements for dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ else()
       CACHE BOOL "Use ssh")
   find_pkglibraries(LIBSSH2 libssh2)
   if(NOT LIBSSH2_FOUND)
-    find_package(libssh2 REQUIRED)
+    find_package(libssh2 1.11 REQUIRED)
   endif()
 endif()
 
@@ -143,7 +143,7 @@ else()
 endif()
 
 find_package(
-  Qt6
+  Qt6 6.6
   COMPONENTS ${QT_MODULES} LinguistTools
   REQUIRED)
 if(FLATPAK)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Build Environment
   * Windows - MSVC >= 2017 recommended
   * Linux - GCC >= 6.2 recommended
   * macOS - Xcode >= 10.1 recommended
-* CMake >= 3.3.1
+* CMake >= 3.19
 * Ninja (optional)
 
 Dependencies
@@ -74,7 +74,7 @@ submodules are optional or may also be satisfied by system libraries.
 
 **External Dependencies**
 
-* Qt (required >= 5.12)
+* Qt (required >= 6.6)
 
 **Included Dependencies**
 

--- a/dep/cmark/CMakeLists.txt
+++ b/dep/cmark/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(USE_SYSTEM_CMARK)
   if(PKG_CONFIG_FOUND)
-    pkg_check_modules(CMARK libcmark)
+    pkg_check_modules(CMARK libcmark>=0.30.2)
     add_executable(cmark_exe IMPORTED GLOBAL)
     set_property(TARGET cmark_exe PROPERTY IMPORTED_LOCATION cmark)
   endif()

--- a/dep/hunspell/CMakeLists.txt
+++ b/dep/hunspell/CMakeLists.txt
@@ -1,4 +1,4 @@
-pkg_check_modules(HUNSPELL hunspell)
+pkg_check_modules(HUNSPELL hunspell>=1.7)
 
 if(HUNSPELL_FOUND)
   add_library(hunspell INTERFACE)

--- a/dep/libgit2/CMakeLists.txt
+++ b/dep/libgit2/CMakeLists.txt
@@ -28,7 +28,7 @@ if(WIN32)
 endif()
 
 if(USE_SYSTEM_LIBGIT2)
-  pkg_check_modules(LIBGIT2 REQUIRED libgit2)
+  pkg_check_modules(LIBGIT2 REQUIRED libgit2>=1.9)
 else()
   set(BUILD_CLI OFF)
   add_subdirectory(libgit2)

--- a/dep/libssh2/CMakeLists.txt
+++ b/dep/libssh2/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(USE_SYSTEM_LIBSSH2)
   if(PKG_CONFIG_FOUND)
-    pkg_check_modules(LIBSSH2 REQUIRED libssh2)
+    pkg_check_modules(LIBSSH2 REQUIRED libssh2>=1.11)
   endif()
 
 else()

--- a/dep/lua/CMakeLists.txt
+++ b/dep/lua/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Lua)
+find_package(Lua 5.3)
 if(LUA_FOUND)
   add_library(lua INTERFACE)
   target_include_directories(lua INTERFACE ${LUA_INCLUDE_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,7 @@ macro(test)
   endif()
 
   if(WIN32)
-    find_package(Qt6Gui)
+    find_package(Qt6Gui 6.6)
     string(REPLACE ";" "\;" NEWPATH "$ENV{PATH}")
     string(REPLACE ";" "\;" PLUGIN_PATH
                    "$<TARGET_FILE_DIR:Qt6::QOffscreenIntegrationPlugin>")


### PR DESCRIPTION
Currently calls to `find_package` and `pkg_check_modules` lack a minimum version. If for some reason someone compiles on a system with old libraries with `USE_SYSTEM*` or in all cases old lua, the compilation might fail. For Lua I've confirmed 5.3 is the minimum version to compile against. For Qt I took the version used for building flatpack, and for the rest, it's based on the bundled versions.

I noticed the readme is outdated, so I took the liberty to update that as well while I was at it.

Fixes #972 