### PR TITLE
Fix issue on Linux with last session not being restored in a GUI context

### DIFF
--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -41,6 +41,7 @@ bool Application::mIsInTest = false;
 
 #if defined(Q_OS_LINUX)
 #include <QtDBus/QtDBus>
+#include <unistd.h>
 
 #elif defined(Q_OS_MAC)
 #include <unistd.h>
@@ -283,7 +284,7 @@ void Application::autoUpdate() {
 }
 
 bool Application::restoreWindows() {
-#ifdef Q_OS_MAC
+#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
   // Check for connection to a terminal.
   if (!isatty(fileno(stdin)))
     QDir::setCurrent(Settings::appDir().path());


### PR DESCRIPTION
#980 and #981 highlights an issue on Windows where last repo used isn't restored when Gittyup is opened up. This is also an issue on Linux. The easiest fix here is to just extend the existing MacOS code to cover Linux as well.