### PR TITLE
Fix issues with concurrent testing

### DIFF
--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -105,6 +105,16 @@ Application::Application(int &argc, char **argv, bool haltOnParseError)
   setOrganizationDomain(GITTYUP_ORGANIZATION_DOMAIN);
   setDesktopFileName(GITTYUP_IDENTIFIER);
 
+  // When in test mode, redirect QSettings to a private, per-process location.
+  // This prevents test cases from accidentially cluttering up the user
+  // environment and allows for test cases to run in parallel
+  if (isInTest()) {
+    mTempSettingsDir.reset(new QTemporaryDir);
+    QSettings::setDefaultFormat(QSettings::IniFormat);
+    QSettings::setPath(QSettings::IniFormat, QSettings::UserScope,
+                       mTempSettingsDir->path());
+  }
+
   // Register types that are queued at runtime.
   qRegisterMetaType<git::Id>();
 

--- a/src/app/Application.h
+++ b/src/app/Application.h
@@ -12,6 +12,7 @@
 
 #include "Theme.h"
 #include <QApplication>
+#include <QTemporaryDir>
 
 class QNetworkAccessManager;
 class QNetworkReply;
@@ -42,6 +43,7 @@ private:
 
   QString mPathspec = QString();
   QScopedPointer<Theme> mTheme;
+  QScopedPointer<QTemporaryDir> mTempSettingsDir;
   QStringList mPositionalArguments;
 
   static bool mIsInTest;

--- a/src/app/Theme.cpp
+++ b/src/app/Theme.cpp
@@ -40,31 +40,27 @@ Theme::Theme() {
   mDir = Settings::themesDir();
   mName = QString("System");
 
-  // Create Qt theme.
+  // Create Qt theme. Build the script in memory rather than through a
+  // shared temp file: the theme template is combined with a generated
+  // style.default line reflecting the live QPalette, then executed
+  // directly, so concurrent processes never contend over a fixed path.
   QFile themeFile(mDir.filePath(QString("%1.lua").arg(mName)).toUtf8());
   if (themeFile.open(QIODevice::ReadOnly)) {
-    QDir tempDir = QDir::temp();
-    QFile tempFile(tempDir.filePath(QString("%1.lua").arg(mName)).toUtf8());
-    if (tempFile.open(QIODevice::ReadWrite | QIODevice::Truncate)) {
-      mDir = tempDir;
-
-      // Copy template.
-      tempFile.write(themeFile.readAll());
-
-      // Add theme colors for scintilla editor.
-      tempFile.write(
-          QString("theme.property['style.default']      = 'fore:%1,back:%2'\n")
-              .arg(QPalette().color(QPalette::Text).name(QColor::HexRgb),
-                   QPalette().color(QPalette::Base).name(QColor::HexRgb))
-              .toUtf8());
-      tempFile.close();
-    }
+    QByteArray source = themeFile.readAll();
     themeFile.close();
-  }
 
-  // Load Qt theme.
-  QByteArray file = mDir.filePath(QString("%1.lua").arg(mName)).toUtf8();
-  mMap = ConfFile(file).parse("theme");
+    // Add theme colors for scintilla editor.
+    source +=
+        QString("theme.property['style.default']      = 'fore:%1,back:%2'\n")
+            .arg(QPalette().color(QPalette::Text).name(QColor::HexRgb),
+                 QPalette().color(QPalette::Base).name(QColor::HexRgb))
+            .toUtf8();
+
+    mMap = ConfFile(source, mDir).parse("theme");
+  } else {
+    QByteArray file = mDir.filePath(QString("%1.lua").arg(mName)).toUtf8();
+    mMap = ConfFile(file).parse("theme");
+  }
 
   QPalette palette;
   QColor base = palette.color(QPalette::Base);

