### PR TITLE
Enable and fix all -Wall warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,9 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 if(NOT MSVC)
-  add_compile_options(-Werror=switch)
+  add_compile_options(-Wall -Werror)
 endif()
-# Uncomment to compile with more warnings add_compile_options(-Wall) Uncomment
-# to compile with even more warnings add_compile_options(-Wextra) TODO:
-# currently there are too many unused parameters which overwhelms the warning
-# output with `-Wall`. So let's leave fixing these for later.
+# Uncomment to compile with even more warnings add_compile_options(-Wextra)
 if(NOT MSVC)
   add_compile_options(-Wno-unused-parameter)
 endif()

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -232,7 +232,7 @@ Application::Application(int &argc, char **argv, bool haltOnParseError)
   if (!dir.exists())
     dir.setPath("/Applications");
   dir.cd("Utilities/Terminal.app/Contents/Resources/Fonts");
-  foreach (const QString &name, dir.entryList({"SF*Mono-*.otf"}, QDir::Files))
+  for (const QString &name : dir.entryList({"SF*Mono-*.otf"}, QDir::Files))
     QFontDatabase::addApplicationFont(dir.filePath(name));
 
   // Create shared menu bar on macOS.
@@ -324,6 +324,8 @@ bool Application::restoreWindows() {
   return MainWindow::restoreWindows();
 }
 
