### PR TITLE
Remove support for Qt5

### DIFF
--- a/src/qtsupport.h
+++ b/src/qtsupport.h
@@ -1,17 +1,2 @@
 /// Backwards compatibility for older versions of QT
-/// Several symbols have been deprecated in QT5.14 and moved to new
-/// namespaces. This file provides support for older versions of QT.
-
-#include <QString>
-#include <QTextStream>
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-namespace Qt {
-static auto endl = ::endl;
-static auto KeepEmptyParts = QString::KeepEmptyParts;
-static auto SkipEmptyParts = QString::SkipEmptyParts;
-} // namespace Qt
-
-// QButtonGroup::buttonClicked is deprecated in favor of QButtonGroup::idClicked
-#define idClicked buttonClicked
-#endif
+/// This file provides support for older versions of QT.

--- a/src/tools/ShowTool.cpp
+++ b/src/tools/ShowTool.cpp
@@ -40,46 +40,7 @@ bool ShowTool::openFileManager(QString path) {
 #endif
   }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
   QStringList cmdParts = QProcess::splitCommand(fileManagerCmd);
-#else
-  /* Source:
-   * https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/io/qprocess.cpp */
-  QStringList cmdParts;
-  QString tmp;
-  int quoteCount = 0;
-  bool inQuote = false;
-
-  // handle quoting. tokens can be surrounded by double quotes
-  // "hello world". three consecutive double quotes represent
-  // the quote character itself.
-  for (int i = 0; i < fileManagerCmd.size(); ++i) {
-    if (fileManagerCmd.at(i) == QLatin1Char('"')) {
-      ++quoteCount;
-      if (quoteCount == 3) {
-        // third consecutive quote
-        quoteCount = 0;
-        tmp += fileManagerCmd.at(i);
-      }
-      continue;
-    }
-    if (quoteCount) {
-      if (quoteCount == 1)
-        inQuote = !inQuote;
-      quoteCount = 0;
-    }
-    if (!inQuote && fileManagerCmd.at(i).isSpace()) {
-      if (!tmp.isEmpty()) {
-        cmdParts += tmp;
-        tmp.clear();
-      }
-    } else {
-      tmp += fileManagerCmd.at(i);
-    }
-  }
-  if (!tmp.isEmpty())
-    cmdParts += tmp;
-#endif
   path = QDir::toNativeSeparators(path);
 
   for (QString &part : cmdParts)

--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -241,7 +241,6 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
   setLayout(layout);
 
   const QButtonGroup *viewGroup = segmentedButton->buttonGroup();
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
   connect(
       viewGroup, QOverload<int>::of(&QButtonGroup::idClicked), this,
       [this](int id) {
@@ -255,21 +254,6 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
           unstagedFiles->setSelectionMode(QAbstractItemView::ExtendedSelection);
         }
       });
-#else
-  connect(
-      viewGroup, QOverload<QAbstractButton *>::of(&QButtonGroup::buttonClicked),
-      [this, viewGroup](QAbstractButton *button) {
-        mFileView->setCurrentIndex(viewGroup->id(button));
-        // Change selection mode.
-        if (viewGroup->id(button) == Blame) {
-          stagedFiles->setSelectionMode(QAbstractItemView::SingleSelection);
-          unstagedFiles->setSelectionMode(QAbstractItemView::SingleSelection);
-        } else {
-          stagedFiles->setSelectionMode(QAbstractItemView::ExtendedSelection);
-          unstagedFiles->setSelectionMode(QAbstractItemView::ExtendedSelection);
-        }
-      });
-#endif
 
   connect(mDiffTreeModel, &DiffTreeModel::checkStateChanged, this,
           &DoubleTreeWidget::treeModelStateChanged);

--- a/src/ui/TemplateDialog.cpp
+++ b/src/ui/TemplateDialog.cpp
@@ -255,21 +255,11 @@ void TemplateDialog::importTemplates(QString filename) {
       const int index = line.indexOf(QStringLiteral(":"));
       if (index == -1)
         continue;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+
       const QString name = line.sliced(0, index);
       if (index + 1 >= line.length())
         continue;
       QString value = line.sliced(index + 1);
-#else
-      const auto list = line.split(QStringLiteral(":"));
-      if (list.length() < 2)
-        continue;
-      const QString name = list.at(0);
-      QString value;
-      for (int i = 1; i < list.length() - 1; i++)
-        value += QStringLiteral("%1:").arg(list.at(i));
-      value += list.last();
-#endif
       value = value.replace(QStringLiteral("\\n"), QStringLiteral("\n"));
       value = value.replace(QStringLiteral("\\t"), QStringLiteral("\t"));
       TemplateButton::Template t;


### PR DESCRIPTION
Qt 5.15 LTS ended in May 2025, so no need to burden ourselves with Qt5 support

Given how widespread `qtsupport.h` is and that there theoretically could be a future use of it, I've just simply deleted most of the content rather than deleting the file itself.