--- a/src/conf/ConfFile.cpp
+++ b/src/conf/ConfFile.cpp
@@ -66,12 +66,22 @@ QVariantMap table(lua_State *L) {
 
 ConfFile::ConfFile(const QString &filename) : mFilename(filename) {}
 
+ConfFile::ConfFile(const QByteArray &source, const QDir &baseDir)
+    : mSource(source), mBaseDir(baseDir) {}
+
 ConfFile::~ConfFile() {}
 
 QVariantMap ConfFile::parse(const QString &name) {
-  // Verify the existence of the file.
-  QFileInfo info(mFilename);
-  QString canPath = info.canonicalPath();
+  // Determine the directory used to extend package.path so require()
+  // keeps working relative to the script's logical location, whether
+  // the script itself comes from disk or from an in-memory buffer.
+  QString canPath;
+  if (mFilename.isEmpty()) {
+    canPath = mBaseDir.canonicalPath();
+  } else {
+    canPath = QFileInfo(mFilename).canonicalPath();
+  }
+
   if (canPath.isEmpty())
     return QVariantMap();
 
@@ -104,8 +114,19 @@ QVariantMap ConfFile::parse(const QString &name) {
     lua_setglobal(L, tableName);
   }
 
-  // Execute the configuration script.
-  if (luaL_dofile(L, localName))
+  // Execute the configuration script, either from disk or from the
+  // in-memory buffer supplied via the QByteArray/QDir constructor.
+  bool failed;
+  if (mFilename.isEmpty()) {
+    QByteArray chunkName = "@" + localPath + "/(generated)";
+    failed = luaL_loadbuffer(L, mSource.constData(), mSource.size(),
+                             chunkName.constData()) ||
+             lua_pcall(L, 0, LUA_MULTRET, 0);
+  } else {
+    failed = luaL_dofile(L, localName);
+  }
+
+  if (failed)
     lua_error(L);
 
   // Push global table.

--- a/src/conf/ConfFile.h
+++ b/src/conf/ConfFile.h
@@ -10,12 +10,19 @@
 #ifndef CONFFILE_H
 #define CONFFILE_H
 
+#include <QDir>
 #include <QString>
 #include <QVariant>
 
 class ConfFile {
 public:
   ConfFile(const QString &filename);
+
+  // Parse Lua source held in memory rather than on disk. baseDir is used
+  // to set up package.path so the script can still require() files
+  // relative to the theme/config directory it logically belongs to.
+  ConfFile(const QByteArray &source, const QDir &baseDir);
+
   virtual ~ConfFile();
 
   // Table is the name of a new global table that the script
@@ -25,6 +32,8 @@ public:
 
 private:
   QString mFilename;
+  QByteArray mSource;
+  QDir mBaseDir;
 };
 
 #endif

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -101,7 +101,7 @@ public:
 
     resetSettings();
   }
-  
+
   ~CommitModel() {
     // Ensure that mStatus is stopped since it captures `this` and potentially
     // might crash after the destructor is finished

--- a/src/ui/CommitList.cpp
+++ b/src/ui/CommitList.cpp
@@ -101,6 +101,12 @@ public:
 
     resetSettings();
   }
+  
+  ~CommitModel() {
+    // Ensure that mStatus is stopped since it captures `this` and potentially
+    // might crash after the destructor is finished
+    cancelStatus();
+  }
 
   git::Reference reference() const { return mRef; }
 

--- a/test/CommitAuthorCommitter.cpp
+++ b/test/CommitAuthorCommitter.cpp
@@ -8,8 +8,8 @@
 #include "git/Reference.h"
 #include "git/Signature.h"
 
-#define INIT_REPO(repoPath, /* bool */ useTempDir)                             \
-  QString path = Test::extractRepository(repoPath, useTempDir);                \
+#define INIT_REPO(repoPath)                                                    \
+  QString path = Test::extractRepository(repoPath);                            \
   QVERIFY(!path.isEmpty());                                                    \
   git::Repository repo = git::Repository::open(path);                          \
   QVERIFY(repo.isValid());                                                     \
@@ -46,7 +46,7 @@ void TestCommitAuthorCommitter::cleanupTestCase() {
  * Check that author and email address are preserved during cherry pick
  */
 void TestCommitAuthorCommitter::testCherryPickAuthorEmailPreservance() {
-  INIT_REPO("CherryPickAuthorEmail.zip", true);
+  INIT_REPO("CherryPickAuthorEmail.zip");
 
   git::Commit commit =
       repo.lookupCommit("710846db7a1fbd583975da0a6c10f9c2964ebd08");
@@ -78,7 +78,7 @@ void TestCommitAuthorCommitter::testCherryPickAuthorEmailPreservance() {
  * is the current user
  */
 void TestCommitAuthorCommitter::testRevertAuthorEmailPreservance() {
-  INIT_REPO("CherryPickAuthorEmail.zip", true);
+  INIT_REPO("CherryPickAuthorEmail.zip");
 
   git::Commit commit =
       repo.lookupCommit("710846db7a1fbd583975da0a6c10f9c2964ebd08");

--- a/test/EditorLineInfos.cpp
+++ b/test/EditorLineInfos.cpp
@@ -15,8 +15,8 @@
 #include "git/Commit.h"
 #include "git/Tree.h"
 
-#define INIT_REPO(repoPath, /* bool */ useTempDir)                             \
-  QString path = Test::extractRepository(repoPath, useTempDir);                \
+#define INIT_REPO(repoPath)                                                    \
+  QString path = Test::extractRepository(repoPath);                            \
   QVERIFY2(!path.isEmpty(), qPrintable("Extracting repository failed"));       \
   mRepo = git::Repository::open(path);                                         \
   QVERIFY2(mRepo.isValid(), qPrintable("Unable to open repository"));          \
@@ -146,7 +146,7 @@ void TestEditorLineInfo::initTestCase() {}
 
 #if EXECUTE_ONLY_LAST_TEST == 0
 void TestEditorLineInfo::editorLineSingleHunkAdditionStaged() {
-  INIT_REPO("01_singleHunkAdditionStaged.zip", true)
+  INIT_REPO("01_singleHunkAdditionStaged.zip")
   QVERIFY(stagedDiff.count() > 0);
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
@@ -174,7 +174,7 @@ void TestEditorLineInfo::editorLineSingleHunkAdditionStaged() {
 }
 
 void TestEditorLineInfo::editorLineSingleHunkDeletionStaged() {
-  INIT_REPO("02_singleHunkDeletionStaged.zip", true)
+  INIT_REPO("02_singleHunkDeletionStaged.zip")
   QVERIFY(stagedDiff.count() > 0);
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
@@ -202,7 +202,7 @@ void TestEditorLineInfo::editorLineSingleHunkDeletionStaged() {
 }
 
 void TestEditorLineInfo::editorLineSingleHunkChangeStaged() {
-  INIT_REPO("03_singleHunkChangeSingleLine.zip", true)
+  INIT_REPO("03_singleHunkChangeSingleLine.zip")
   QVERIFY(stagedDiff.count() > 0);
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
@@ -238,7 +238,7 @@ void TestEditorLineInfo::editorLineSingleHunkChangeStaged() {
 }
 
 void TestEditorLineInfo::editorLineSingleHunkChange_onlyAdditionStaged() {
-  INIT_REPO("04_singleHunkChange_onlyAdditionStaged.zip", true)
+  INIT_REPO("04_singleHunkChange_onlyAdditionStaged.zip")
   QVERIFY(stagedDiff.count() > 0);
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
@@ -274,7 +274,7 @@ void TestEditorLineInfo::editorLineSingleHunkChange_onlyAdditionStaged() {
 }
 
 void TestEditorLineInfo::editorLineSingleHunkChange_onlyDeletionStaged() {
-  INIT_REPO("05_singleHunkChange_onlyDeletionStaged.zip", true)
+  INIT_REPO("05_singleHunkChange_onlyDeletionStaged.zip")
   QVERIFY(stagedDiff.count() > 0);
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
@@ -310,7 +310,7 @@ void TestEditorLineInfo::editorLineSingleHunkChange_onlyDeletionStaged() {
 }
 
 void TestEditorLineInfo::singleHunk_multipleDeletions() {
-  INIT_REPO("06_singleHunk_multipleDeletions.zip", true)
+  INIT_REPO("06_singleHunk_multipleDeletions.zip")
   QVERIFY(stagedDiff.count() > 0);
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
@@ -342,7 +342,7 @@ void TestEditorLineInfo::singleHunk_multipleDeletions() {
 }
 
 void TestEditorLineInfo::singleHunk_multipleAdditions() {
-  INIT_REPO("07_singleHunk_multipleAdditions.zip", true)
+  INIT_REPO("07_singleHunk_multipleAdditions.zip")
   QVERIFY(stagedDiff.count() > 0);
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
@@ -376,7 +376,7 @@ void TestEditorLineInfo::singleHunk_multipleAdditions() {
 }
 
 void TestEditorLineInfo::multipleHunks_multipleDeletions() {
-  INIT_REPO("08_multipleHunks_multipleDeletions.zip", true)
+  INIT_REPO("08_multipleHunks_multipleDeletions.zip")
   QVERIFY(stagedDiff.count() > 0);
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
@@ -437,7 +437,7 @@ void TestEditorLineInfo::multipleHunks_multipleDeletions() {
 }
 
 void TestEditorLineInfo::multipleHunks_multipleAdditions() {
-  INIT_REPO("09_multipleHunks_multipleAdditions.zip", true)
+  INIT_REPO("09_multipleHunks_multipleAdditions.zip")
   QVERIFY(stagedDiff.count() > 0);
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
@@ -500,7 +500,7 @@ void TestEditorLineInfo::multipleHunks_multipleAdditions() {
 void TestEditorLineInfo::singleHunk_additionsOnly_secondStagedPatch() {
   // Testing the finding of the staged patch index
 
-  INIT_REPO("11_singleHunk_additionsOnly_secondStagedPatch.zip", true)
+  INIT_REPO("11_singleHunk_additionsOnly_secondStagedPatch.zip")
   QVERIFY(stagedDiff.count() > 0);
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
@@ -536,7 +536,7 @@ void TestEditorLineInfo::singleHunk_additionsOnly_secondStagedPatch() {
 void TestEditorLineInfo::singleHunk_deletionsOnly_secondStagedPatch() {
   // Testing the finding of the staged patch index
 
-  INIT_REPO("12_singleHunk_deletionsOnly_secondStagedPatch.zip", true)
+  INIT_REPO("12_singleHunk_deletionsOnly_secondStagedPatch.zip")
   QVERIFY(stagedDiff.count() > 0);
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
@@ -570,7 +570,7 @@ void TestEditorLineInfo::singleHunk_deletionsOnly_secondStagedPatch() {
 }
 
 void TestEditorLineInfo::multipleHunks_misc1() {
-  INIT_REPO("10_misc.zip", true)
+  INIT_REPO("10_misc.zip")
   QVERIFY(stagedDiff.count() > 0);
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
@@ -637,7 +637,7 @@ void TestEditorLineInfo::multipleHunks_misc1() {
 //}
 
 void TestEditorLineInfo::multipleHunks_StageSingleLines() {
-  INIT_REPO("13_singleHunkNoStaged.zip", true)
+  INIT_REPO("13_singleHunkNoStaged.zip")
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
   // no staged lines yet, so no staged patch
@@ -727,7 +727,7 @@ void TestEditorLineInfo::multipleHunks_StageSingleLines2() {
    * and then the added line
    */
 
-  INIT_REPO("13_singleHunkNoStaged.zip", true)
+  INIT_REPO("13_singleHunkNoStaged.zip")
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
   // no staged lines yet, so no staged patch
@@ -828,7 +828,7 @@ void TestEditorLineInfo::windowsCRLF() {
    * The repository was created on windows
    */
 
-  INIT_REPO("14_windowsCRLF.zip", true)
+  INIT_REPO("14_windowsCRLF.zip")
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
   // no staged lines yet, so no staged patch
@@ -882,7 +882,7 @@ void TestEditorLineInfo::windowsCRLFMultiHunk() {
    * hunks. The CRLF file was created directly on linux and not on windows
    */
 
-  INIT_REPO("15_windowsCRLF_multipleHunks.zip", true)
+  INIT_REPO("15_windowsCRLF_multipleHunks.zip")
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
   // no staged lines yet, so no staged patch
@@ -938,7 +938,7 @@ void TestEditorLineInfo::windowsCRLFMultiHunk() {
 }
 
 void TestEditorLineInfo::sameContentRemoveLine() {
-  INIT_REPO("16_LinestagingLineContent.zip", true)
+  INIT_REPO("16_LinestagingLineContent.zip")
   QVERIFY(stagedDiff.count() > 0);
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
@@ -953,7 +953,7 @@ void TestEditorLineInfo::sameContentRemoveLine() {
 }
 
 void TestEditorLineInfo::sameContentAddLine() {
-  INIT_REPO("17_LinestagingLineContentStageAddedLine.zip", true)
+  INIT_REPO("17_LinestagingLineContentStageAddedLine.zip")
   QVERIFY(stagedDiff.count() > 0);
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
@@ -969,7 +969,7 @@ void TestEditorLineInfo::sameContentAddLine() {
 #endif
 
 // void TestEditorLineInfo::deleteCompleteContent() {
-//   INIT_REPO("18_deleteLinesStagedLast.zip", true)
+//   INIT_REPO("18_deleteLinesStagedLast.zip")
 //   QVERIFY(stagedDiff.count() > 0);
 //   QVERIFY(diff.count() > 0);
 //   git::Patch patch = diff.patch(0);
@@ -986,7 +986,7 @@ void TestEditorLineInfo::sameContentAddLine() {
 //}
 
 void TestEditorLineInfo::discardCompleteDeletedContent() {
-  INIT_REPO("19_discardCompleteDeletedContent.zip", true)
+  INIT_REPO("19_discardCompleteDeletedContent.zip")
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
   // no staged lines yet, so no staged patch
@@ -1018,7 +1018,7 @@ void TestEditorLineInfo::discardCompleteDeletedContent() {
 }
 
 void TestEditorLineInfo::discardCompleteAddedContent() {
-  INIT_REPO("20_discardCompleteAddedContent.zip", true)
+  INIT_REPO("20_discardCompleteAddedContent.zip")
   QVERIFY(diff.count() > 0);
   git::Patch patch = diff.patch(0);
   // no staged lines yet, so no staged patch

--- a/test/Submodule.cpp
+++ b/test/Submodule.cpp
@@ -24,8 +24,8 @@
 #include <QWizard>
 #include <QLineEdit>
 
-#define INIT_REPO(repoPath, /* bool */ useTempDir)                             \
-  QString path = Test::extractRepository(repoPath, useTempDir);                \
+#define INIT_REPO(repoPath)                                                    \
+  QString path = Test::extractRepository(repoPath);                            \
   QVERIFY(!path.isEmpty());                                                    \
   auto repo = git::Repository::open(path);                                     \
   QVERIFY(repo.isValid());                                                     \
@@ -53,7 +53,7 @@ private:
 
 void TestSubmodule::updateSubmoduleClone() {
   // Update submodules after cloning
-  QString remote = Test::extractRepository("SubmoduleTest.zip", true);
+  QString remote = Test::extractRepository("SubmoduleTest.zip");
   QCOMPARE(remote.isEmpty(), false);
 
   Settings *settings = Settings::instance();
@@ -94,7 +94,7 @@ void TestSubmodule::updateSubmoduleClone() {
 
 void TestSubmodule::noUpdateSubmoduleClone() {
   // Don't update submodules after cloning
-  QString remote = Test::extractRepository("SubmoduleTest.zip", true);
+  QString remote = Test::extractRepository("SubmoduleTest.zip");
   QCOMPARE(remote.isEmpty(), false);
 
   Settings *settings = Settings::instance();
@@ -135,7 +135,7 @@ void TestSubmodule::noUpdateSubmoduleClone() {
 
 void TestSubmodule::discardFile() {
   // Discarding a file should not reset the submodule
-  INIT_REPO("SubmoduleTest.zip", true);
+  INIT_REPO("SubmoduleTest.zip");
   repoView->updateSubmodules(repo.submodules(), true, true);
 
   qWait(1000); // Not needed if the test is long enough and the fetch operation

--- a/test/Submodule.cpp
+++ b/test/Submodule.cpp
@@ -61,14 +61,17 @@ void TestSubmodule::updateSubmoduleClone() {
   CloneDialog *d = new CloneDialog(CloneDialog::Kind::Clone);
 
   RepoView *view = nullptr;
+  MainWindow *window = nullptr;
 
   bool cloneFinished = false;
-  QObject::connect(d, &CloneDialog::accepted, [d, &view, &cloneFinished] {
-    cloneFinished = true;
-    if (MainWindow *window = MainWindow::open(d->path())) {
-      view = window->currentView();
-    }
-  });
+  QObject::connect(d, &CloneDialog::accepted,
+                   [d, &window, &view, &cloneFinished] {
+                     cloneFinished = true;
+                     window = MainWindow::open(d->path());
+                     if (window) {
+                       view = window->currentView();
+                     }
+                   });
 
   QTemporaryDir tempdir;
   QVERIFY(tempdir.isValid());
@@ -90,6 +93,14 @@ void TestSubmodule::updateSubmoduleClone() {
     QVERIFY(s.isValid());
     QVERIFY(s.isInitialized());
   }
+
+  // Close the window so it doesn't outlive this test: MainWindow::open()
+  // heap-allocates it, and while alive it stays connected to the global
+  // RecentRepositories signal, reacting to later tests' clones by
+  // re-reading this repo's directory after tempdir (above) has been
+  // deleted.
+  window->close();
+  qWait(0); // let the WA_DeleteOnClose deferred deletion run now
 }
 
 void TestSubmodule::noUpdateSubmoduleClone() {
@@ -102,14 +113,17 @@ void TestSubmodule::noUpdateSubmoduleClone() {
   CloneDialog *d = new CloneDialog(CloneDialog::Kind::Clone);
 
   RepoView *view = nullptr;
+  MainWindow *window = nullptr;
 
   bool cloneFinished = false;
-  QObject::connect(d, &CloneDialog::accepted, [d, &view, &cloneFinished] {
-    cloneFinished = true;
-    if (MainWindow *window = MainWindow::open(d->path())) {
-      view = window->currentView();
-    }
-  });
+  QObject::connect(d, &CloneDialog::accepted,
+                   [d, &window, &view, &cloneFinished] {
+                     cloneFinished = true;
+                     window = MainWindow::open(d->path());
+                     if (window) {
+                       view = window->currentView();
+                     }
+                   });
 
   QTemporaryDir tempdir;
   QVERIFY(tempdir.isValid());
@@ -131,6 +145,11 @@ void TestSubmodule::noUpdateSubmoduleClone() {
     QVERIFY(s.isValid());
     QCOMPARE(s.isInitialized(), false);
   }
+
+  // Close the window so it doesn't outlive this test; see comment in
+  // updateSubmoduleClone().
+  window->close();
+  qWait(0); // let the WA_DeleteOnClose deferred deletion run now
 }
 
 void TestSubmodule::discardFile() {

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -102,15 +102,11 @@ int on_extract_entry(const char *filename, void *arg) {
  * \param filename
  * \return
  */
-QString extractRepository(const QString &filename, bool useTempDir) {
+QString extractRepository(const QString &filename) {
 
   QDir repoPath(TESTREPOSITORIES_PATH);
   QFileInfo f(repoPath.filePath(filename));
-  QByteArray exportPath;
-  if (useTempDir)
-    exportPath = tempDir.path().toLatin1();
-  else
-    exportPath = repoPath.path().toLatin1();
+  QByteArray exportPath = tempDir.path().toLatin1();
   QString exportFolder = QDir(exportPath).filePath(f.baseName());
 
   if (!QDir(exportFolder).exists() && !f.exists()) {
@@ -118,7 +114,7 @@ QString extractRepository(const QString &filename, bool useTempDir) {
     return "";
   }
 
-  if (useTempDir && !tempDir.isValid()) {
+  if (!tempDir.isValid()) {
     Debug("Not able to create temporary directory.");
     return "";
   }

--- a/test/Test.h
+++ b/test/Test.h
@@ -56,7 +56,7 @@ private:
 
 void refresh(RepoView *repoView, bool expectDirty = true);
 void fetch(RepoView *repoView, git::Remote remote);
-QString extractRepository(const QString &filename, bool useTempDir);
+QString extractRepository(const QString &filename);
 void initRepo(git::Repository &repo);
 
 Application createApp(int &argc, char *argv[]);

--- a/test/TreeView.cpp
+++ b/test/TreeView.cpp
@@ -12,8 +12,8 @@
 using namespace Test;
 using namespace QTest;
 
-#define INIT_REPO(repoPath, /* bool */ useTempDir)                             \
-  QString path = Test::extractRepository(repoPath, useTempDir);                \
+#define INIT_REPO(repoPath)                                                    \
+  QString path = Test::extractRepository(repoPath);                            \
   QVERIFY(!path.isEmpty());                                                    \
   auto repo = git::Repository::open(path);                                     \
   QVERIFY(repo.isValid());                                                     \
@@ -50,7 +50,7 @@ private:
 };
 
 void TestTreeView::restoreStagedFileAfterCommit() {
-  INIT_REPO("TreeViewCollapseCount.zip", true);
+  INIT_REPO("TreeViewCollapseCount.zip");
 
   // Check for a single file called "test".
   RepoView *view = window.currentView();
@@ -113,7 +113,7 @@ void TestTreeView::discardFiles() {
   // not selected files Discarding a folder in staged treeview should only
   // delete the staged files, but not the unstaged files in that folder!
 
-  INIT_REPO("TestRepository.zip", false);
+  INIT_REPO("TestRepository.zip");
 
   git::Commit commit =
       repo.lookupCommit("5c61b24e236310ad4a8a64f7cd1ccc968f1eec20");
@@ -203,7 +203,7 @@ void TestTreeView::discardFiles() {
 }
 
 void TestTreeView::fileMergeCrash() {
-  INIT_REPO("CrashMerge.zip", false);
+  INIT_REPO("CrashMerge.zip");
 
   git::Reference otherBranch = repo.lookupRef("refs/heads/otherBranch");
   QVERIFY(otherBranch);
@@ -279,7 +279,7 @@ void TestTreeView::fileMergeCrash() {
 }
 
 void TestTreeView::dirtySubmoduleAndStagedSubmodule() {
-  INIT_REPO("DirtySubmoduleUnstagedTree.zip", false);
+  INIT_REPO("DirtySubmoduleUnstagedTree.zip");
 
   auto doubleTree = repoView->findChild<DoubleTreeWidget *>();
   QVERIFY(doubleTree);
@@ -316,7 +316,7 @@ void TestTreeView::dirtySubmoduleAndStagedSubmodule() {
 }
 
 void TestTreeView::conflictedAndStagedFile() {
-  INIT_REPO("ConflictedAndStagedFile.zip", false);
+  INIT_REPO("ConflictedAndStagedFile.zip");
 
   auto doubleTree = repoView->findChild<DoubleTreeWidget *>();
   QVERIFY(doubleTree);

--- a/test/TreeView.cpp
+++ b/test/TreeView.cpp
@@ -290,6 +290,14 @@ void TestTreeView::dirtySubmoduleAndStagedSubmodule() {
 
   {
     QAbstractItemModel *stagedModel = stagedTree->model();
+
+    {
+      // Wait for refresh
+      auto timeout = Timeout(10000, "Repository didn't refresh in time");
+      while (stagedModel->rowCount() < 1)
+        qWait(300);
+    }
+
     QCOMPARE(stagedModel->rowCount(), 1);
     QModelIndex index = stagedModel->index(0, 0); // submodules folder
     QVERIFY(index.isValid());
@@ -327,6 +335,14 @@ void TestTreeView::conflictedAndStagedFile() {
 
   {
     QAbstractItemModel *stagedModel = stagedTree->model();
+
+    {
+      // Wait for refresh
+      auto timeout = Timeout(10000, "Repository didn't refresh in time");
+      while (stagedModel->rowCount() < 1)
+        qWait(300);
+    }
+
     QCOMPARE(stagedModel->rowCount(), 1);
     QModelIndex index = stagedModel->index(0, 0); // "folder" folder
     QVERIFY(index.isValid());

--- a/test/amend.cpp
+++ b/test/amend.cpp
@@ -15,8 +15,8 @@
 #include <QDateTimeEdit>
 #include <QLineEdit>
 
-#define INIT_REPO(repoPath, /* bool */ useTempDir)                             \
-  QString path = Test::extractRepository(repoPath, useTempDir);                \
+#define INIT_REPO(repoPath)                                                    \
+  QString path = Test::extractRepository(repoPath);                            \
   QVERIFY(!path.isEmpty());                                                    \
   git::Repository repo = git::Repository::open(path);                          \
   QVERIFY(repo.isValid());                                                     \
@@ -36,7 +36,7 @@ private slots:
 using namespace git;
 
 void TestAmend::testAmend() {
-  INIT_REPO("CherryPickAuthorEmail.zip", true);
+  INIT_REPO("CherryPickAuthorEmail.zip");
 
   git::Reference master = repo.lookupRef(QString("refs/heads/master"));
   QVERIFY(master.isValid());

--- a/test/fileContextMenu.cpp
+++ b/test/fileContextMenu.cpp
@@ -9,8 +9,8 @@
 #include <QMessageBox>
 #include <QPushButton>
 
-#define INIT_REPO(repoPath, /* bool */ useTempDir)                             \
-  QString path = Test::extractRepository(repoPath, useTempDir);                \
+#define INIT_REPO(repoPath)                                                    \
+  QString path = Test::extractRepository(repoPath);                            \
   QVERIFY(!path.isEmpty());                                                    \
   git::Repository repo = git::Repository::open(path);                          \
   QVERIFY(repo.isValid());                                                     \
@@ -36,7 +36,7 @@ private slots:
 using namespace git;
 
 void TestFileContextMenu::testDiscardFile() {
-  INIT_REPO("TestRepository.zip", false);
+  INIT_REPO("TestRepository.zip");
 
   git::Commit commit =
       repo.lookupCommit("5c61b24e236310ad4a8a64f7cd1ccc968f1eec20");
@@ -112,7 +112,7 @@ void TestFileContextMenu::testDiscardFile() {
 }
 
 void TestFileContextMenu::testDiscardSubmodule() {
-  INIT_REPO("TestRepository.zip", false);
+  INIT_REPO("TestRepository.zip");
 
   git::Commit commit =
       repo.lookupCommit("5c61b24e236310ad4a8a64f7cd1ccc968f1eec20");
@@ -193,7 +193,7 @@ void TestFileContextMenu::testDiscardSubmodule() {
 }
 
 void TestFileContextMenu::testDiscardFolder() {
-  INIT_REPO("TestRepository.zip", false);
+  INIT_REPO("TestRepository.zip");
 
   git::Commit commit =
       repo.lookupCommit("5c61b24e236310ad4a8a64f7cd1ccc968f1eec20");
@@ -271,7 +271,7 @@ void TestFileContextMenu::testDiscardFolder() {
 }
 
 void TestFileContextMenu::testDiscardNothing() {
-  INIT_REPO("TestRepository.zip", false);
+  INIT_REPO("TestRepository.zip");
 
   git::Commit commit =
       repo.lookupCommit("5c61b24e236310ad4a8a64f7cd1ccc968f1eec20");
@@ -340,7 +340,7 @@ void TestFileContextMenu::testDiscardNothing() {
 }
 
 void TestFileContextMenu::testIgnoreFile() {
-  INIT_REPO("TestRepository.zip", false);
+  INIT_REPO("TestRepository.zip");
 
   git::Commit commit =
       repo.lookupCommit("5c61b24e236310ad4a8a64f7cd1ccc968f1eec20");
@@ -388,7 +388,7 @@ void TestFileContextMenu::testIgnoreFile() {
 }
 
 void TestFileContextMenu::testIgnoreFileUntracked() {
-  INIT_REPO("TestRepository.zip", false);
+  INIT_REPO("TestRepository.zip");
 
   git::Commit commit =
       repo.lookupCommit("5c61b24e236310ad4a8a64f7cd1ccc968f1eec20");
@@ -459,7 +459,7 @@ void TestFileContextMenu::testIgnoreFileUntracked() {
 }
 
 void TestFileContextMenu::testIgnoreFolder() {
-  INIT_REPO("TestRepository.zip", false);
+  INIT_REPO("TestRepository.zip");
 
   git::Commit commit =
       repo.lookupCommit("5c61b24e236310ad4a8a64f7cd1ccc968f1eec20");
@@ -523,7 +523,7 @@ void TestFileContextMenu::testIgnoreFolder() {
 }
 
 void TestFileContextMenu::testRemoveUntrackedFolder() {
-  INIT_REPO("TestRepository.zip", false);
+  INIT_REPO("TestRepository.zip");
 
   git::Commit commit =
       repo.lookupCommit("5c61b24e236310ad4a8a64f7cd1ccc968f1eec20");

--- a/test/rebase.cpp
+++ b/test/rebase.cpp
@@ -31,8 +31,8 @@
 #include <QTextEdit>
 #include <QPushButton>
 
-#define INIT_REPO(repoPath, /* bool */ useTempDir)                             \
-  QString path = Test::extractRepository(repoPath, useTempDir);                \
+#define INIT_REPO(repoPath)                                                    \
+  QString path = Test::extractRepository(repoPath);                            \
   QVERIFY(!path.isEmpty());                                                    \
   mRepo = git::Repository::open(path);                                         \
   QVERIFY(mRepo.isValid());                                                    \
@@ -98,7 +98,7 @@ private:
 //###################################################################################################
 
 void TestRebase::withoutConflicts() {
-  INIT_REPO("rebaseConflicts.zip", true);
+  INIT_REPO("rebaseConflicts.zip");
 
   int rebaseFinished = 0;
   int rebaseAboutToRebase = 0;
@@ -173,7 +173,7 @@ void TestRebase::withoutConflicts() {
 }
 
 void TestRebase::conflictingRebase() {
-  INIT_REPO("rebaseConflicts.zip", true);
+  INIT_REPO("rebaseConflicts.zip");
 
   auto *detailview = repoView->findChild<DetailView *>();
   QVERIFY(detailview);
@@ -310,7 +310,7 @@ void TestRebase::conflictingRebase() {
 }
 
 void TestRebase::conflictingRebaseCustomMessage() {
-  INIT_REPO("rebaseConflicts.zip", true);
+  INIT_REPO("rebaseConflicts.zip");
 
   auto *detailview = repoView->findChild<DetailView *>();
   QVERIFY(detailview);
@@ -393,7 +393,7 @@ void TestRebase::conflictingRebaseCustomMessage() {
 }
 
 void TestRebase::continueExternalStartedRebase() {
-  //    INIT_REPO("rebaseConflicts.zip", true);
+  //    INIT_REPO("rebaseConflicts.zip");
 
   //    QCOMPARE(repoView->isRebaseContinueVisible(), false);
   //    QCOMPARE(repoView->isRebaseAbortVisible(), false);
@@ -490,7 +490,7 @@ void TestRebase::continueExternalStartedRebase() {
 
 void TestRebase::startRebaseContinueInCLI() {
   //    // Check that GUI is updated correctly
-  //    INIT_REPO("rebaseConflicts.zip", true);
+  //    INIT_REPO("rebaseConflicts.zip");
 
   //    int rebaseFinished = 0;
   //    int rebaseAboutToRebase = 0;
@@ -585,7 +585,7 @@ void TestRebase::startRebaseContinueInCLI() {
 void TestRebase::startRebaseContinueInCLIContinueGUI() {
   //    // Check that GUI is updated correctly
 
-  //    INIT_REPO("rebaseConflicts.zip", true);
+  //    INIT_REPO("rebaseConflicts.zip");
 
   //    QCOMPARE(repoView->isRebaseContinueVisible(), false);
   //    QCOMPARE(repoView->isRebaseAbortVisible(), false);
@@ -682,7 +682,7 @@ void TestRebase::startRebaseContinueInCLIContinueGUI() {
 }
 
 void TestRebase::abortMR() {
-  INIT_REPO("rebaseConflicts.zip", true);
+  INIT_REPO("rebaseConflicts.zip");
 
   auto *detailview = repoView->findChild<DetailView *>();
   QVERIFY(detailview);
@@ -790,7 +790,7 @@ void TestRebase::commitDuringRebase() {
    * Commit something else too
    * Continue rebase */
 
-  INIT_REPO("rebaseConflicts.zip", true);
+  INIT_REPO("rebaseConflicts.zip");
 
   auto *detailview = repoView->findChild<DetailView *>();
   QVERIFY(detailview);


### PR DESCRIPTION
This fixes six issues causing intermittent failure in the test cases

1. System.lua is created and destroyed at run-time at in the same temp location. Now the file is just patched in-memory instead, when necessary, avoiding this clash between test cases
2. Some test cases don't write to a temporary directory. Quite frankly I don't see the use-case for testing without a per-process temporary directory, so the option is just removed
3. All test cases read and write to the same settings, which very inconveniently is the user settings. Now they all write to a per-process temporary directory. If a test case crash, you're no longer stuck with a cluttered user settings and recent repos.
4. Occasionally MainWindow is being reused in the Submodule test code. This cause crashes since particularly the repo directory might be gone and invalid in the next test case.
5. There's a potential use-after-free in a future started by CommitModel
6. On Windows, the `TreeView` test case is prone to fail. I got Claude to debug this for me, but there seems to be a missing wait-for-refresh in the `TreeView` test code. I've copied some wait code use elsewhere in the test code to wait for a `QAbstractItemModel` object to be fully refreshed.

I've been running this quite a few times, and `ctest -jN` (N for example being 32) no longer seem to fail. Typically, particularly the `TreeView` test case was prone to fail, and we've seen this in the GitHub CI/CD pipeline for Windows. I'm pretty confident this will fix those problem.

Added bonus is that the test cases run far faster in parallel, and it has no chance to mess up the user settings if it crashes.

Fixes #546
Fixes #769 