### PR TITLE
Drop gnome-keyring and reword libsecret entry to indicate GNOME and KDE support

### DIFF
--- a/l10n/gittyup_de.ts
+++ b/l10n/gittyup_de.ts
@@ -1055,6 +1055,34 @@
     </message>
 </context>
 <context>
+    <name>CredentialHelper</name>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="70"/>
+        <source>Caching the credentials in the RAM. Required to enter credentials on every startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="73"/>
+        <source>Storing the credentials unencrypted on disk, protected only by filesystem permissions &lt;a href=&quot;https://git-scm.com/docs/git-credential-store&quot;&gt;git-credential-store&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="79"/>
+        <source>MacOS credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="82"/>
+        <source>Windows credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="87"/>
+        <source>Store credentials via Secret Service D-Bus (GNOME Keyring, KDE Wallet, or similar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DateSelectionGroupWidget</name>
     <message>
         <location filename="../src/dialogs/AmendDialog.cpp" line="21"/>

--- a/l10n/gittyup_en.ts
+++ b/l10n/gittyup_en.ts
@@ -1009,6 +1009,34 @@
     </message>
 </context>
 <context>
+    <name>CredentialHelper</name>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="70"/>
+        <source>Caching the credentials in the RAM. Required to enter credentials on every startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="73"/>
+        <source>Storing the credentials unencrypted on disk, protected only by filesystem permissions &lt;a href=&quot;https://git-scm.com/docs/git-credential-store&quot;&gt;git-credential-store&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="79"/>
+        <source>MacOS credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="82"/>
+        <source>Windows credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="87"/>
+        <source>Store credentials via Secret Service D-Bus (GNOME Keyring, KDE Wallet, or similar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DateSelectionGroupWidget</name>
     <message>
         <location filename="../src/dialogs/AmendDialog.cpp" line="21"/>

--- a/l10n/gittyup_es.ts
+++ b/l10n/gittyup_es.ts
@@ -1058,6 +1058,34 @@
     </message>
 </context>
 <context>
+    <name>CredentialHelper</name>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="70"/>
+        <source>Caching the credentials in the RAM. Required to enter credentials on every startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="73"/>
+        <source>Storing the credentials unencrypted on disk, protected only by filesystem permissions &lt;a href=&quot;https://git-scm.com/docs/git-credential-store&quot;&gt;git-credential-store&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="79"/>
+        <source>MacOS credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="82"/>
+        <source>Windows credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="87"/>
+        <source>Store credentials via Secret Service D-Bus (GNOME Keyring, KDE Wallet, or similar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DateSelectionGroupWidget</name>
     <message>
         <location filename="../src/dialogs/AmendDialog.cpp" line="21"/>

--- a/l10n/gittyup_ja.ts
+++ b/l10n/gittyup_ja.ts
@@ -1055,6 +1055,34 @@
     </message>
 </context>
 <context>
+    <name>CredentialHelper</name>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="70"/>
+        <source>Caching the credentials in the RAM. Required to enter credentials on every startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="73"/>
+        <source>Storing the credentials unencrypted on disk, protected only by filesystem permissions &lt;a href=&quot;https://git-scm.com/docs/git-credential-store&quot;&gt;git-credential-store&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="79"/>
+        <source>MacOS credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="82"/>
+        <source>Windows credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="87"/>
+        <source>Store credentials via Secret Service D-Bus (GNOME Keyring, KDE Wallet, or similar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DateSelectionGroupWidget</name>
     <message>
         <location filename="../src/dialogs/AmendDialog.cpp" line="21"/>

--- a/l10n/gittyup_pt.ts
+++ b/l10n/gittyup_pt.ts
@@ -1055,6 +1055,34 @@
     </message>
 </context>
 <context>
+    <name>CredentialHelper</name>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="70"/>
+        <source>Caching the credentials in the RAM. Required to enter credentials on every startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="73"/>
+        <source>Storing the credentials unencrypted on disk, protected only by filesystem permissions &lt;a href=&quot;https://git-scm.com/docs/git-credential-store&quot;&gt;git-credential-store&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="79"/>
+        <source>MacOS credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="82"/>
+        <source>Windows credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="87"/>
+        <source>Store credentials via Secret Service D-Bus (GNOME Keyring, KDE Wallet, or similar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DateSelectionGroupWidget</name>
     <message>
         <location filename="../src/dialogs/AmendDialog.cpp" line="21"/>

--- a/l10n/gittyup_pt_BR.ts
+++ b/l10n/gittyup_pt_BR.ts
@@ -1221,6 +1221,34 @@
     </message>
 </context>
 <context>
+    <name>CredentialHelper</name>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="70"/>
+        <source>Caching the credentials in the RAM. Required to enter credentials on every startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="73"/>
+        <source>Storing the credentials unencrypted on disk, protected only by filesystem permissions &lt;a href=&quot;https://git-scm.com/docs/git-credential-store&quot;&gt;git-credential-store&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="79"/>
+        <source>MacOS credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="82"/>
+        <source>Windows credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="87"/>
+        <source>Store credentials via Secret Service D-Bus (GNOME Keyring, KDE Wallet, or similar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DateSelectionGroupWidget</name>
     <message>
         <location filename="../src/dialogs/AmendDialog.cpp" line="21"/>

--- a/l10n/gittyup_ru.ts
+++ b/l10n/gittyup_ru.ts
@@ -1055,6 +1055,34 @@
     </message>
 </context>
 <context>
+    <name>CredentialHelper</name>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="70"/>
+        <source>Caching the credentials in the RAM. Required to enter credentials on every startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="73"/>
+        <source>Storing the credentials unencrypted on disk, protected only by filesystem permissions &lt;a href=&quot;https://git-scm.com/docs/git-credential-store&quot;&gt;git-credential-store&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="79"/>
+        <source>MacOS credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="82"/>
+        <source>Windows credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="87"/>
+        <source>Store credentials via Secret Service D-Bus (GNOME Keyring, KDE Wallet, or similar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DateSelectionGroupWidget</name>
     <message>
         <location filename="../src/dialogs/AmendDialog.cpp" line="21"/>

--- a/l10n/gittyup_ta.ts
+++ b/l10n/gittyup_ta.ts
@@ -815,6 +815,29 @@
     </message>
 </context>
 <context>
+    <name>CredentialHelper</name>
+    <message>
+        <source>Caching the credentials in the RAM. Required to enter credentials on every startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Storing the credentials unencrypted on disk, protected only by filesystem permissions &lt;a href=&quot;https://git-scm.com/docs/git-credential-store&quot;&gt;git-credential-store&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MacOS credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Store credentials via Secret Service D-Bus (GNOME Keyring, KDE Wallet, or similar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DateSelectionGroupWidget</name>
     <message>
         <source>Datetime source</source>

--- a/l10n/gittyup_zh_CN.ts
+++ b/l10n/gittyup_zh_CN.ts
@@ -1055,6 +1055,34 @@
     </message>
 </context>
 <context>
+    <name>CredentialHelper</name>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="70"/>
+        <source>Caching the credentials in the RAM. Required to enter credentials on every startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="73"/>
+        <source>Storing the credentials unencrypted on disk, protected only by filesystem permissions &lt;a href=&quot;https://git-scm.com/docs/git-credential-store&quot;&gt;git-credential-store&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="79"/>
+        <source>MacOS credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="82"/>
+        <source>Windows credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cred/CredentialHelper.cpp" line="87"/>
+        <source>Store credentials via Secret Service D-Bus (GNOME Keyring, KDE Wallet, or similar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DateSelectionGroupWidget</name>
     <message>
         <location filename="../src/dialogs/AmendDialog.cpp" line="21"/>

--- a/src/cred/CredentialHelper.cpp
+++ b/src/cred/CredentialHelper.cpp
@@ -30,7 +30,6 @@ const QString storeStoreNameOld = "store";
 const QString osxKeyChainStoreName = "osxkeychain";
 const QString winCredStoreName = "wincred";
 const QString libSecretStoreName = "libsecret";
-const QString gnomeKeyringStoreName = "gnome-keyring";
 
 } // namespace
 
@@ -83,17 +82,10 @@ CredentialHelper::getAvailableHelperInformation() {
 #else
   QLibrary lib("secret-1", 0);
   if (lib.load()) {
-    list.append(HelperInformation(libSecretStoreName,
-                                  tr("Secret Service D-Bus client library")));
-  }
-  // libsecret replaces libgnome-keyring.
-  QLibrary lib2(gnomeKeyringStoreName, 0);
-  if (lib2.load()) {
     list.append(HelperInformation(
-        gnomeKeyringStoreName,
-        tr("Prefer <a "
-           "href=\"https://wiki.gnome.org/Projects/Libsecret\">libsecret</a> "
-           "over gnome-keyring if available")));
+        libSecretStoreName,
+        tr("Store credentials via Secret Service D-Bus (GNOME Keyring, "
+           "KDE Wallet, or similar)")));
   }
 #endif
   return list;


### PR DESCRIPTION
libgnome-keyring has been [deprecated since 2014](https://mail.gnome.org/archives/commits-list/2014-January/msg01585.html). I think it's well over-due to remove it from Gittyup