### PR TITLE
If the content is not a binary we have to add the content from readAll and not just replacing

### DIFF
--- a/src/ui/BlameEditor.cpp
+++ b/src/ui/BlameEditor.cpp
@@ -146,11 +146,12 @@ bool BlameEditor::load(const QString &name, const git::Blob &blob,
     // Limit the read to kMaxReadBinary to determine if the file is binary
     content = file.read(kMaxReadBinary);
     git::Buffer buffer(content.constData(), content.length());
-    if (buffer.isBinary())
+    if (buffer.isBinary()) {
       return false;
-    // Okay, not a binary file. Now we need to grab the rest if needed
-    else if (content.length() == kMaxReadBinary)
-      content = file.readAll();
+    } else if (content.length() >= kMaxReadBinary) {
+      // Okay, not a binary file. Now we need to grab the rest if needed
+      content += file.readAll();
+    }
   }
 
   // Set editor text.

--- a/src/ui/DiffView/FileWidget.cpp
+++ b/src/ui/DiffView/FileWidget.cpp
@@ -398,13 +398,14 @@ FileWidget::FileWidget(DiffView *view, const git::Diff &diff,
     // Collapse on check.
     if (disclosure)
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
-      connect(mHeader->check(), &QCheckBox::checkStateChanged,
-              [this](Qt::CheckState state) {
+      connect(mHeader->check(), &QCheckBox::checkStateChanged, [this](Qt::CheckState state) {
+		mHeader->disclosureButton()->setChecked(state != Qt::Checked);
+       });
 #else
       connect(mHeader->check(), &QCheckBox::stateChanged, [this](int state) {
+		mHeader->disclosureButton()->setChecked(state != Qt::Checked);
+      });
 #endif
-                mHeader->disclosureButton()->setChecked(state != Qt::Checked);
-              });
   }
 
   // Try to load an image from the file.

--- a/src/ui/DiffView/FileWidget.cpp
+++ b/src/ui/DiffView/FileWidget.cpp
@@ -398,12 +398,13 @@ FileWidget::FileWidget(DiffView *view, const git::Diff &diff,
     // Collapse on check.
     if (disclosure)
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
-      connect(mHeader->check(), &QCheckBox::checkStateChanged, [this](Qt::CheckState state) {
-		mHeader->disclosureButton()->setChecked(state != Qt::Checked);
-       });
+      connect(mHeader->check(), &QCheckBox::checkStateChanged,
+              [this](Qt::CheckState state) {
+                mHeader->disclosureButton()->setChecked(state != Qt::Checked);
+              });
 #else
       connect(mHeader->check(), &QCheckBox::stateChanged, [this](int state) {
-		mHeader->disclosureButton()->setChecked(state != Qt::Checked);
+        mHeader->disclosureButton()->setChecked(state != Qt::Checked);
       });
 #endif
   }


### PR DESCRIPTION
Reason: QIODevice::readAll(): Reads all remaining data from the device, and returns it as a byte array.

Introduced in #959

@AHSauge can you review?