+// Currently unused on MacOS
+#if defined(Q_OS_LINUX) || defined(Q_OS_WIN)
 static MainWindow *openOrSwitch(QDir repo) {
   repo.makeAbsolute();
 
@@ -344,6 +346,7 @@ static MainWindow *openOrSwitch(QDir repo) {
 
   return MainWindow::open(repo.path(), true);
 }
+#endif
 
 #if defined(Q_OS_LINUX)
 #define DBUS_SERVICE_NAME GITTYUP_IDENTIFIER
@@ -516,7 +519,7 @@ void Application::handleSslErrors(QNetworkReply *reply,
   QMessageBox msg(QMessageBox::Warning, title, text, buttons);
 
   QString message;
-  foreach (const QSslError &error, errors)
+  for (const QSslError &error : errors)
     message.append(QString("<p>%1</p>").arg(error.errorString()));
   msg.setInformativeText(message);
 

--- a/src/app/CustomTheme.cpp
+++ b/src/app/CustomTheme.cpp
@@ -27,7 +27,7 @@ void setPaletteColors(QPalette &palette, QPalette::ColorRole role,
   }
 
   QVariantMap map = variant.toMap();
-  foreach (const QString &key, map.keys()) {
+  for (const QString &key : map.keys()) {
     QColor color(map.value(key).toString());
     if (!color.isValid()) {
       Q_ASSERT(false);

--- a/src/conf/RecentRepositories.cpp
+++ b/src/conf/RecentRepositories.cpp
@@ -85,7 +85,7 @@ RecentRepositories *RecentRepositories::instance() {
 
 void RecentRepositories::store() {
   QStringList paths;
-  foreach (RecentRepository *repo, mRepos)
+  for (RecentRepository *repo : mRepos)
     paths.append(repo->gitpath());
 
   QSettings().setValue(kRecentKey, paths);
@@ -136,7 +136,7 @@ void RecentRepositories::load() {
    * In this case the complete paths are shown and not only 'repositoryname',
    * otherwise they are not distinguishable in the recent repository list:
    */
-  foreach (const QString &path, paths) {
+  for (const QString &path : paths) {
     RecentRepository *repo = new RecentRepository(path, this);
     auto functor = [repo](RecentRepository *rhs) {
       return (repo->name() == rhs->name());

--- a/src/conf/Settings.cpp
+++ b/src/conf/Settings.cpp
@@ -53,7 +53,7 @@ QString promptKey(Prompt::Kind kind) { return Prompt::key(kind); }
 } // namespace
 
 Settings::Settings(QObject *parent) : QObject(parent) {
-  foreach (const QFileInfo &file, confDir().entryInfoList(QStringList("*.lua")))
+  for (const QFileInfo &file : confDir().entryInfoList(QStringList("*.lua")))
     mDefaults[file.baseName()] = ConfFile(file.absoluteFilePath()).parse();
   mDefaults[kLastPathKey] = QDir::homePath();
   QVariantMap map;
@@ -125,10 +125,11 @@ QString Settings::lexer(const QString &filename) {
 
   // Try all patterns first.
   QVariantMap lexers(mDefaults.value("lexers").toMap());
-  foreach (const QString &key, lexers.keys()) {
+  for (const QString &key : lexers.keys()) {
     QVariantMap map(lexers.value(key).toMap());
     if (map.contains("patterns")) {
-      foreach (QString pattern, map.value("patterns").toString().split(",")) {
+      for (const QString &pattern :
+           map.value("patterns").toString().split(",")) {
         QRegularExpression regExp{
             QRegularExpression::fromWildcard(pattern, CS)};
         if (regExp.match(name).hasMatch())
@@ -138,10 +139,10 @@ QString Settings::lexer(const QString &filename) {
   }
 
   // Try to match by extension.
-  foreach (const QString &key, lexers.keys()) {
+  for (const QString &key : lexers.keys()) {
     QVariantMap map(lexers.value(key).toMap());
     if (map.contains("extensions")) {
-      foreach (QString ext, map.value("extensions").toString().split(",")) {
+      for (const QString &ext : map.value("extensions").toString().split(",")) {
         if (suffix == ext)
           return key;
       }

--- a/src/cred/GitCredential.cpp
+++ b/src/cred/GitCredential.cpp
@@ -56,7 +56,7 @@ bool GitCredential::get(const QString &url, QString &username,
   process.waitForFinished();
 
   QString output = process.readAllStandardOutput();
-  foreach (const QString &line, output.split('\n')) {
+  for (const QString &line : output.split('\n')) {
     int pos = line.indexOf('=');
     if (pos < 0)
       continue;

--- a/src/cred/Store.cpp
+++ b/src/cred/Store.cpp
@@ -86,11 +86,11 @@ bool Store::store(const QString &url, const QString &username,
   if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
     return false;
 
-  foreach (const auto &protocolKey, store.keys()) {
+  for (const auto &protocolKey : store.keys()) {
     auto protocol = store[protocolKey];
-    foreach (const auto &hostKey, protocol.keys()) {
+    for (const auto &hostKey : protocol.keys()) {
       auto host = protocol[hostKey];
-      foreach (const auto &usernameKey, host.keys()) {
+      for (const auto &usernameKey : host.keys()) {
         QUrl temp;
         temp.setScheme(protocolKey);
         temp.setHost(hostKey);

--- a/src/dialogs/ConfigDialog.cpp
+++ b/src/dialogs/ConfigDialog.cpp
@@ -198,7 +198,7 @@ public:
 
     connect(footer, &Footer::minusClicked, this, [this, table] {
       QModelIndexList indexes = table->selectionModel()->selectedRows();
-      foreach (const QModelIndex &index, indexes) {
+      for (const QModelIndex &index : indexes) {
         QString name = index.data().toString();
         QString title = tr("Delete Remote?");
         QString text = tr("Are you sure you want to delete '%1'?");
@@ -279,13 +279,13 @@ public:
       // Get all selected branches before removing any.
       QList<git::Branch> branches;
       QModelIndexList indexes = mTable->selectionModel()->selectedRows();
-      foreach (const QModelIndex &index, indexes) {
+      for (const QModelIndex &index : indexes) {
         QVariant var = index.data(BranchTableModel::BranchRole);
         branches.append(var.value<git::Branch>());
       }
 
       // Remove them all.
-      foreach (git::Branch branch, branches) {
+      for (const git::Branch &branch : branches) {
         Q_ASSERT(!branch.isHead());
         DeleteBranchDialog dialog(branch, this);
         dialog.exec();
@@ -296,7 +296,7 @@ public:
     auto updateMinusButton = [this, footer] {
       QModelIndexList indexes = mTable->selectionModel()->selectedRows();
       bool enabled = !indexes.isEmpty();
-      foreach (const QModelIndex &index, indexes) {
+      for (const QModelIndex &index : indexes) {
         QVariant var = index.data(BranchTableModel::BranchRole);
         if (var.value<git::Branch>().isHead()) {
           enabled = false;
@@ -435,7 +435,7 @@ public:
         context, contextLabel, form->labelForField(contextLayout)};
 
     auto setWidgetsEnabled = [widgets](bool enabled) {
-      foreach (QWidget *widget, widgets)
+      for (QWidget *widget : widgets)
         widget->setEnabled(enabled);
     };
 
@@ -570,7 +570,7 @@ public:
               git::Repository tmp(repo);
               QModelIndexList indexes =
                   includedList->selectionModel()->selectedRows();
-              foreach (const QModelIndex &index, indexes) {
+              for (const QModelIndex &index : indexes) {
                 QString text = index.data(Qt::DisplayRole).toString();
                 tmp.lfsSetTracked(text, false);
               }
@@ -595,7 +595,7 @@ public:
     tableLayout->addWidget(footer);
 
     QMap<QString, QString> map;
-    foreach (const QString &string, repo.lfsEnvironment()) {
+    for (const QString &string : repo.lfsEnvironment()) {
       if (string.contains("=")) {
         QString key = string.section('=', 0, 0);
         QString value = string.section('=', 1);
@@ -685,7 +685,7 @@ public:
       textEdit->setFixedSize(size);
       textEdit->setReadOnly(true);
 
-      foreach (const QString &string, repo.lfsEnvironment()) {
+      for (const QString &string : repo.lfsEnvironment()) {
         textEdit->append(string);
       }
 

--- a/src/dialogs/DiffPanel.cpp
+++ b/src/dialogs/DiffPanel.cpp
@@ -37,7 +37,7 @@ DiffPanel::DiffPanel(const git::Repository &repo, QWidget *parent)
   auto contextSignal = QOverload<int>::of(&QSpinBox::valueChanged);
   connect(context, contextSignal, [this](int value) {
     mConfig.setValue("diff.context", value);
-    foreach (MainWindow *window, MainWindow::windows()) {
+    for (MainWindow *window : MainWindow::windows()) {
       for (int i = 0; i < window->count(); ++i)
         window->view(i)->refresh();
     }
@@ -53,7 +53,7 @@ DiffPanel::DiffPanel(const git::Repository &repo, QWidget *parent)
   QComboBox *encoding = new QComboBox(this);
   encoding->addItem(tr("System Locale"), -1);
   encoding->insertSeparator(encoding->count());
-  for (int i = 0; i < encodings.size(); i++) {
+  for (int i = 0; i < static_cast<int>(encodings.size()); i++) {
     encoding->addItem(encodings[i], i);
   }
   QString name = mConfig.value<QString>("gui.encoding");
@@ -68,7 +68,7 @@ DiffPanel::DiffPanel(const git::Repository &repo, QWidget *parent)
       mConfig.setValue("gui.encoding", encoding->itemText(index));
     }
 
-    foreach (MainWindow *window, MainWindow::windows()) {
+    for (MainWindow *window : MainWindow::windows()) {
       for (int i = 0; i < window->count(); ++i)
         window->view(i)->refresh();
     }

--- a/src/dialogs/ExternalToolsDialog.cpp
+++ b/src/dialogs/ExternalToolsDialog.cpp
@@ -87,7 +87,7 @@ QVBoxLayout *ExternalToolsDialog::createUserDefinedLayout(const QString &type) {
 
   connect(footer, &Footer::minusClicked, [table, model] {
     QModelIndexList indexes = table->selectionModel()->selectedRows(0);
-    foreach (const QModelIndex &index, indexes)
+    for (const QModelIndex &index : indexes)
       model->remove(index.data(Qt::DisplayRole).toString());
     model->refresh();
     table->resizeColumnsToContents();

--- a/src/dialogs/HotkeysPanel.cpp
+++ b/src/dialogs/HotkeysPanel.cpp
@@ -373,7 +373,7 @@ HotkeysPanel::HotkeysPanel(QWidget *parent) : QTreeView(parent) {
     QString label = hotkey.label().replace(slashRegex, "/");
     int lastSep = label.lastIndexOf('/');
 
-    HotkeyGroupData *group;
+    HotkeyGroupData *group = nullptr;
 
     // Look for existing group along hierarchy
     int pos = lastSep;

--- a/src/dialogs/PluginsPanel.cpp
+++ b/src/dialogs/PluginsPanel.cpp
@@ -42,7 +42,7 @@ void PluginsPanel::refresh() {
   QFont bold = font();
   bold.setBold(true);
 
-  foreach (PluginRef plugin, Plugin::plugins(mRepo)) {
+  for (const PluginRef &plugin : Plugin::plugins(mRepo)) {
     QTreeWidgetItem *root = new QTreeWidgetItem(this, {plugin->name()});
     root->setData(Name, Qt::UserRole, QVariant::fromValue(plugin));
     root->setFont(Name, bold);
@@ -71,7 +71,7 @@ void PluginsPanel::refresh() {
       dialog.setWindowTitle(tr("%1 Options").arg(plugin->name()));
 
       QFormLayout *layout = new QFormLayout(&dialog);
-      foreach (const QString &key, keys) {
+      for (const QString &key : keys) {
         QWidget *widget = nullptr;
         QVariant value = plugin->optionValue(key);
         switch (plugin->optionKind(key)) {
@@ -112,7 +112,7 @@ void PluginsPanel::refresh() {
 
           case Plugin::List: {
             QComboBox *comboBox = new QComboBox(&dialog);
-            foreach (const QString &opt, plugin->optionOpts(key))
+            for (const QString &opt : plugin->optionOpts(key))
               comboBox->addItem(opt);
             comboBox->setCurrentIndex(value.toInt() - 1);
 
@@ -139,7 +139,7 @@ void PluginsPanel::refresh() {
         refresh();
     });
 
-    foreach (const QString &key, plugin->diagnosticKeys()) {
+    for (const QString &key : plugin->diagnosticKeys()) {
       QString desc = plugin->diagnosticDescription(key);
       QStringList strings = {plugin->diagnosticName(key), QString(), desc};
       QTreeWidgetItem *item = new QTreeWidgetItem(root, strings);

--- a/src/dialogs/PullRequestDialog.cpp
+++ b/src/dialogs/PullRequestDialog.cpp
@@ -37,7 +37,7 @@ PullRequestDialog::PullRequestDialog(RepoView *view) : QDialog(view) {
 
   QComboBox *fromRepo = new QComboBox(this);
   fromRepo->setEditable(true);
-  foreach (const git::Reference &ref, view->repo().branches(GIT_BRANCH_LOCAL))
+  for (const git::Reference &ref : view->repo().branches(GIT_BRANCH_LOCAL))
     fromRepo->addItem(ref.name(), QVariant::fromValue(ref));
   fromRepo->setCurrentIndex(fromRepo->findText(view->repo().head().name()));
   auto indexChanged = QOverload<int>::of(&QComboBox::currentIndexChanged);
@@ -63,7 +63,7 @@ PullRequestDialog::PullRequestDialog(RepoView *view) : QDialog(view) {
   remoteRepo->account()->requestForkParents(remoteRepo);
   connect(remoteRepo->account(), &Account::forkParentsReady, this,
           [toRepo](const QMap<QString, QString> &parents) {
-            foreach (const QString parent, parents.keys()) {
+            for (const QString &parent : parents.keys()) {
               toRepo->addItem(parent, parents.value(parent));
             }
           });

--- a/src/dialogs/RemoteDialog.cpp
+++ b/src/dialogs/RemoteDialog.cpp
@@ -30,7 +30,7 @@ RemoteDialog::RemoteDialog(Kind kind, RepoView *parent) : QDialog(parent) {
   mRemotes = new QComboBox(this);
   mRemotes->setEditable(true);
   mRemotes->setMinimumContentsLength(16);
-  foreach (const git::Remote &remote, repo.remotes())
+  for (const git::Remote &remote : repo.remotes())
     mRemotes->addItem(remote.name(), QVariant::fromValue(remote));
 
   git::Remote defaultRemote = repo.defaultRemote();

--- a/src/dialogs/SettingsDialog.cpp
+++ b/src/dialogs/SettingsDialog.cpp
@@ -64,13 +64,13 @@ void populateExternalTools(QComboBox *comboBox, const QString &type) {
                                     ExternalTool::readBuiltInTools(type);
 
   QStringList names;
-  foreach (const ExternalTool::Info &tool, tools) {
+  for (const ExternalTool::Info &tool : tools) {
     if (tool.found)
       names.append(tool.name);
   }
 
   std::sort(names.begin(), names.end());
-  foreach (const QString &tool, names)
+  for (const QString &tool : names)
     comboBox->addItem(tool);
 }
 
@@ -147,7 +147,7 @@ public:
 
 #if defined(Q_OS_LINUX) || defined(Q_OS_WIN)
     form->addRow(tr("Single instance:"), mSingleInstance);
-#elif defined(Q_OS_MACX)
+#elif defined(Q_OS_MACOS)
     mSingleInstance->setVisible(false);
 #endif
 
@@ -170,7 +170,7 @@ public:
 
     connect(mFetch, &QCheckBox::toggled, this, [](bool checked) {
       Settings::instance()->setValue(Setting::Id::FetchAutomatically, checked);
-      foreach (MainWindow *window, MainWindow::windows()) {
+      for (MainWindow *window : MainWindow::windows()) {
         for (int i = 0; i < window->count(); ++i)
           window->view(i)->startFetchTimer();
       }

--- a/src/dialogs/StartDialog.cpp
+++ b/src/dialogs/StartDialog.cpp
@@ -424,7 +424,7 @@ StartDialog::StartDialog(QWidget *parent) : QDialog(parent) {
               });
 
     // Remove selected indexes from settings.
-    foreach (const QModelIndex &index, indexes)
+    for (const QModelIndex &index : indexes)
       RecentRepositories::instance()->remove(index.row());
   });
 
@@ -608,11 +608,11 @@ void StartDialog::accept() {
   QModelIndexList hostIndexes = mHostTree->selectionModel()->selectedIndexes();
 
   QStringList paths;
-  foreach (const QModelIndex &index, repoIndexes)
+  for (const QModelIndex &index : repoIndexes)
     paths.append(index.data(Qt::UserRole).toString());
 
   QModelIndexList uncloned;
-  foreach (const QModelIndex &index, hostIndexes) {
+  for (const QModelIndex &index : hostIndexes) {
     QModelIndex parent = index.parent();
     if (parent.isValid()) {
       Account *account = parent.data(AccountRole).value<Account *>();
@@ -646,7 +646,7 @@ void StartDialog::accept() {
     return;
 
   // Add the remainder as tabs.
-  foreach (const QString &path, paths)
+  for (const QString &path : paths)
     window->addTab(path);
 }
 
@@ -692,7 +692,7 @@ void StartDialog::updateButtons() {
   bool clone = false;
   QPushButton *open = mButtonBox->button(QDialogButtonBox::Open);
   open->setEnabled(!repoIndexes.isEmpty() || !hostIndexes.isEmpty());
-  foreach (const QModelIndex &index, hostIndexes) {
+  for (const QModelIndex &index : hostIndexes) {
     QModelIndex parent = index.parent();
     if (!parent.isValid()) {
       open->setEnabled(false);

--- a/src/dialogs/SubmoduleDelegate.cpp
+++ b/src/dialogs/SubmoduleDelegate.cpp
@@ -29,7 +29,7 @@ QWidget *SubmoduleDelegate::createEditor(QWidget *parent,
 
   QComboBox *cb = new QComboBox(parent);
   cb->addItem(QString()); // empty name
-  foreach (const git::Branch &branch, repo.branches(GIT_BRANCH_LOCAL))
+  for (const git::Branch &branch : repo.branches(GIT_BRANCH_LOCAL))
     cb->addItem(branch.name());
 
   return cb;

--- a/src/dialogs/UpdateSubmodulesDialog.cpp
+++ b/src/dialogs/UpdateSubmodulesDialog.cpp
@@ -24,13 +24,13 @@ class Model : public QAbstractTableModel {
 public:
   Model(const git::Repository &repo, QObject *parent = nullptr)
       : QAbstractTableModel(parent) {
-    foreach (const git::Submodule &submodule, repo.submodules())
+    for (const git::Submodule &submodule : repo.submodules())
       mSubmodules.append({true, submodule});
   }
 
   QList<git::Submodule> enabledSubmodules() const {
     QList<git::Submodule> submodules;
-    foreach (const Entry &entry, mSubmodules) {
+    for (const Entry &entry : mSubmodules) {
       if (entry.enabled)
         submodules.append(entry.submodule);
     }

--- a/src/editor/ScintillaQt.cpp
+++ b/src/editor/ScintillaQt.cpp
@@ -549,7 +549,7 @@ void ScintillaQt::inputMethodEvent(QInputMethodEvent *event) {
     unsigned int attrSegment = 0;
 #endif
 
-    foreach (QInputMethodEvent::Attribute attr, event->attributes()) {
+    for (const QInputMethodEvent::Attribute &attr : event->attributes()) {
       if (attr.type == QInputMethodEvent::TextFormat) {
         QTextFormat format = attr.value.value<QTextFormat>();
         QTextCharFormat charFormat = format.toCharFormat();

--- a/src/editor/TextEditor.cpp
+++ b/src/editor/TextEditor.cpp
@@ -394,8 +394,8 @@ QList<TextEditor::Diagnostic> TextEditor::diagnostics(int line) {
 }
 
 void TextEditor::addDiagnostic(int line, const Diagnostic &diag) {
-  int marker;
-  int indicator;
+  int marker = 0;
+  int indicator = 0;
   switch (diag.kind) {
     case Note:
       marker = NoteMarker;

--- a/src/git/Command.cpp
+++ b/src/git/Command.cpp
@@ -47,7 +47,7 @@ QString Command::substitute(const QProcessEnvironment &env,
 
   // Substitute in reverse order.
   QString result = command;
-  foreach (const QRegularExpressionMatch &match, matches) {
+  for (const QRegularExpressionMatch &match : matches) {
     QString value = env.value(match.captured(1));
     result.replace(match.capturedStart(), match.capturedLength(), value);
   }

--- a/src/git/Commit.cpp
+++ b/src/git/Commit.cpp
@@ -69,7 +69,7 @@ QString Commit::message(MessageOptions options) const {
 QString Commit::description() const {
   // Build list of candidates.
   QHash<Id, TagRef> candidates;
-  foreach (const TagRef &tag, repo().tags()) {
+  for (const TagRef &tag : repo().tags()) {
     if (Commit commit = tag.target())
       candidates.insert(commit.id(), tag);
   }
@@ -99,7 +99,7 @@ QString Commit::description() const {
 }
 
 QString Commit::detachedHeadName() const {
-  foreach (const TagRef &tag, repo().tags()) {
+  for (const TagRef &tag : repo().tags()) {
     if (tag.target().id() == id())
       return tag.name();
   }
@@ -280,7 +280,7 @@ bool Commit::reset(git_reset_t type, const QStringList &paths,
     // Paths are assumed to be exact matches.
     opts.checkout_strategy |= GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH;
 
-    foreach (const QString &path, paths) {
+    for (const QString &path : paths) {
       storage.append(path.toUtf8());
       rawPaths.append(storage.last().data());
     }
@@ -348,7 +348,7 @@ QString Commit::substituteEmoji(const QString &text) const {
 
   // Substitute in reverse order.
   QString result = text;
-  foreach (const QRegularExpressionMatch &match, matches) {
+  for (const QRegularExpressionMatch &match : matches) {
     auto it = sEmojiCache.constFind(match.captured(1));
     if (it != sEmojiCache.constEnd())
       result.replace(match.capturedStart(), match.capturedLength(), it.value());

--- a/src/git/Filter.cpp
+++ b/src/git/Filter.cpp
@@ -97,7 +97,7 @@ static int stream_close(git_writestream *s) {
 
 static int stream_write(git_writestream *s, const char *buffer, size_t len) {
   struct Stream *stream = reinterpret_cast<struct Stream *>(s);
-  const auto res = stream->process.write(buffer, len);
+  const size_t res = stream->process.write(buffer, len);
   if (res != len)
     return -1;
   return 0;
@@ -173,7 +173,7 @@ void Filter::init() {
   }
 
   // Register filters.
-  foreach (const QString &key, filters.keys()) {
+  for (const QString &key : filters.keys()) {
     FilterInfo &info = filters[key];
     if (info.clean.isEmpty() || info.smudge.isEmpty())
       continue;

--- a/src/git/Index.cpp
+++ b/src/git/Index.cpp
@@ -32,7 +32,7 @@ namespace {
 void countDirectoryEntries(const QString &file, int &count) {
   QDir dir(file);
   auto filters = QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot;
-  foreach (const QString &entry, dir.entryList(filters)) {
+  for (const QString &entry : dir.entryList(filters)) {
     QString file = dir.filePath(entry);
     if (QFileInfo(file).isDir()) {
       countDirectoryEntries(file, count);
@@ -143,7 +143,7 @@ void Index::setStaged(const QStringList &files, bool staged, bool yieldFocus) {
   QStringList changedFiles;
   Repository repo(git_index_owner(d->index));
   RepositoryNotifier *notifier = repo.notifier();
-  foreach (const QString &file, files) {
+  for (const QString &file : files) {
     QByteArray path = file.toUtf8();
 
     // Get the id and mode of the file in the HEAD commit.
@@ -288,7 +288,7 @@ void Index::setStaged(const QStringList &files, bool staged, bool yieldFocus) {
 
   if (!changedFiles.isEmpty()) {
     git_index_write(d->index);
-    foreach (const QString &changedFile, changedFiles)
+    for (const QString &changedFile : changedFiles)
       d->stagedCache.remove(changedFile);
     emit notifier->indexChanged(changedFiles, yieldFocus);
   }
@@ -346,7 +346,7 @@ bool Index::addDirectory(const QString &file) const {
   QDir dir(file);
   git_repository *repo = git_index_owner(d->index);
   auto filters = QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot;
-  foreach (const QString &entry, dir.entryList(filters)) {
+  for (const QString &entry : dir.entryList(filters)) {
     QString file = dir.filePath(entry);
     if (QFileInfo(file).isDir()) {
       if (!addDirectory(file))

--- a/src/git/Patch.cpp
+++ b/src/git/Patch.cpp
@@ -327,8 +327,8 @@ QByteArray Patch::generateResult(QList<QList<QByteArray>> &image,
                                  const FilterList &filters) const {
   // Generate result.
   QByteArray result;
-  foreach (const QList<QByteArray> &lines, image) {
-    foreach (const QByteArray &line, lines)
+  for (const QList<QByteArray> &lines : image) {
+    for (const QByteArray &line : lines)
       result.append(line);
   }
 

--- a/src/git/Remote.cpp
+++ b/src/git/Remote.cpp
@@ -54,7 +54,7 @@ QString keyFile(const QString &path = QString()) {
   if (!dir.cd(".ssh"))
     return QString();
 
-  foreach (const QString &kind, kKeyKinds) {
+  for (const QString &kind : kKeyKinds) {
     QString name = QString("id_%1").arg(kind);
     if (dir.exists(name))
       return dir.absoluteFilePath(name);
@@ -586,7 +586,7 @@ Result Remote::push(Callbacks *callbacks, const QStringList &refspecs) {
 
   QVector<char *> raw;
   QVector<QByteArray> storage;
-  foreach (const QString &refspec, refspecs) {
+  for (const QString &refspec : refspecs) {
     storage.append(refspec.toUtf8());
     raw.append(storage.last().data());
   }
@@ -614,7 +614,7 @@ Result Remote::push(Callbacks *callbacks, const Reference &src,
   QStringList refspecs(refspec);
   if (tags) {
     // Add tags individually. Wildcard push refspecs aren't supported yet.
-    foreach (const TagRef &tag, repo.tags())
+    for (const TagRef &tag : repo.tags())
       refspecs.append(prefix + tag.qualifiedName());
   }
 

--- a/src/git/Repository.cpp
+++ b/src/git/Repository.cpp
@@ -68,9 +68,11 @@ const QString kConfigDir = "gittyup";
 const QString kConfigFile = "config";
 const QString kStarFile = "starred";
 
+#ifndef USE_SYSTEM_LIBGIT2
 int blame_progress(const git_oid *suspect, void *payload) {
   return reinterpret_cast<Blame::Callbacks *>(payload)->progress() ? 0 : -1;
 }
+#endif
 
 int checkout_notify(git_checkout_notify_t why, const char *path,
                     const git_diff_file *baseline, const git_diff_file *target,
@@ -120,7 +122,7 @@ Repository::Data::Data(git_repository *repo)
   if (ids.isEmpty())
     return;
 
-  foreach (const QByteArray &id, ids.split('\n'))
+  for (const QByteArray &id : ids.split('\n'))
     starredCommits.insert(git::Id(QByteArray::fromHex(id), hash_type));
 }
 
@@ -556,7 +558,7 @@ RevWalk Repository::walker(int sort) const {
 
   RevWalk walker(revwalk);
   git_revwalk_sorting(revwalk, sort);
-  foreach (const Reference &ref, refs())
+  for (const Reference &ref : refs())
     git_revwalk_push_ref(revwalk, ref.qualifiedName().toUtf8());
 
   return walker;
@@ -661,7 +663,7 @@ Commit Repository::commit(const Signature &author, const Signature &committer,
 
 QList<Commit> Repository::starredCommits() const {
   QList<Commit> commits;
-  foreach (const Id &id, d->starredCommits) {
+  for (const Id &id : d->starredCommits) {
     if (Commit commit = lookupCommit(id))
       commits.append(commit);
   }
@@ -686,7 +688,7 @@ void Repository::setCommitStarred(const Id &commit, bool starred) {
     return;
 
   QByteArrayList ids;
-  foreach (const Id &id, d->starredCommits)
+  for (const Id &id : d->starredCommits)
     ids.append(id.toByteArray().toHex());
 
   file.write(ids.join('\n'));
@@ -703,7 +705,7 @@ QList<Submodule> Repository::submodules() const {
   ensureSubmodulesCached();
 
   QList<Submodule> submodules;
-  foreach (const QString &name, d->submodules) {
+  for (const QString &name : d->submodules) {
     if (Submodule submodule = lookupSubmodule(name))
       submodules.append(submodule);
   }
@@ -807,7 +809,7 @@ QList<Commit> Repository::stashes() const {
   git_stash_foreach(d->repo, insert_stash_id, &ids);
 
   QList<Commit> commits;
-  foreach (const Id &id, ids) {
+  for (const Id &id : ids) {
     git_commit *commit = nullptr;
     if (!git_commit_lookup(&commit, d->repo, id))
       commits.append(Commit(commit));
@@ -1034,7 +1036,7 @@ bool Repository::checkout(const Commit &commit, CheckoutCallbacks *callbacks,
         GIT_CHECKOUT_UPDATE_SUBMODULES; // GIT_CHECKOUT_UPDATE_SUBMODULES is not
                                         // yet implemented from libgit2
 
-    foreach (const QString &path, paths) {
+    for (const QString &path : paths) {
       storage.append(path.toUtf8());
       rawPaths.append(storage.last().data());
     }
@@ -1107,7 +1109,7 @@ Repository::LfsTracking Repository::lfsTracked() {
 
   QStringList tracked, excluded;
   bool excluding = false;
-  foreach (const QString &line, lines) {
+  for (const QString &line : lines) {
     if (line[0] != ' ') {
       excluding = true;
     } else if (excluding) {
@@ -1220,7 +1222,7 @@ void Repository::init() {
   QStringList paths = {"/etc/ssl/certs/ca-certificates.crt",
                        "/etc/pki/tls/certs/ca-bundle.crt"};
 
-  foreach (const QString &path, paths) {
+  for (const QString &path : paths) {
     if (QFile::exists(path)) {
       git_libgit2_opts(GIT_OPT_SET_SSL_CERT_LOCATIONS,
                        path.toUtf8().constData(), NULL);

--- a/src/host/Accounts.cpp
+++ b/src/host/Accounts.cpp
@@ -28,7 +28,7 @@ int Accounts::indexOf(Account *account) const {
 
 Repository *Accounts::lookup(const QString &url) const {
   QUrl remote(url);
-  foreach (Account *account, mAccounts) {
+  for (Account *account : mAccounts) {
     for (int i = 0; i < account->repositoryCount(); ++i) {
       Repository *repo = account->repository(i);
       if (url == repo->url(Repository::Ssh))
@@ -44,7 +44,7 @@ Repository *Accounts::lookup(const QString &url) const {
 }
 
 Account *Accounts::lookup(const QString &username, Account::Kind kind) const {
-  foreach (Account *account, mAccounts) {
+  for (Account *account : mAccounts) {
     if (username == account->username() && kind == account->kind())
       return account;
   }

--- a/src/host/GitHub.cpp
+++ b/src/host/GitHub.cpp
@@ -79,7 +79,7 @@ GitHub::GitHub(const QString &username) : Account(username) {
 
         QMap<QString, QString> map;
         QRegularExpression re("<(.*)>; rel=\"(\\w+)\"");
-        foreach (const QString &record, link.split(", ")) {
+        for (const QString &record : link.split(", ")) {
           QRegularExpressionMatch match = re.match(record);
           if (match.isValid() && match.hasMatch())
             map.insert(match.captured(2), match.captured(1));
@@ -181,7 +181,7 @@ void GitHub::createPullRequest(Repository *repo, const QString &ownerRepo,
 
   QUrl url(QString("https://api.github.com/repos/%1/pulls").arg(ownerRepo));
   rest(url, doc, [this, title](const QJsonObject &obj) {
-    foreach (const QJsonValue &error, obj.value("errors").toArray())
+    for (const QJsonValue &error : obj.value("errors").toArray())
       emit pullRequestError(title,
                             error.toObject().value("message").toString());
   });
@@ -223,7 +223,7 @@ void GitHub::requestComments(Repository *repo, const QString &oid) {
       return;
 
     CommitComments comments;
-    foreach (const QJsonValue &value, nodes) {
+    for (const QJsonValue &value : nodes) {
       QJsonObject obj = value.toObject();
       QString path = obj.value("path").toString();
       int position = obj.value("position").toInt() - 1;

--- a/src/host/GitLab.cpp
+++ b/src/host/GitLab.cpp
@@ -60,7 +60,7 @@ GitLab::GitLab(const QString &username) : Account(username) {
 
         QMap<QString, QString> map;
         QRegularExpression re("<(.*)>; rel=\"(\\w+)\"");
-        foreach (const QString &record, link.split(", ")) {
+        for (const QString &record : link.split(", ")) {
           QRegularExpressionMatch match = re.match(record);
           if (match.isValid() && match.hasMatch())
             map.insert(match.captured(2), match.captured(1));

--- a/src/host/Gitea.cpp
+++ b/src/host/Gitea.cpp
@@ -79,7 +79,7 @@ Gitea::Gitea(const QString &username) : Account(username) {
 
         QMap<QString, QString> map;
         QRegularExpression re("<(.*)>; rel=\"(\\w+)\"");
-        foreach (const QString &record, link.split(", ")) {
+        for (const QString &record : link.split(", ")) {
           QRegularExpressionMatch match = re.match(record);
           if (match.isValid() && match.hasMatch())
             map.insert(match.captured(2), match.captured(1));
@@ -181,7 +181,7 @@ void Gitea::createPullRequest(Repository *repo, const QString &ownerRepo,
 
   QUrl url(QString("https://try.gitea.io/repos/%1/pulls").arg(ownerRepo));
   rest(url, doc, [this, title](const QJsonObject &obj) {
-    foreach (const QJsonValue &error, obj.value("errors").toArray())
+    for (const QJsonValue &error : obj.value("errors").toArray())
       emit pullRequestError(title,
                             error.toObject().value("message").toString());
   });
@@ -223,7 +223,7 @@ void Gitea::requestComments(Repository *repo, const QString &oid) {
       return;
 
     CommitComments comments;
-    foreach (const QJsonValue &value, nodes) {
+    for (const QJsonValue &value : nodes) {
       QJsonObject obj = value.toObject();
       QString path = obj.value("path").toString();
       int position = obj.value("position").toInt() - 1;

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -91,7 +91,7 @@ void Index::reset() {
 
 void Index::cleanTemporaryFiles() {
   QStringList filters;
-  foreach (const QString &file, kIndexFiles)
+  for (const QString &file : kIndexFiles)
     filters.append(file + ".*");
 
   QDir dir = indexDir();
@@ -105,7 +105,7 @@ void Index::cleanTemporaryFiles() {
   if (!lock.tryLock(1000))
     return;
 
-  foreach (const QString &file, files)
+  for (const QString &file : files)
     dir.remove(file);
 }
 
@@ -117,7 +117,7 @@ bool Index::remove() {
     return false;
 
   QDir dir = indexDir();
-  foreach (const QString &file, kIndexFiles) {
+  for (const QString &file : kIndexFiles) {
     if (!dir.remove(file))
       return false;
   }
@@ -149,7 +149,7 @@ bool Index::write(const PostingMap &map) {
     return false;
 
   // Write id file.
-  foreach (const git::Id &id, mIds)
+  for (const git::Id &id : mIds)
     idFile.write(id.toByteArray(), id.getSize());
 
   // Merge new entries into existing postings file.
@@ -213,7 +213,7 @@ bool Index::write(const PostingMap &map) {
 
     // Write postings.
     writeVInt(postOut, postings.size());
-    foreach (const Posting &posting, postings) {
+    for (const Posting &posting : postings) {
       quint32 proxPos = proxFile.pos(); // truncate
       writeVInt(postOut, posting.id);
       postOut << posting.field << proxPos;
@@ -259,7 +259,7 @@ QList<git::Commit> Index::commits(const QString &filter) const {
 QList<git::Commit> Index::commits(const QList<Posting> &postings) const {
   // Look up commits.
   QSet<git::Commit> commits;
-  foreach (const Posting &posting, postings) {
+  for (const Posting &posting : postings) {
     // If we fail this check, then the index is mismatching the repo
     // The FIXME below might be the cause of that
     if (posting.id < mIds.size()) {
@@ -327,7 +327,7 @@ QList<Index::Posting> Index::postings(const Predicate &pred,
     return QList<Posting>();
 
   QList<Posting> postings;
-  foreach (const Word &word, mDict) {
+  for (const Word &word : mDict) {
     // Test predicate.
     if (!pred(word.key))
       continue;
@@ -509,7 +509,7 @@ void Index::writePositions(QDataStream &out,
                            const QVector<quint32> &positions) {
   quint32 prev = 0;
   writeVInt(out, positions.size());
-  foreach (quint32 position, positions) {
+  for (quint32 position : positions) {
     // Convert to delta from absolute.
     quint32 delta = position - prev;
     writeVInt(out, delta);

--- a/src/index/Indexer/indexer.cpp
+++ b/src/index/Indexer/indexer.cpp
@@ -72,7 +72,7 @@ namespace {
 int fds[2];
 void term(int) {
   char ch = 1;
-  write(fds[0], &ch, sizeof(ch));
+  [[maybe_unused]] ssize_t n = write(fds[0], &ch, sizeof(ch));
 }
 #endif
 } // namespace
@@ -156,8 +156,8 @@ Indexer::Indexer(Index &index, bool notify, QObject *parent)
     : QObject(parent), mIndex(index), mIds(index),
       // mIntermediateQueue will be filled by the workers spawned in the start()
       // method below.
-      mReduce(mIds, mIntermediateQueue, mResults,
-              mIndex), // Receives intermediate and converts them to results
+      mReduce(mIds, mIntermediateQueue,
+              mResults), // Receives intermediate and converts them to results
       mResultWriter(index, mResults,
                     notify) { // Receives results and writes them down to file
   mWalker = mIndex.repo().walker();
@@ -170,7 +170,7 @@ Indexer::Indexer(Index &index, bool notify, QObject *parent)
     connect(notifier, &QSocketNotifier::activated, [this, notifier] {
       notifier->setEnabled(false);
       char ch;
-      read(fds[1], &ch, sizeof(ch));
+      [[maybe_unused]] ssize_t n = read(fds[1], &ch, sizeof(ch));
       cancel();
       notifier->setEnabled(true);
     });

--- a/src/index/Indexer/map.cpp
+++ b/src/index/Indexer/map.cpp
@@ -51,7 +51,7 @@ void Map::run() {
     result.fields[Index::Email][email].append(0);
 
     quint32 namePos = 0;
-    foreach (const QString &name, author.name().split(kWsRe)) {
+    for (const QString &name : author.name().split(kWsRe)) {
       QByteArray key = name.toUtf8().toLower();
       result.fields[Index::Author][key].append(namePos++);
     }

--- a/src/index/Indexer/reduce.h
+++ b/src/index/Indexer/reduce.h
@@ -17,10 +17,8 @@ class Index;
 class Reduce : public QThread {
 public:
   Reduce(IdStorage &ids, WorkerQueue<Intermediate> &queue,
-         WorkerQueue<Index::PostingMap> &results, Index &index,
-         QObject *parent = nullptr)
-      : QThread(parent), mIds(ids), mQueue(queue), mResults(results),
-        mIndex(index) {}
+         WorkerQueue<Index::PostingMap> &results, QObject *parent = nullptr)
+      : QThread(parent), mIds(ids), mQueue(queue), mResults(results) {}
 
 private:
   void run() override;
@@ -29,7 +27,6 @@ private:
   IdStorage &mIds;
   WorkerQueue<Intermediate> &mQueue;
   WorkerQueue<Index::PostingMap> &mResults;
-  Index &mIndex;
   quint16 mProcessedElemenets = 0;
 };
 

--- a/src/index/Query.cpp
+++ b/src/index/Query.cpp
@@ -105,7 +105,7 @@ public:
 
   QString toString() const override {
     QStringList terms;
-    foreach (const Index::Term &term, mTerms)
+    for (const Index::Term &term : mTerms)
       terms.append(term.text);
     Index::Field field = mTerms.first().field;
     return QString("%1:\"%2\"").arg(Index::fieldName(field), terms.join(" "));
@@ -128,8 +128,8 @@ public:
     for (int i = 1; i < mTerms.size(); ++i) {
       const Index::Term &term = mTerms.at(i);
       QMap<quint32, QMap<quint8, QSet<quint32>>> ids;
-      foreach (const Index::Posting &posting, index->postings(term, true)) {
-        foreach (quint32 pos, posting.positions)
+      for (const Index::Posting &posting : index->postings(term, true)) {
+        for (quint32 pos : posting.positions)
           ids[posting.id][posting.field].insert(pos);
       }
 
@@ -140,7 +140,7 @@ public:
           it.remove();
         } else {
           bool found = false;
-          foreach (quint32 pos, posting.positions) {
+          for (quint32 pos : posting.positions) {
             if (ids[posting.id][posting.field].contains(pos + offset)) {
               found = true;
               break;
@@ -193,7 +193,7 @@ public:
     } else {
       // Add commits that aren't already in the result set.
       QSet<git::Commit> set(commits.begin(), commits.end());
-      foreach (const git::Commit &commit, rhs) {
+      for (const git::Commit &commit : rhs) {
         if (!set.contains(commit))
           commits.append(commit);
       }

--- a/src/index/WorkerQueue.h
+++ b/src/index/WorkerQueue.h
@@ -61,7 +61,7 @@ public:
     if (mStop)
       return std::nullopt;
     else {
-      T item = std::move(mQueue.dequeue());
+      T item = mQueue.dequeue();
       mNotFull.wakeOne();
       if (mQueue.size() == 0)
         mEmpty.wakeAll();

--- a/src/index/lexer_test.cpp
+++ b/src/index/lexer_test.cpp
@@ -92,7 +92,7 @@ int main(int argc, char *argv[]) {
   lexers.insert("null", &generic);
 
   QTextStream out(stdout);
-  foreach (const QString &arg, args) {
+  for (const QString &arg : args) {
     // Open file.
     QFile file(arg);
     if (!file.open(QIODevice::ReadOnly))

--- a/src/log/LogView.cpp
+++ b/src/log/LogView.cpp
@@ -79,7 +79,7 @@ void LogView::copy() {
   QString plainText;
   QString richText;
   QModelIndexList indexes = collectSelectedIndexes(this, QModelIndex());
-  foreach (const QModelIndex &index, indexes) {
+  for (const QModelIndex &index : indexes) {
     QString prefix;
 
     // Indent child indices

--- a/src/plugins/Plugin.cpp
+++ b/src/plugins/Plugin.cpp
@@ -556,7 +556,7 @@ QString Plugin::scriptDir() const { return mDir; }
 QString Plugin::errorString() const { return mError; }
 
 bool Plugin::isEnabled() const {
-  foreach (const QString &key, mDiagnostics.keys()) {
+  for (const QString &key : mDiagnostics.keys()) {
     if (isEnabled(key))
       return true;
   }
@@ -683,12 +683,12 @@ bool Plugin::hunk(TextEditor *editor) const {
 QList<PluginRef> Plugin::plugins(const git::Repository &repo) {
   QList<PluginRef> plugins;
   QDir dir = Settings::pluginsDir();
-  foreach (const QString &name, dir.entryList({"*.lua"}, QDir::Files))
+  for (const QString &name : dir.entryList({"*.lua"}, QDir::Files))
     plugins.append(PluginRef(new Plugin(dir.filePath(name), repo)));
 
   QDir user = Settings::userDir();
   if (user.cd("plugins")) {
-    foreach (const QString &name, user.entryList({"*.lua"}, QDir::Files))
+    for (const QString &name : user.entryList({"*.lua"}, QDir::Files))
       plugins.append(PluginRef(new Plugin(user.filePath(name), repo)));
   }
 

--- a/src/ui/AdvancedSearchWidget.cpp
+++ b/src/ui/AdvancedSearchWidget.cpp
@@ -131,12 +131,12 @@ void AdvancedSearchWidget::exec(QLineEdit *parent, Index *index) {
   // FIXME: Phrase queries are lossy.
   QMap<Index::Field, QStringList> map;
   if (QueryRef query = Query::parseQuery(parent->text())) {
-    foreach (const Index::Term &term, query->terms())
+    for (const Index::Term &term : query->terms())
       map[term.field].append(term.text);
   }
 
   // Reset fields.
-  foreach (QLineEdit *lineEdit, mLineEdits) {
+  for (QLineEdit *lineEdit : mLineEdits) {
     QVariant var = lineEdit->property(kFieldProp);
     Index::Field field = static_cast<Index::Field>(var.toInt());
     lineEdit->setText(map.value(field).join(' '));
@@ -145,7 +145,7 @@ void AdvancedSearchWidget::exec(QLineEdit *parent, Index *index) {
   // Load completion data in the background.
   std::ignore = QtConcurrent::run([this, index] {
     QMap<Index::Field, QStringList> fields = index->fieldMap();
-    foreach (QLineEdit *lineEdit, mLineEdits) {
+    for (QLineEdit *lineEdit : mLineEdits) {
       QVariant var = lineEdit->property(kFieldProp);
       Index::Field field = static_cast<Index::Field>(var.toInt());
       QAbstractItemModel *model = lineEdit->completer()->model();
@@ -159,7 +159,7 @@ void AdvancedSearchWidget::exec(QLineEdit *parent, Index *index) {
 
 void AdvancedSearchWidget::hideEvent(QHideEvent *event) {
   // Clear completion data.
-  foreach (QLineEdit *lineEdit, mLineEdits) {
+  for (QLineEdit *lineEdit : mLineEdits) {
     QAbstractItemModel *model = lineEdit->completer()->model();
     if (QStringListModel *list = qobject_cast<QStringListModel *>(model))
       list->setStringList(QStringList());
@@ -170,7 +170,7 @@ void AdvancedSearchWidget::hideEvent(QHideEvent *event) {
 
 void AdvancedSearchWidget::accept() {
   QStringList fields;
-  foreach (QLineEdit *lineEdit, mLineEdits) {
+  for (QLineEdit *lineEdit : mLineEdits) {
     QString text = lineEdit->text();
     if (text.isEmpty())
       continue;

--- a/src/ui/Badge.cpp
+++ b/src/ui/Badge.cpp
@@ -59,7 +59,7 @@ QSize Badge::size(const QFont &font, const QList<Label> &labels) {
 
   int width = 0;
   QFontMetrics fm(font);
-  foreach (const Label &label, labels)
+  for (const Label &label : labels)
     width += size(font, label).width();
   return QSize(width + ((labels.size() - 1) * kSpacing), fm.lineSpacing() + 2);
 }

--- a/src/ui/BlameEditor.cpp
+++ b/src/ui/BlameEditor.cpp
@@ -148,7 +148,7 @@ bool BlameEditor::load(const QString &name, const git::Blob &blob,
     git::Buffer buffer(content.constData(), content.length());
     if (buffer.isBinary()) {
       return false;
-    } else if (content.length() >= kMaxReadBinary) {
+    } else if (static_cast<size_t>(content.length()) >= kMaxReadBinary) {
       // Okay, not a binary file. Now we need to grab the rest if needed
       content += file.readAll();
     }

--- a/src/ui/ColumnView.cpp
+++ b/src/ui/ColumnView.cpp
@@ -82,7 +82,6 @@ public:
       return;
     }
 
-    QWindow *win = window()->windowHandle();
     QIcon icon = index.data(Qt::DecorationRole).value<QIcon>();
     mIcon->setPixmap(
         icon.pixmap(QSize(ICON_SIZE, ICON_SIZE), window()->devicePixelRatio()));

--- a/src/ui/CommitEditor.cpp
+++ b/src/ui/CommitEditor.cpp
@@ -77,7 +77,7 @@ private:
     }
 
     QMenu *menu = createStandardContextMenu();
-    foreach (const QTextEdit::ExtraSelection &es, mSpellList) {
+    for (const QTextEdit::ExtraSelection &es : mSpellList) {
       if (es.cursor == cursor && es.format == mSpellFormat) {
 
         // Replace standard context menu.
@@ -87,7 +87,7 @@ private:
         if (!suggestions.isEmpty()) {
           QMenu *spellReplace = menu->addMenu(tr("Replace..."));
           QMenu *spellReplaceAll = menu->addMenu(tr("Replace All..."));
-          foreach (const QString &str, suggestions) {
+          for (const QString &str : suggestions) {
             QAction *replace = spellReplace->addAction(str);
             connect(replace, &QAction::triggered, [this, event, str] {
               QTextCursor cursor = cursorForPosition(event->pos());
@@ -217,7 +217,7 @@ private:
   }
 
   bool ignoredAt(const QTextCursor &cursor) {
-    foreach (const QTextEdit::ExtraSelection &es, extraSelections()) {
+    for (const QTextEdit::ExtraSelection &es : extraSelections()) {
       if (es.cursor == cursor && es.format == mIgnoredFormat)
         return true;
     }
@@ -310,7 +310,7 @@ CommitEditor::CommitEditor(const git::Repository &repo, QWidget *parent)
   // Spell check language menu actions.
   bool selected = false;
   QList<QAction *> actionList;
-  foreach (const QString &dict, dictNameList) {
+  for (const QString &dict : dictNameList) {
     QLocale locale(dict);
 
     // Convert language_COUNTRY format from dictionary filename to string
@@ -342,19 +342,17 @@ CommitEditor::CommitEditor(const git::Repository &repo, QWidget *parent)
 
   // Sort menu entries alphabetical.
   std::sort(actionList.begin(), actionList.end(),
-            [actionList](QAction *la, QAction *ra) {
-              return la->text() < ra->text();
-            });
+            [](QAction *la, QAction *ra) { return la->text() < ra->text(); });
 
   QActionGroup *dictActionGroup = new QActionGroup(this);
   dictActionGroup->setExclusive(true);
-  foreach (QAction *action, actionList)
+  for (QAction *action : actionList)
     dictActionGroup->addAction(action);
 
   // No dictionary set: select dictionary for system language and country
   if ((!selected) && (mDictName != "none")) {
     QString name = QLocale::system().name();
-    foreach (QAction *action, dictActionGroup->actions()) {
+    for (QAction *action : dictActionGroup->actions()) {
       if (action->data().toString().startsWith(name)) {
         action->setChecked(true);
         mDictName = action->data().toString();
@@ -365,7 +363,7 @@ CommitEditor::CommitEditor(const git::Repository &repo, QWidget *parent)
 
     // Fallback: ignore country (e.g.: use de_DE instead of de_AT)
     if (!selected) {
-      foreach (QAction *action, dictActionGroup->actions()) {
+      for (QAction *action : dictActionGroup->actions()) {
         if (action->data().toString().startsWith(name.left(2))) {
           action->setChecked(true);
           mDictName = action->data().toString();
@@ -456,7 +454,7 @@ CommitEditor::CommitEditor(const git::Repository &repo, QWidget *parent)
     QString path = mDictPath + "/" + mDictName;
     if (!mMessage->setupSpellCheck(path, mUserDict, mSpellError,
                                    mSpellIgnore)) {
-      foreach (QAction *action, dictActionGroup->actions()) {
+      for (QAction *action : dictActionGroup->actions()) {
         action->setChecked(false);
         if (mDictName == action->data().toString()) {
           action->setEnabled(false);

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -224,7 +224,7 @@ public:
       }
 
       if (mRefsFilter == CommitList::RefsFilter::AllRefs) {
-        foreach (const git::Reference ref, mRepo.refs()) {
+        for (const git::Reference &ref : mRepo.refs()) {
           if (!ref.isStash())
             mWalker.push(ref);
         }
@@ -272,7 +272,7 @@ public:
 
       // Replace commit with its parents.
       QList<git::Commit> replacements;
-      foreach (const git::Commit &parent, commit.parents()) {
+      for (const git::Commit &parent : commit.parents()) {
         // FIXME: Mark commits that point to existing parent?
         if (indexOf(parent) < 0 && !contains(parent, rows))
           replacements.append(parent);
@@ -288,7 +288,7 @@ public:
         if (!replacements.isEmpty()) {
           git::Commit replacement = replacements.takeFirst();
           mParents.insert(index, Parent(replacement, parent.color));
-          foreach (const git::Commit &replacement, replacements)
+          for (const git::Commit &replacement : replacements)
             mParents.append(Parent(replacement, nextColor()));
         }
       }
@@ -375,9 +375,9 @@ public:
 
       case CommitList::Role::GraphRole: {
         QVariantList columns;
-        foreach (const Column &column, row.columns) {
+        for (const Column &column : row.columns) {
           QVariantList segments;
-          foreach (const Segment &segment, column)
+          for (const Segment &segment : column)
             segments.append(segment.segment);
           columns.append(QVariant(segments));
         }
@@ -387,9 +387,9 @@ public:
 
       case CommitList::Role::GraphColorRole: {
         QVariantList columns;
-        foreach (const Column &column, row.columns) {
+        for (const Column &column : row.columns) {
           QVariantList segments;
-          foreach (const Segment &segment, column)
+          for (const Segment &segment : column)
             segments.append(segment.color);
           columns.append(QVariant(segments));
         }
@@ -447,12 +447,12 @@ private:
   }
 
   bool contains(const git::Commit &commit, const QList<Row> &rows) const {
-    foreach (const Row &row, mRows) {
+    for (const Row &row : mRows) {
       if (row.commit == commit)
         return true;
     }
 
-    foreach (const Row &row, rows) {
+    for (const Row &row : rows) {
       if (row.commit == commit)
         return true;
     }
@@ -484,7 +484,7 @@ private:
       }
 
       // Add a path to each successor.
-      foreach (const git::Commit &successor, successors) {
+      for (const git::Commit &successor : successors) {
         // Find index of parent in next row.
         int index = indexOf(successor);
         if (index < 0)
@@ -531,13 +531,13 @@ private:
   QColor nextColor() {
     // Get the first unused (or least used) color.
     QMap<QString, int> counts;
-    foreach (const Parent &parent, mParents)
+    for (const Parent &parent : mParents)
       counts[parent.color.name()]++;
 
     int count = 0;
     QList<QColor> colors = Application::theme()->branchTopologyEdges();
     forever {
-      foreach (const QColor &color, colors) {
+      for (const QColor &color : colors) {
         if (counts.value(color.name()) == count)
           return color;
       }
@@ -1129,7 +1129,7 @@ private:
           {Badge::Label::Type::Ref, head.name(), true});
     }
 
-    foreach (const git::Reference &ref, mRepo.refs()) {
+    for (const git::Reference &ref : mRepo.refs()) {
       if (git::Commit target = ref.target())
         mRefs[target.id()].append(
             {Badge::Label::Type::Ref, ref.name(), ref.isHead(), ref.isTag()});
@@ -1210,7 +1210,7 @@ CommitList::CommitList(Index *index, QWidget *parent)
           &CommitList::restoreSelection);
 
   CommitModel *model = static_cast<CommitModel *>(mModel);
-  connect(model, &CommitModel::statusFinished, [this, model](bool visible) {
+  connect(model, &CommitModel::statusFinished, [this](bool visible) {
     mRestoreSelection = true; // Reset to default
 
     // Select the first commit if the selection was cleared.
@@ -1296,7 +1296,7 @@ git::Diff CommitList::selectedDiff() const {
 
 QList<git::Commit> CommitList::selectedCommits() const {
   QList<git::Commit> selectedCommits;
-  foreach (const QModelIndex &index, sortedIndexes()) {
+  for (const QModelIndex &index : sortedIndexes()) {
     git::Commit commit = index.data(CommitRole).value<git::Commit>();
     if (commit.isValid())
       selectedCommits.append(commit);
@@ -1461,7 +1461,7 @@ void CommitList::setModel(QAbstractItemModel *model) {
       selectionModel, &QItemSelectionModel::selectionChanged,
       [this](const QItemSelection &selected, const QItemSelection &deselected) {
         // Update the index before each selected/deselected range.
-        foreach (const QItemSelectionRange &range, selected + deselected) {
+        for (const QItemSelectionRange &range : selected + deselected) {
           if (int row = range.top())
             update(this->model()->index(row - 1, 0));
         }
@@ -1538,7 +1538,7 @@ void CommitList::contextMenuEvent(QContextMenuEvent *event) {
   } else {
     // multiple selection
     bool anyStarred = false;
-    foreach (const QModelIndex &index, selectionModel()->selectedIndexes()) {
+    for (const QModelIndex &index : selectionModel()->selectedIndexes()) {
       if (index.data(CommitRole).isValid() &&
           index.data(CommitRole).value<git::Commit>().isStarred()) {
         anyStarred = true;
@@ -1547,7 +1547,7 @@ void CommitList::contextMenuEvent(QContextMenuEvent *event) {
     }
 
     menu.addAction(anyStarred ? tr("Unstar") : tr("Star"), [this, anyStarred] {
-      foreach (const QModelIndex &index, selectionModel()->selectedIndexes())
+      for (const QModelIndex &index : selectionModel()->selectedIndexes())
         if (index.data(CommitRole).isValid())
           index.data(CommitRole).value<git::Commit>().setStarred(!anyStarred);
     });
@@ -1852,7 +1852,7 @@ void CommitList::notifySelectionChanged() {
     return;
 
   // Redraw all selected indexes. Separators may have changed.
-  foreach (const QModelIndex &index, indexes)
+  for (const QModelIndex &index : indexes)
     update(index);
   git::Diff diff = selectedDiff();
   emit diffSelected(diff, mFile, mSpontaneous);

--- a/src/ui/CommitToolBar.cpp
+++ b/src/ui/CommitToolBar.cpp
@@ -51,7 +51,7 @@ public:
 
     RepoView *view = RepoView::parentView(parent);
     git::Config config = view->repo().appConfig();
-    foreach (const QString &key, map.keys()) {
+    for (const QString &key : map.keys()) {
       QAction *action = menu->addAction(key);
       action->setCheckable(true);
       actions->addAction(action);

--- a/src/ui/DetailView.cpp
+++ b/src/ui/DetailView.cpp
@@ -299,8 +299,8 @@ public:
 
   void setReferences(const QList<git::Commit> &commits) {
     QList<Badge::Label> refs;
-    foreach (const git::Commit &commit, commits) {
-      foreach (const git::Reference &ref, commit.refs())
+    for (const git::Commit &commit : commits) {
+      for (const git::Reference &ref : commit.refs())
         refs.append(
             {Badge::Label::Type::Ref, ref.name(), ref.isHead(), ref.isTag()});
     }
@@ -339,7 +339,7 @@ public:
 
       // Add names.
       QSet<QString> authors, committers;
-      foreach (const git::Commit &commit, commits) {
+      for (const git::Commit &commit : commits) {
         authors.insert(kBoldFmt.arg(commit.author().name()));
         committers.insert(kBoldFmt.arg(commit.committer().name()));
       }
@@ -401,7 +401,7 @@ public:
         kAuthorFmt.arg(committer.name(), committer.email()));
 
     QStringList parents;
-    foreach (const git::Commit &parent, commit.parents()) {
+    for (const git::Commit &parent : commit.parents()) {
       QUrl url;
       url.setScheme("id");
       url.setPath(parent.id().toString());

--- a/src/ui/DiffView/CommentWidget.h
+++ b/src/ui/DiffView/CommentWidget.h
@@ -14,7 +14,7 @@ public:
     setContentsMargins(4, 4, 4, 4);
 
     QVBoxLayout *layout = new QVBoxLayout(this);
-    foreach (const QDateTime &key, comments.keys())
+    for (const QDateTime &key : comments.keys())
       layout->addWidget(new Comment(key, comments.value(key), this));
   }
 };

--- a/src/ui/DiffView/DiffView.cpp
+++ b/src/ui/DiffView/DiffView.cpp
@@ -38,8 +38,8 @@ bool copy(const QString &source, const QDir &targetDir) {
   if (!targetDir.mkdir(name))
     return false;
 
-  foreach (const QFileInfo &entry,
-           QDir(source).entryInfoList(DiffViewStyle::kFilters)) {
+  for (const QFileInfo &entry :
+       QDir(source).entryInfoList(DiffViewStyle::kFilters)) {
     if (!copy(entry.filePath(), target))
       return false;
   }
@@ -81,9 +81,9 @@ DiffView::DiffView(const git::Repository &repo, QWidget *parent)
               mComments = comments;
 
               // Invalidate editors.
-              foreach (QWidget *widget, mFiles) {
-                foreach (HunkWidget *hunk,
-                         static_cast<FileWidget *>(widget)->hunks())
+              for (QWidget *widget : mFiles) {
+                for (HunkWidget *hunk :
+                     static_cast<FileWidget *>(widget)->hunks())
                   hunk->invalidate();
               }
 
@@ -114,7 +114,7 @@ void DiffView::setDiff(const git::Diff &diff) {
   git::Repository repo = view->repo();
 
   // Disconnect signals.
-  foreach (QMetaObject::Connection connection, mConnections)
+  for (const QMetaObject::Connection &connection : mConnections)
     disconnect(connection);
   mConnections.clear();
 
@@ -312,8 +312,8 @@ void DiffView::updateFiles() {
 QList<TextEditor *> DiffView::editors() {
   fetchAll();
   QList<TextEditor *> editors;
-  foreach (QWidget *widget, mFiles) {
-    foreach (HunkWidget *hunk, static_cast<FileWidget *>(widget)->hunks())
+  for (QWidget *widget : mFiles) {
+    for (HunkWidget *hunk : static_cast<FileWidget *>(widget)->hunks())
       editors.append(hunk->editor());
   }
 
@@ -349,7 +349,7 @@ void DiffView::dropEvent(QDropEvent *event) {
   // Copy files into the workdir.
   RepoView *view = RepoView::parentView(this);
   git::Repository repo = view->repo();
-  foreach (const QUrl &url, event->mimeData()->urls()) {
+  for (const QUrl &url : event->mimeData()->urls()) {
     if (url.isLocalFile())
       copy(url.toString(DiffViewStyle::kUrlFormat), repo.workdir());
   }

--- a/src/ui/DiffView/FileWidget.cpp
+++ b/src/ui/DiffView/FileWidget.cpp
@@ -390,7 +390,7 @@ FileWidget::FileWidget(DiffView *view, const git::Diff &diff,
         return;
       }
 
-      foreach (HunkWidget *hunk, mHunks)
+      for (HunkWidget *hunk : mHunks)
         hunk->setVisible(visible);
     });
 

--- a/src/ui/DiffView/HunkWidget.cpp
+++ b/src/ui/DiffView/HunkWidget.cpp
@@ -345,7 +345,7 @@ HunkWidget::HunkWidget(DiffView *view, const git::Diff &diff,
             for (int i = 0; i < diags.size(); ++i) {
               const TextEditor::Diagnostic &diag = diags.at(i);
 
-              QStyle::StandardPixmap pixmap;
+              QStyle::StandardPixmap pixmap = QStyle::NStandardPixmap;
               switch (diag.kind) {
                 case TextEditor::Note:
                   pixmap = QStyle::SP_MessageBoxInformation;
@@ -566,7 +566,6 @@ void HunkWidget::setStageState(git::Index::StagedState state) {
     // update the line markers
     bool staged = state == git::Index::StagedState::Staged ? true : false;
     int lineCount = mEditor->lineCount();
-    int count = 0;
     for (int i = 0; i < lineCount; i++) {
       int mask = mEditor->markers(i);
       // if a line was not added or deleted, it cannot be staged so ignore all
@@ -574,7 +573,6 @@ void HunkWidget::setStageState(git::Index::StagedState state) {
       if (mask & (1 << TextEditor::Marker::Addition |
                   1 << TextEditor::Marker::Deletion)) {
         setStaged(i, staged, false);
-        count++;
       }
     }
   }
@@ -668,7 +666,7 @@ QList<HunkWidget::Token> HunkWidget::tokens(int line) const {
 
 QByteArray HunkWidget::tokenBuffer(const QList<HunkWidget::Token> &tokens) {
   QByteArrayList list;
-  foreach (const Token &token, tokens)
+  for (const Token &token : tokens)
     list.append(token.text);
   return list.join('\n');
 }
@@ -762,7 +760,7 @@ void HunkWidget::load(git::Patch &staged, bool force) {
   // Calculate margin width.
   int width = 0;
   int conflictWidth = 0;
-  foreach (const Line &line, lines) {
+  for (const Line &line : lines) {
     int oldWidth = line.oldLine().length();
     int newWidth = line.newLine().length();
     width = qMax(width, oldWidth + newWidth + 1);
@@ -800,7 +798,7 @@ void HunkWidget::load(git::Patch &staged, bool force) {
   }
 
   // Execute hunk plugins.
-  foreach (PluginRef plugin, mView->plugins()) {
+  for (const PluginRef &plugin : mView->plugins()) {
     if (plugin->isValid() && plugin->isEnabled())
       plugin->hunk(mEditor);
   }
@@ -853,8 +851,6 @@ void HunkWidget::setEditorLineInfos(QList<Line> &lines,
   const int count = lines.size();
   int marker = -1;
   int additions = 0, deletions = 0;
-  int additions_tot = 0, deletions_tot = 0;
-  int stagedAdditions = 0, stagedDeletions = 0;
   bool staged = false;
   int current_staged_index = -1;
   int current_staged_line_idx = 0;
@@ -968,18 +964,15 @@ void HunkWidget::setEditorLineInfos(QList<Line> &lines,
               mStaged.lineContent(current_staged_index,
                                   current_staged_line_idx) ==
                   mPatch.lineContent(mIndex, lidx)) {
-            stagedAdditions++;
             current_staged_line_idx++;
             staged = true;
           }
         }
-        additions_tot++;
         break;
       }
       case GIT_DIFF_LINE_DELETION: {
         marker = TextEditor::Deletion;
         deletions++;
-        deletions_tot++;
 
         // Check if staged
         if (!mPatch.isConflicted() && mStaged.count() > 0 &&
@@ -999,7 +992,6 @@ void HunkWidget::setEditorLineInfos(QList<Line> &lines,
             assert(mStaged.lineContent(current_staged_index,
                                        current_staged_line_idx) ==
                    mPatch.lineContent(mIndex, lidx));
-            stagedDeletions++;
             staged = true;
           }
         }
@@ -1106,10 +1098,10 @@ void HunkWidget::createMarkersAndLineNumbers(const Line &line, int lidx,
         QFontMetrics(font).horizontalAdvance(' ') * DiffViewStyle::kIndent * 2;
     int width = mEditor->textRectangle().width() - margin - 50;
 
-    foreach (const QDateTime &key, it->keys()) {
+    for (const QDateTime &key : it->keys()) {
       QStringList paragraphs;
       Account::Comment comment = it->value(key);
-      foreach (const QString &paragraph, comment.body.split('\n')) {
+      for (const QString &paragraph : comment.body.split('\n')) {
         if (paragraph.isEmpty()) {
           paragraphs.append(QString());
           continue;
@@ -1147,7 +1139,7 @@ void HunkWidget::createMarkersAndLineNumbers(const Line &line, int lidx,
 
   QString atnText;
   QByteArray atnStyles;
-  foreach (const Annotation &annotation, annotations) {
+  for (const Annotation &annotation : annotations) {
     if (!atnText.isEmpty()) {
       atnText.append("\n\n");
       atnStyles.append(QByteArray(2, TextEditor::CommentBody));

--- a/src/ui/DoubleTreeWidget.cpp
+++ b/src/ui/DoubleTreeWidget.cpp
@@ -159,7 +159,7 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
 
   stagedFiles->setModel(new TreeProxy(true, mDiffTreeModel, this));
   connect(stagedFiles, &QAbstractItemView::doubleClicked,
-          [this, repoView](const QModelIndex &index) {
+          [repoView](const QModelIndex &index) {
             openExternalDiffTool(index, repoView, true);
           });
 
@@ -189,7 +189,7 @@ DoubleTreeWidget::DoubleTreeWidget(const git::Repository &repo, QWidget *parent)
 
   unstagedFiles->setModel(new TreeProxy(false, mDiffTreeModel, this));
   connect(unstagedFiles, &QAbstractItemView::doubleClicked,
-          [this, repoView](const QModelIndex &index) {
+          [repoView](const QModelIndex &index) {
             openExternalDiffTool(index, repoView, false);
           });
 
@@ -341,7 +341,7 @@ void DoubleTreeWidget::showFileContextMenu(const QPoint &pos, RepoView *view,
     return;
 
   const bool statusDiff = diff.isStatusDiff();
-  foreach (const QModelIndex &index, indexes) {
+  for (const QModelIndex &index : indexes) {
     auto node = index.data(Qt::UserRole).value<Node *>();
 
     addNodeToMenu(view->repo().index(), files, node, staged, statusDiff);
@@ -519,7 +519,7 @@ void DoubleTreeWidget::storeSelection() {
 
 void DoubleTreeWidget::loadSelection() {
   QModelIndex index;
-  Qt::CheckState state;
+  Qt::CheckState state = Qt::Unchecked;
 
   if (mSelectedFile.filename != "") {
     index = mDiffTreeModel->index(mSelectedFile.filename);

--- a/src/ui/FileContextMenu.cpp
+++ b/src/ui/FileContextMenu.cpp
@@ -102,7 +102,7 @@ FileContextMenu::FileContextMenu(RepoView *view, const QStringList &files,
   QList<ExternalTool *> diffTools;
   QList<ExternalTool *> diffToLocalTools;
   QList<ExternalTool *> mergeTools;
-  foreach (const QString &file, files) {
+  for (const QString &file : files) {
     // Convert to absolute path.
     QString path = repo.workdir().filePath(file);
 
@@ -114,7 +114,7 @@ FileContextMenu::FileContextMenu(RepoView *view, const QStringList &files,
 
     ExternalTool *tool = nullptr;
     // Add diff to local
-    if (tool = ExternalTool::create(file, diff, repo, true, this)) {
+    if ((tool = ExternalTool::create(file, diff, repo, true, this))) {
       Q_ASSERT(tool->kind() == ExternalTool::Diff);
       diffToLocalTools.append(tool);
       connect(tool, &ExternalTool::error, [this](ExternalTool::Error error) {
@@ -132,7 +132,7 @@ FileContextMenu::FileContextMenu(RepoView *view, const QStringList &files,
     }
 
     // Add diff or merge tool.
-    if (tool = ExternalTool::create(file, diff, repo, false, this)) {
+    if ((tool = ExternalTool::create(file, diff, repo, false, this))) {
       switch (tool->kind()) {
         case ExternalTool::Diff:
           diffTools.append(tool);
@@ -187,7 +187,7 @@ FileContextMenu::FileContextMenu(RepoView *view, const QStringList &files,
     addSeparator();
 
     bool locked = false;
-    foreach (const QString &file, files) {
+    for (const QString &file : files) {
       if (repo.lfsIsLocked(file)) {
         locked = true;
         break;
@@ -275,7 +275,7 @@ void FileContextMenu::handleUncommittedChanges(const git::Index &index,
 
     int staged = 0;
     int unstaged = 0;
-    foreach (const QString &file, files) {
+    for (const QString &file : files) {
       switch (index.isStaged(file)) {
         case git::Index::Disabled:
           break;
@@ -327,7 +327,7 @@ void FileContextMenu::handleUncommittedChanges(const git::Index &index,
   }
 
   // handle files not submodules
-  foreach (const QString &file, filePatches) {
+  for (const QString &file : filePatches) {
     handlePath(repo, file, diff, modified, untracked);
   }
 
@@ -346,7 +346,7 @@ void FileContextMenu::handleUncommittedChanges(const git::Index &index,
         dialog->setDetailedText(detailedText);
 
         // Expand the Show Details
-        foreach (QAbstractButton *button, dialog->buttons()) {
+        for (QAbstractButton *button : dialog->buttons()) {
           if (dialog->buttonRole(button) == QMessageBox::ActionRole) {
             button->click(); // click it to expand the text
             break;
@@ -384,7 +384,7 @@ void FileContextMenu::handleUncommittedChanges(const git::Index &index,
   QAction *ignore = addAction(tr("Ignore"));
   ignore->setObjectName("IgnoreAction");
   connect(ignore, &QAction::triggered, this, &FileContextMenu::ignoreFile);
-  foreach (const QString &file, files) {
+  for (const QString &file : files) {
     int index = diff.indexOf(file);
     if (index < 0)
       continue;
@@ -483,7 +483,7 @@ void FileContextMenu::handleCommits(const QList<git::Commit> &commits,
   /* disable checkout if the file is already
    * in the current working directory */
   git::Commit commit = commits.first();
-  foreach (const QString &file, files) {
+  for (const QString &file : files) {
     if (commit.tree().id(file) == repo.workdirId(file)) {
       checkout->setEnabled(false);
       checkout->setToolTip(
@@ -533,7 +533,7 @@ FileContextMenu::addExternalToolsAction(const QList<ExternalTool *> &tools) {
 
   // Add action.
   QAction *action = addAction(tools.first()->name(), [this, tools] {
-    foreach (ExternalTool *tool, tools) {
+    for (ExternalTool *tool : tools) {
       if (tool->start())
         return;
 
@@ -563,7 +563,7 @@ FileContextMenu::addExternalToolsAction(const QList<ExternalTool *> &tools) {
   });
 
   // Disable if any tools are invalid.
-  foreach (ExternalTool *tool, tools) {
+  for (ExternalTool *tool : tools) {
     if (!tool->isValid()) {
       action->setEnabled(false);
       break;

--- a/src/ui/FindWidget.cpp
+++ b/src/ui/FindWidget.cpp
@@ -141,13 +141,13 @@ FindWidget::FindWidget(EditorProvider *provider, QWidget *parent)
 void FindWidget::reset() { mEditorIndex = 0; }
 
 void FindWidget::clearHighlights() {
-  foreach (TextEditor *editor, mEditorProvider->editors())
+  for (TextEditor *editor : mEditorProvider->editors())
     editor->clearHighlights();
 }
 
 void FindWidget::highlightAll() {
   int matches = 0;
-  foreach (TextEditor *editor, mEditorProvider->editors())
+  for (TextEditor *editor : mEditorProvider->editors())
     matches += editor->highlightAll(sText);
 
   QString text;

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -292,7 +292,7 @@ MainWindow *MainWindow::activeWindow() {
 
 QList<MainWindow *> MainWindow::windows() {
   QList<MainWindow *> mainWins;
-  foreach (QWidget *win, QApplication::topLevelWidgets()) {
+  for (QWidget *win : QApplication::topLevelWidgets()) {
     if (MainWindow *mainWin = qobject_cast<MainWindow *>(win))
       mainWins.append(mainWin);
   }
@@ -306,7 +306,7 @@ bool MainWindow::restoreWindows() {
   // Open windows.
   QSettings settings;
   settings.beginGroup(kWindowsGroup);
-  foreach (const QString &group, settings.childGroups()) {
+  for (const QString &group : settings.childGroups()) {
     settings.beginGroup(group);
     int index = settings.value(kIndexKey).toInt();
     bool active = settings.value(kActiveKey).toBool();
@@ -328,7 +328,7 @@ bool MainWindow::restoreWindows() {
       continue;
 
     // Add the remainder as tabs.
-    foreach (const QString &path, paths)
+    for (const QString &path : paths)
       window->addTab(path);
 
     // Select saved index.
@@ -446,7 +446,7 @@ void MainWindow::dragEnterEvent(QDragEnterEvent *event) {
   if (!event->mimeData()->hasFormat("text/uri-list"))
     return;
 
-  foreach (const QUrl &url, event->mimeData()->urls()) {
+  for (const QUrl &url : event->mimeData()->urls()) {
     if (!url.isLocalFile())
       return;
 
@@ -462,7 +462,7 @@ void MainWindow::dragEnterEvent(QDragEnterEvent *event) {
 }
 
 void MainWindow::dropEvent(QDropEvent *event) {
-  foreach (const QUrl &url, event->mimeData()->urls())
+  for (const QUrl &url : event->mimeData()->urls())
     addTab(url.toLocalFile());
 }
 

--- a/src/ui/MenuBar.cpp
+++ b/src/ui/MenuBar.cpp
@@ -753,7 +753,7 @@ MenuBar::MenuBar(QWidget *parent) : QMenuBar(parent) {
       return;
 
     RepoView *view = win->currentView();
-    foreach (const git::Submodule &submodule, view->repo().submodules()) {
+    for (const git::Submodule &submodule : view->repo().submodules()) {
       QAction *action = mOpenSubmodule->addAction(submodule.name());
       connect(action, &QAction::triggered,
               [view, submodule] { view->openSubmodule(submodule); });

--- a/src/ui/PathspecWidget.cpp
+++ b/src/ui/PathspecWidget.cpp
@@ -54,7 +54,7 @@ public:
 protected:
   void contextMenuEvent(QContextMenuEvent *event) override {
     QStringList files;
-    foreach (const QModelIndex &index, selectionModel()->selectedIndexes())
+    for (const QModelIndex &index : selectionModel()->selectedIndexes())
       files.append(index.data(Qt::EditRole).toString());
 
     FileContextMenu menu(RepoView::parentView(this), files);

--- a/src/ui/ReferenceModel.cpp
+++ b/src/ui/ReferenceModel.cpp
@@ -86,7 +86,7 @@ void ReferenceModel::update() {
   // Add local branches.
   if (mKinds & ReferenceView::LocalBranches) {
     QList<git::Reference> branches;
-    foreach (const git::Branch &branch, mRepo.branches(GIT_BRANCH_LOCAL)) {
+    for (const git::Branch &branch : mRepo.branches(GIT_BRANCH_LOCAL)) {
       Debug("ReferenceView: Local branches: " << branch.name());
       const bool branchOnCommit =
           !mCommit.isValid() || branch.annotatedCommit().commit() == mCommit;
@@ -120,7 +120,7 @@ void ReferenceModel::update() {
   // Add remote branches.
   if (mKinds & ReferenceView::RemoteBranches) {
     QList<git::Reference> remotes;
-    foreach (const git::Branch &branch, mRepo.branches(GIT_BRANCH_REMOTE)) {
+    for (const git::Branch &branch : mRepo.branches(GIT_BRANCH_REMOTE)) {
       // Filter remote HEAD branches.
       Debug("ReferenceView: Remote branches: " << branch.name());
       const bool remoteOnCommit =
@@ -139,7 +139,7 @@ void ReferenceModel::update() {
   // Add tags.
   if (mKinds & ReferenceView::Tags) {
     QList<git::Reference> tags;
-    foreach (const git::TagRef &tag, mRepo.tags()) {
+    for (const git::TagRef &tag : mRepo.tags()) {
       Debug("ReferenceView: Tags: " << tag.name());
       const bool tagOnCommit =
           !mCommit.isValid() || tag.annotatedCommit().commit() == mCommit;

--- a/src/ui/RemoteCallbacks.cpp
+++ b/src/ui/RemoteCallbacks.cpp
@@ -235,7 +235,7 @@ bool RemoteCallbacks::negotiation(
 
   // Write updates.
   QTextStream out(&process);
-  foreach (const git::Remote::PushUpdate &update, updates)
+  for (const git::Remote::PushUpdate &update : updates)
     out << update.dstName << " " << update.dstId.toString() << " "
         << update.srcName << " " << update.srcId.toString() << Qt::endl;
   process.closeWriteChannel();

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -781,7 +781,7 @@ bool RepoView::lfsSetLocked(const QStringList &paths, bool lock) {
   QStringList errors;
   QString verb = lock ? tr("Lock") : tr("Unlock");
 
-  foreach (const QString &path, paths) {
+  for (const QString &path : paths) {
     if (!repo().lfsSetLocked(path, lock))
       errors.append(
           tr("Unable to %1 '%2' - %3")
@@ -792,7 +792,7 @@ bool RepoView::lfsSetLocked(const QStringList &paths, bool lock) {
     return true;
 
   LogEntry *entry = addLogEntry(tr("Git LFS"), verb);
-  foreach (const QString &error, errors)
+  for (const QString &error : errors)
     entry->addEntry(LogEntry::Error, error);
 
   return false;
@@ -914,7 +914,7 @@ LogEntry *RepoView::error(LogEntry *parent, const QString &action,
     items.removeLast();
 
   LogEntry *root = parent->addEntry(LogEntry::Error, items.takeFirst());
-  foreach (const QString &item, items)
+  for (const QString &item : items)
     root->addEntry(LogEntry::File, item);
 
   return root;
@@ -953,7 +953,7 @@ void RepoView::fetchAll() {
   // Queue up all remotes to fetch them serially.
   QString text = tr("%1 remotes").arg(remotes.size());
   LogEntry *entry = addLogEntry(text, tr("Fetch All"));
-  foreach (const git::Remote &remote, remotes)
+  for (const git::Remote &remote : remotes)
     fetch(remote, false, true, entry);
 }
 
@@ -1050,7 +1050,7 @@ QFuture<git::Result> RepoView::fetch(const git::Remote &rmt, bool tags,
 
         if (result && submodules) {
           // Scan for unmodified submodules on the fetch thread.
-          foreach (const git::Submodule &submodule, mRepo.submodules()) {
+          for (const git::Submodule &submodule : mRepo.submodules()) {
             if (GIT_SUBMODULE_STATUS_IS_UNMODIFIED(
                     mRepo.submoduleStatus(submodule.name())))
               submodules->append(submodule.name());
@@ -1109,7 +1109,7 @@ void RepoView::pull(MergeFlags flags, const git::Remote &rmt, bool tags,
             if (!names.isEmpty()) {
               callback = [this, entry, names] {
                 QList<git::Submodule> modules;
-                foreach (const QString &name, names)
+                for (const QString &name : names)
                   modules.append(mRepo.lookupSubmodule(name));
                 updateSubmodules(modules, true, false, false, entry);
               };
@@ -1244,7 +1244,7 @@ void RepoView::fastForward(const git::Reference &ref,
   CheckoutCallbacks callbacks(parent, GIT_CHECKOUT_NOTIFY_UPDATED);
   if (!mRepo.checkout(commit, &callbacks)) {
     LogEntry *err = error(parent, tr("fast-forward"), head.name());
-    foreach (const QString &path, callbacks.conflicts())
+    for (const QString &path : callbacks.conflicts())
       err->addEntry(LogEntry::File, path)->setStatus('!');
 
     QUrlQuery query;
@@ -1373,7 +1373,7 @@ void RepoView::mergeAbort(LogEntry *parent) {
     LogEntry *parent = addLogEntry(tr("merge"), tr("Abort"));
     QString err = tr("Some merged files have unstaged changes");
     LogEntry *entry = error(parent, tr("abort merge"), QString(), err);
-    foreach (const QString &conflict, conflicts)
+    for (const QString &conflict : conflicts)
       entry->addEntry(LogEntry::File, conflict)->setStatus('M');
     return;
   }
@@ -2002,7 +2002,7 @@ void RepoView::checkout(const git::Commit &commit, const git::Reference &ref,
       (detach && !mRepo.setHeadDetached(commit)) ||
       (!detach && !mRepo.setHead(ref))) {
     LogEntry *err = error(entry, tr("checkout"), name);
-    foreach (const QString &path, callbacks.conflicts())
+    for (const QString &path : callbacks.conflicts())
       err->addEntry(LogEntry::File, path)->setStatus('!');
 
     if (ref.isValid()) {
@@ -2402,7 +2402,7 @@ RepoView::submoduleResetInfoList(const git::Repository &repo,
                                  LogEntry *parent) {
   // Only reset modified submodules
   QList<git::Submodule> modules;
-  foreach (const git::Submodule &submodule, submodules) {
+  for (const git::Submodule &submodule : submodules) {
     int status = repo.submoduleStatus(submodule.name());
 
     if (status & (GIT_SUBMODULE_STATUS_WD_MODIFIED |
@@ -2419,7 +2419,7 @@ RepoView::submoduleResetInfoList(const git::Repository &repo,
     entry->addEntry(tr("Untouched"));
 
   QList<SubmoduleInfo> list;
-  foreach (const git::Submodule &module, modules)
+  for (const git::Submodule &module : modules)
     list.append({module, repo, entry});
   return list;
 }
@@ -2463,7 +2463,7 @@ QList<RepoView::SubmoduleInfo> RepoView::submoduleUpdateInfoList(
     bool init, bool checkout_force, LogEntry *parent) {
   // Gather list of submodules.
   QList<git::Submodule> modules;
-  foreach (const git::Submodule &submodule, submodules) {
+  for (const git::Submodule &submodule : submodules) {
     // FIXME: Add hint to init the submodule?
     if (!init && !submodule.isInitialized())
       continue;
@@ -2483,7 +2483,7 @@ QList<RepoView::SubmoduleInfo> RepoView::submoduleUpdateInfoList(
     entry->addEntry(tr("Already up-to-date."));
 
   QList<SubmoduleInfo> list;
-  foreach (const git::Submodule &module, modules)
+  for (const git::Submodule &module : modules)
     list.append({module, repo, entry});
   return list;
 }
@@ -2884,8 +2884,10 @@ void RepoView::showEvent(QShowEvent *event) {
 }
 
 void RepoView::closeEvent(QCloseEvent *event) {
-  // Try to close tracked windows.
-  foreach (QWidget *window, mTrackedWindows) {
+  // Try to close tracked windows. Iterate over a copy since closing a
+  // window may synchronously remove it from mTrackedWindows.
+  const QList<QWidget *> trackedWindows = mTrackedWindows;
+  for (QWidget *window : trackedWindows) {
     if (!window->close()) {
       event->ignore();
       return;

--- a/src/ui/SideBar.cpp
+++ b/src/ui/SideBar.cpp
@@ -773,7 +773,7 @@ SideBar::SideBar(TabWidget *tabs, MainWindow *mainWindow, QWidget *parent)
   });
 
   connect(footer, &Footer::minusClicked, [this, view, model, sel] {
-    foreach (const QModelIndex &index, sel->selectedIndexes()) {
+    for (const QModelIndex &index : sel->selectedIndexes()) {
       if (RepoView *tab = index.data(TabRole).value<RepoView *>()) {
         tab->close();
 

--- a/src/ui/SpellChecker.cpp
+++ b/src/ui/SpellChecker.cpp
@@ -32,7 +32,7 @@ SpellChecker::SpellChecker(const QString &dictionaryPath,
       QString line = stream.readLine();
       while (!line.isEmpty()) {
         auto match = enc_detector.match(line);
-        if (match.hasMatch() >= 0) {
+        if (match.hasMatch()) {
           encoding = match.captured(1);
           break;
         }
@@ -80,7 +80,7 @@ QStringList SpellChecker::suggest(const QString &word) {
 
   // Decode from the encoding used by current dictionary to Unicode.
   auto decoder = QStringDecoder{mEncoding};
-  foreach (const std::string &str, suggestion)
+  for (const std::string &str : suggestion)
     suggestions.append(decoder.decode(str.data()));
 
   return suggestions;

--- a/src/ui/TreeModel.cpp
+++ b/src/ui/TreeModel.cpp
@@ -109,7 +109,7 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const {
 
       int count = 0;
       git::Index index = mDiff.index();
-      foreach (const QString &path, paths) {
+      for (const QString &path : paths) {
         // isStaged on folders does not work, because folder cannot be staged
         switch (index.isStaged(path)) {
           case git::Index::Disabled:

--- a/src/ui/TreeProxy.cpp
+++ b/src/ui/TreeProxy.cpp
@@ -24,7 +24,7 @@ const QString kLinkFmt = "<a href='%1'>%2</a>";
 } // namespace
 
 TreeProxy::TreeProxy(bool staged, QAbstractItemModel *model, QObject *parent)
-    : mStaged(staged), QSortFilterProxyModel(parent) {
+    : QSortFilterProxyModel(parent), mStaged(staged) {
   setSourceModel(model);
 }
 

--- a/src/ui/TreeView.cpp
+++ b/src/ui/TreeView.cpp
@@ -44,9 +44,9 @@ const QString kLabelFmt = "<p style='color: gray; font-weight: bold'>%1</p>";
 } // namespace
 
 TreeView::TreeView(QWidget *parent, const QString &name)
-    : QTreeView(parent),
+    : QTreeView(parent), mName(name),
       mFileListDelegatePtr(std::make_unique<ViewDelegate>(this, true)),
-      mFileTreeDelegatePtr(std::make_unique<ViewDelegate>(this)), mName(name) {
+      mFileTreeDelegatePtr(std::make_unique<ViewDelegate>(this)) {
   setObjectName(name);
 }
 

--- a/src/ui/TreeWidget.cpp
+++ b/src/ui/TreeWidget.cpp
@@ -143,7 +143,7 @@ void TreeWidget::findPrevious() { mEditor->findPrevious(); }
 void TreeWidget::contextMenuEvent(QContextMenuEvent *event) {
   QStringList files;
   QModelIndexList indexes = mView->selectionModel()->selectedIndexes();
-  foreach (const QModelIndex &index, indexes)
+  for (const QModelIndex &index : indexes)
     files.append(index.data(Qt::EditRole).toString());
 
   if (files.isEmpty())

--- a/src/ui/ViewDelegate.cpp
+++ b/src/ui/ViewDelegate.cpp
@@ -18,7 +18,6 @@ void ViewDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
     int width = size.width();
     int height = size.height();
 
-    auto startIter = status.cbegin(), endIter = status.cend();
     int leftAdjust = 0, rightAdjust = -3, leftWidth = 0, rightWidth = -width;
     if (mMultiColumn) {
       leftAdjust = 3;

--- a/src/update/UpdateDialog.cpp
+++ b/src/update/UpdateDialog.cpp
@@ -127,7 +127,7 @@ UpdateDialog::UpdateDialog(const QString &platform, const QString &version,
   });
 
   connect(buttons, &QDialogButtonBox::rejected, this, &UpdateDialog::reject);
-  connect(this, &UpdateDialog::accepted, [platform, link] {
+  connect(this, &UpdateDialog::accepted, [link] {
     // Start download.
     if (Updater::DownloadRef download = Updater::instance()->download(link)) {
       DownloadDialog *dialog = new DownloadDialog(download);

--- a/src/watcher/RepositoryWatcher_linux.cpp
+++ b/src/watcher/RepositoryWatcher_linux.cpp
@@ -112,7 +112,7 @@ public:
     mWds[wd] = dir;
 
     // Watch subdirs.
-    foreach (const QString &name, dir.entryList(kFilters)) {
+    for (const QString &name : dir.entryList(kFilters)) {
       QString path = dir.filePath(name);
       if (!mRepo.isIgnored(path))
         watch(path);

--- a/src/watcher/RepositoryWatcher_qt.cpp
+++ b/src/watcher/RepositoryWatcher_qt.cpp
@@ -54,7 +54,7 @@ public:
     mFSWatcher.addPath(dir.path().toUtf8());
 
     // Watch subdirs.
-    foreach (const QString &name, dir.entryList(kFilters)) {
+    for (const QString &name : dir.entryList(kFilters)) {
       QString path = dir.filePath(name);
       if (!mRepo.isIgnored(path))
         watch(path);


### PR DESCRIPTION
This enables compilation with `-Wall -Werror` for non-Windows targets, and fixes a number of hidden warnings in the code. There are some genuine bug fixes in here as well as a results, such as fixing an encoding issue in the spell checker.