### PR TITLE
Remove hardcoded append in translation texts

### DIFF
--- a/l10n/gittyup_de.ts
+++ b/l10n/gittyup_de.ts
@@ -363,17 +363,17 @@
     <name>AuthorCommitterDate</name>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="178"/>
-        <source>Author/Committer: </source>
+        <source>Author/Committer: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="182"/>
-        <source>Author: </source>
+        <source>Author: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="184"/>
-        <source>Committer: </source>
+        <source>Committer: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/l10n/gittyup_en.ts
+++ b/l10n/gittyup_en.ts
@@ -355,17 +355,17 @@
     <name>AuthorCommitterDate</name>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="178"/>
-        <source>Author/Committer: </source>
+        <source>Author/Committer: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="182"/>
-        <source>Author: </source>
+        <source>Author: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="184"/>
-        <source>Committer: </source>
+        <source>Committer: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/l10n/gittyup_es.ts
+++ b/l10n/gittyup_es.ts
@@ -363,17 +363,17 @@
     <name>AuthorCommitterDate</name>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="178"/>
-        <source>Author/Committer: </source>
+        <source>Author/Committer: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="182"/>
-        <source>Author: </source>
+        <source>Author: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="184"/>
-        <source>Committer: </source>
+        <source>Committer: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/l10n/gittyup_ja.ts
+++ b/l10n/gittyup_ja.ts
@@ -363,17 +363,17 @@
     <name>AuthorCommitterDate</name>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="178"/>
-        <source>Author/Committer: </source>
+        <source>Author/Committer: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="182"/>
-        <source>Author: </source>
+        <source>Author: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="184"/>
-        <source>Committer: </source>
+        <source>Committer: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/l10n/gittyup_pt.ts
+++ b/l10n/gittyup_pt.ts
@@ -363,17 +363,17 @@
     <name>AuthorCommitterDate</name>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="178"/>
-        <source>Author/Committer: </source>
+        <source>Author/Committer: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="182"/>
-        <source>Author: </source>
+        <source>Author: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="184"/>
-        <source>Committer: </source>
+        <source>Committer: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/l10n/gittyup_pt_BR.ts
+++ b/l10n/gittyup_pt_BR.ts
@@ -423,17 +423,17 @@
     <name>AuthorCommitterDate</name>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="178"/>
-        <source>Author/Committer: </source>
+        <source>Author/Committer: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="182"/>
-        <source>Author: </source>
+        <source>Author: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="184"/>
-        <source>Committer: </source>
+        <source>Committer: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/l10n/gittyup_ru.ts
+++ b/l10n/gittyup_ru.ts
@@ -363,17 +363,17 @@
     <name>AuthorCommitterDate</name>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="178"/>
-        <source>Author/Committer: </source>
+        <source>Author/Committer: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="182"/>
-        <source>Author: </source>
+        <source>Author: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="184"/>
-        <source>Committer: </source>
+        <source>Committer: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/l10n/gittyup_ta.ts
+++ b/l10n/gittyup_ta.ts
@@ -288,16 +288,16 @@
 <context>
     <name>AuthorCommitterDate</name>
     <message>
-        <source>Author/Committer: </source>
-        <translation>ஆசிரியர்/கமிட்டி:</translation>
+        <source>Author/Committer: %1</source>
+        <translation>ஆசிரியர்/கமிட்டி: %1</translation>
     </message>
     <message>
-        <source>Author: </source>
-        <translation>ஆசிரியர்:</translation>
+        <source>Author: %1</source>
+        <translation>ஆசிரியர்: %1</translation>
     </message>
     <message>
-        <source>Committer: </source>
-        <translation>ஆணையர்:</translation>
+        <source>Committer: %1</source>
+        <translation>ஆணையர்: %1</translation>
     </message>
 </context>
 <context>

--- a/l10n/gittyup_zh_CN.ts
+++ b/l10n/gittyup_zh_CN.ts
@@ -363,18 +363,18 @@
     <name>AuthorCommitterDate</name>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="178"/>
-        <source>Author/Committer: </source>
-        <translation>作者/提交者：</translation>
+        <source>Author/Committer: %1</source>
+        <translation>作者/提交者： %1</translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="182"/>
-        <source>Author: </source>
-        <translation>作者：</translation>
+        <source>Author: %1</source>
+        <translation>作者： %1</translation>
     </message>
     <message>
         <location filename="../src/ui/DetailView.cpp" line="184"/>
-        <source>Committer: </source>
-        <translation>提交者：</translation>
+        <source>Committer: %1</source>
+        <translation>提交者： %1</translation>
     </message>
 </context>
 <context>

--- a/src/dialogs/SettingsDialog.cpp
+++ b/src/dialogs/SettingsDialog.cpp
@@ -273,7 +273,7 @@ public:
     }
     mStoreCredentials->setChecked(checked);
 
-    QString info = tr("") + "<table>";
+    QString info = "<table>";
     for (const auto &helper :
          CredentialHelper::getAvailableHelperInformation()) {
       info += QStringLiteral("<tr><td><b>%1</b></td><td>%2</td><td>")

--- a/src/ui/DetailView.cpp
+++ b/src/ui/DetailView.cpp
@@ -178,13 +178,13 @@ public:
   void setAuthorCommitter(const QString &author, const QString &committer) {
     mSameAuthorCommitter = author == committer;
     if (mSameAuthorCommitter) {
-      mAuthor->setText(tr("Author/Committer: ") + author);
+      mAuthor->setText(tr("Author/Committer: %1").arg(author));
       mAuthor->adjustSize();
       mCommitter->setVisible(false);
     } else {
-      mAuthor->setText(tr("Author: ") + author);
+      mAuthor->setText(tr("Author: %1").arg(author));
       mAuthor->adjustSize();
-      mCommitter->setText(tr("Committer: ") + committer);
+      mCommitter->setText(tr("Committer: %1").arg(committer));
       mCommitter->adjustSize();
       mCommitter->setVisible(true);
     }

--- a/src/ui/FileContextMenu.cpp
+++ b/src/ui/FileContextMenu.cpp
@@ -422,8 +422,8 @@ void FileContextMenu::handleCommits(const QList<git::Commit> &commits,
               view->addLogEntry(tr("Saving files"),
                                 tr("Saving files of selected version to disk"));
           for (const auto &file : files) {
-            const auto saveFile =
-                view->addLogEntry(tr("Save file ") + file, "Save file", save);
+            const auto saveFile = view->addLogEntry(
+                tr("Save file %1").arg(file), "Save file", save);
             // assumption. file is a file not a folder!
             if (!exportFile(view, folder, file))
               view->error(saveFile, "save file", file, tr("Invalid Blob"));
@@ -439,7 +439,7 @@ void FileContextMenu::handleCommits(const QList<git::Commit> &commits,
     auto filename = file.split("/").last();
 
     auto logentry =
-        view->addLogEntry(tr("Opening file"), tr("Open ") + filename);
+        view->addLogEntry(tr("Opening file"), tr("Open %1").arg(filename));
 
     if (exportFile(view, folder, file))
       QDesktopServices::openUrl(QUrl::fromLocalFile(


### PR DESCRIPTION
Arguments need to be part of the translation text otherwise word re-ordering isn't possible