### PR TITLE
Fix flatpak builds not working properly with repos outside home directory

### DIFF
--- a/src/dialogs/StartDialog.cpp
+++ b/src/dialogs/StartDialog.cpp
@@ -21,6 +21,7 @@
 #include "ui/ProgressIndicator.h"
 #include "ui/RepoView.h"
 #include "ui/TabWidget.h"
+#include "util/Path.h"
 #include <QAbstractItemModel>
 #include <QAbstractListModel>
 #include <QApplication>
@@ -117,7 +118,10 @@ public:
     RecentRepository *repo = repos->repository(index.row());
     switch (role) {
       case Qt::DisplayRole:
-        return mShowFullPath ? repo->gitpath() : repo->name();
+        // Display the real host path; gitpath() itself (Qt::UserRole) stays the
+        // sandbox path so the repo can still be opened from inside the sandbox
+        return mShowFullPath ? util::sandboxPathToHost(repo->gitpath())
+                             : repo->name();
 
       case Qt::UserRole:
         return repo->gitpath();

--- a/src/tools/DiffTool.cpp
+++ b/src/tools/DiffTool.cpp
@@ -10,6 +10,7 @@
 #include "DiffTool.h"
 #include "git/Command.h"
 #include "git/Repository.h"
+#include "util/Path.h"
 #include <QProcess>
 #include <QTemporaryFile>
 #include <QDebug>
@@ -81,9 +82,14 @@ bool DiffTool::start() {
   QString localPath =
       local ? local->fileName() : QFileInfo(mFile).absoluteFilePath();
 #if defined(FLATPAK) || defined(DEBUG_FLATPAK)
-  QStringList arguments = {"--host", QStringLiteral("--env=LOCAL=") + localPath,
-                           "--env=REMOTE=" + remotePath,
-                           "--env=MERGED=" + mFile, "--env=BASE=" + mFile};
+  // Resolve potentially sandboxed path
+  const QString hostLocal = util::sandboxPathToHost(localPath);
+  const QString hostRemote = util::sandboxPathToHost(remotePath);
+  const QString hostMerged = util::sandboxPathToHost(mFile);
+  QStringList arguments = {"--host", QStringLiteral("--env=LOCAL=") + hostLocal,
+                           "--env=REMOTE=" + hostRemote,
+                           "--env=MERGED=" + hostMerged,
+                           "--env=BASE=" + hostMerged};
   arguments.append("sh");
   arguments.append("-c");
   arguments.append(command);

--- a/src/tools/EditTool.cpp
+++ b/src/tools/EditTool.cpp
@@ -10,6 +10,7 @@
 #include "EditTool.h"
 #include "git/Config.h"
 #include "git/Repository.h"
+#include "util/Path.h"
 #include <QDesktopServices>
 #include <QProcess>
 #include <QUrl>
@@ -26,6 +27,9 @@ ExternalTool::Kind EditTool::kind() const { return Edit; }
 QString EditTool::name() const { return tr("Edit in External Editor"); }
 
 bool EditTool::start() {
+  // Resolve potentially sandboxed path
+  const QString file = util::sandboxPathToHost(mFile);
+
   git::Config config = git::Config::global();
   QString editor = config.value<QString>("gui.editor");
 
@@ -42,7 +46,7 @@ bool EditTool::start() {
     editor = qgetenv("EDITOR");
 
   if (editor.isEmpty())
-    return QDesktopServices::openUrl(QUrl::fromLocalFile(mFile));
+    return QDesktopServices::openUrl(QUrl::fromLocalFile(file));
 
   // Find arguments.
   QStringList args = editor.split("\" \"");
@@ -68,7 +72,7 @@ bool EditTool::start() {
 
   // Remove command, add filename, trim command.
   args.removeFirst();
-  args.append(mFile);
+  args.append(file);
   editor.remove("\"");
 
   // Destroy this after process finishes.

--- a/src/tools/MergeTool.cpp
+++ b/src/tools/MergeTool.cpp
@@ -12,6 +12,7 @@
 #include "git/Config.h"
 #include "git/Index.h"
 #include "git/Repository.h"
+#include "util/Path.h"
 #include "Debug.h"
 #include <QDateTime>
 #include <QDir>
@@ -110,9 +111,12 @@ bool MergeTool::start() {
   process->setProcessEnvironment(env);
 
 #if defined(FLATPAK) || defined(DEBUG_FLATPAK)
+  // Resolve potentially sandboxed path
+  const QString hostMerged = util::sandboxPathToHost(mFile);
   QStringList arguments = {"--host", "--env=LOCAL=" + local->fileName(),
                            "--env=REMOTE=" + remote->fileName(),
-                           "--env=MERGED=" + mFile, "--env=BASE=" + basePath};
+                           "--env=MERGED=" + hostMerged,
+                           "--env=BASE=" + basePath};
   arguments.append("sh");
   arguments.append("-c");
   arguments.append(command);

--- a/src/tools/ShowTool.cpp
+++ b/src/tools/ShowTool.cpp
@@ -10,6 +10,7 @@
 #include "ShowTool.h"
 #include "conf/Settings.h"
 #include "git/Repository.h"
+#include "util/Path.h"
 #include <QDesktopServices>
 #include <QDir>
 #include <QFileInfo>
@@ -80,7 +81,8 @@ bool ShowTool::openFileManager(QString path) {
   if (!tmp.isEmpty())
     cmdParts += tmp;
 #endif
-  path = QDir::toNativeSeparators(path);
+  // Resolve potentially sandboxed path
+  path = QDir::toNativeSeparators(util::sandboxPathToHost(path));
 
   for (QString &part : cmdParts)
     part = part.arg(path);

--- a/src/ui/DiffTreeModel.cpp
+++ b/src/ui/DiffTreeModel.cpp
@@ -15,6 +15,7 @@
 #include "git/RevWalk.h"
 #include "git/Submodule.h"
 #include "git/Patch.h"
+#include "util/Path.h"
 #include <QStringBuilder>
 #include <QUrl>
 #include <qobjectdefs.h>
@@ -63,7 +64,8 @@ void DiffTreeModel::setDiff(const git::Diff &diff) {
   if (diff) {
     delete mRoot;
     mDiff = diff;
-    mRoot = new Node(mRepo.workdir().path(), -1);
+    // Resolve potentially sandboxed path
+    mRoot = new Node(util::sandboxPathToHost(mRepo.workdir().path()), -1);
     createDiffTree();
   }
 

--- a/src/ui/FileContextMenu.cpp
+++ b/src/ui/FileContextMenu.cpp
@@ -19,6 +19,7 @@
 #include "host/Repository.h"
 #include "tools/EditTool.h"
 #include "tools/ShowTool.h"
+#include "util/Path.h"
 #include <QApplication>
 #include <QClipboard>
 #include <QDir>
@@ -206,7 +207,9 @@ FileContextMenu::FileContextMenu(RepoView *view, const QStringList &files,
     QDir dir = repo.workdir();
     QString file = files.first();
     QString rel = QDir::toNativeSeparators(file);
-    QString abs = QDir::toNativeSeparators(dir.filePath(file));
+    // Resolve potentially sandboxed path
+    QString abs =
+        QDir::toNativeSeparators(util::sandboxPathToHost(dir.filePath(file)));
     QString name = QFileInfo(file).fileName();
     QMenu *copy = addMenu(tr("Copy File Name"));
     if (!name.isEmpty() && name != file) {

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -33,6 +33,7 @@
 #include <QTimeLine>
 #include <QToolButton>
 #include "util/Debug.h"
+#include "util/Path.h"
 
 namespace {
 
@@ -530,7 +531,9 @@ void MainWindow::updateWindowTitle(int ahead, int behind) {
   git::Repository repo = view->repo();
   QDir dir = repo.dir(false);
   git::Reference head = repo.head();
-  QString path = mFullPath ? dir.path() : dir.dirName();
+  // Resolve potentially sandboxed path
+  QString path =
+      mFullPath ? util::sandboxPathToHost(dir.path()) : dir.dirName();
   QString name = head.isValid() ? head.name() : repo.unbornHeadName();
   QString title = tr("%1 - %2").arg(path, name);
 

--- a/src/ui/RepoView.cpp
+++ b/src/ui/RepoView.cpp
@@ -52,6 +52,7 @@
 #include "log/LogEntry.h"
 #include "log/LogView.h"
 #include "tools/ShowTool.h"
+#include "util/Path.h"
 #include "watcher/RepositoryWatcher.h"
 #include <QCheckBox>
 #include <QCloseEvent>
@@ -2742,7 +2743,8 @@ void RepoView::openTerminal() {
   child.setProgram("sh");
   child.setArguments(QStringList() << "-c" << terminalCmd);
 #endif
-  child.setWorkingDirectory(mRepo.workdir().absolutePath());
+  child.setWorkingDirectory(
+      util::sandboxPathToHost(mRepo.workdir().absolutePath()));
   Debug("Execute Terminal: Arguments: " << child.arguments());
   child.startDetached();
 #endif

--- a/src/ui/SideBar.cpp
+++ b/src/ui/SideBar.cpp
@@ -19,6 +19,7 @@
 #include "dialogs/AccountDialog.h"
 #include "dialogs/CloneDialog.h"
 #include "host/Accounts.h"
+#include "util/Path.h"
 #include <QAbstractItemModel>
 #include <QFileDialog>
 #include <QMenu>
@@ -352,7 +353,8 @@ public:
                 return mTabs->tabText(row);
 
               RepoView *view = static_cast<RepoView *>(mTabs->widget(row));
-              return view->repo().dir(false).path();
+              // Resolve potentially sandboxed path
+              return util::sandboxPathToHost(view->repo().dir(false).path());
             }
 
             return tr("none");
@@ -361,7 +363,9 @@ public:
             RecentRepositories *recent = RecentRepositories::instance();
             if (recent->count()) {
               RecentRepository *repo = repos->repository(row);
-              return mShowFullPath ? repo->gitpath() : repo->name();
+              // Resolve potentially sandboxed path
+              return mShowFullPath ? util::sandboxPathToHost(repo->gitpath())
+                                   : repo->name();
             }
 
             return tr("none");
@@ -493,7 +497,8 @@ public:
           case Repo:
             if (mTabs->count()) {
               RepoView *view = static_cast<RepoView *>(mTabs->widget(row));
-              return view->repo().dir(false).path();
+              // Resolve potentially sandboxed path
+              return util::sandboxPathToHost(view->repo().dir(false).path());
             }
 
             return "";
@@ -502,7 +507,8 @@ public:
             RecentRepositories *recent = RecentRepositories::instance();
             if (recent->count()) {
               RecentRepository *repo = repos->repository(row);
-              return repo->gitpath();
+              // Resolve potentially sandboxed path
+              return util::sandboxPathToHost(repo->gitpath());
             }
 
             return "";

--- a/src/ui/TreeModel.cpp
+++ b/src/ui/TreeModel.cpp
@@ -13,6 +13,7 @@
 #include "git/Diff.h"
 #include "git/RevWalk.h"
 #include "git/Submodule.h"
+#include "util/Path.h"
 #include <QStringBuilder>
 #include <QUrl>
 
@@ -31,7 +32,10 @@ void TreeModel::setTree(const git::Tree &tree, const git::Diff &diff) {
   beginResetModel();
 
   delete mRoot;
-  mRoot = tree.isValid() ? new Node(mRepo.workdir().path(), tree) : nullptr;
+  // Resolve potentially sandboxed path
+  mRoot = tree.isValid()
+              ? new Node(util::sandboxPathToHost(mRepo.workdir().path()), tree)
+              : nullptr;
 
   mDiff = diff;
 

--- a/src/util/Path.cpp
+++ b/src/util/Path.cpp
@@ -1,8 +1,18 @@
 #include "Path.h"
+#include <optional>
 
 #ifdef Q_OS_WIN
 #include <memory>
 #include <windows.h>
+#endif
+
+#if defined(FLATPAK) && defined(Q_OS_LINUX)
+#include <QByteArray>
+#include <QFile>
+
+#include <cerrno>
+#include <sys/types.h>
+#include <sys/xattr.h>
 #endif
 
 namespace util {
@@ -21,5 +31,70 @@ QString canonicalizePath(QString path) {
   }
 #endif
   return path;
+}
+
+#if defined(FLATPAK) && defined(Q_OS_LINUX)
+namespace {
+
+// The xdg-document-portal fuse filesystem tags every entry it exposes with the
+// real location of that entry on the host in this extended attribute
+std::optional<QString> readHostPathXattr(const QString &path) {
+  const QByteArray name = QFile::encodeName(path);
+
+  for (int size = 512; size <= 64 * 1024; size *= 8) {
+    QByteArray value(size, Qt::Uninitialized);
+    const ssize_t len =
+        getxattr(name.constData(), "user.document-portal.host-path",
+                 value.data(), static_cast<size_t>(value.size()));
+    if (len >= 0) {
+      value.truncate(static_cast<int>(len));
+      // The attribute is stored without a trailing NUL, but just in case...
+      while (value.endsWith('\0'))
+        value.chop(1);
+      return value.isEmpty() ? QString() : QFile::decodeName(value);
+    }
+
+    if (errno != ERANGE)
+      return {};
+  }
+
+  return {};
+}
+
+QString resolvePortalPath(const QString &path) {
+  // Fast path: the portal tags every existing entry directly.
+  std::optional<QString> result = readHostPathXattr(path);
+  if (result.has_value())
+    return result.value();
+
+  // We're not guaranteed that the path exists since the path might not resolve
+  // in the checked out work directory. In those cases we need to find an
+  // ancestor that does resolve, and patch the path
+  QString ancestor = path;
+  QString tail;
+  while (true) {
+    const int slash = ancestor.lastIndexOf(QLatin1Char('/'));
+    if (slash <= 0)
+      break;
+    tail = ancestor.mid(slash) + tail;
+    ancestor.truncate(slash);
+
+    result = readHostPathXattr(ancestor);
+    if (result.has_value())
+      return result.value() + tail;
+  }
+
+  return path;
+}
+
+} // namespace
+#endif // FLATPAK && Q_OS_LINUX
+
+QString sandboxPathToHost(const QString &path) {
+#if defined(FLATPAK) && defined(Q_OS_LINUX)
+  return resolvePortalPath(path);
+#else
+  return path;
+#endif
 }
 } // namespace util

--- a/src/util/Path.h
+++ b/src/util/Path.h
@@ -14,6 +14,12 @@
 
 namespace util {
 QString canonicalizePath(QString path);
-}
+
+/// @brief Convert a potentially sandboxed path into a host path. This can
+/// happen for instances with Flatpak and paths outside home directory
+/// @param path Potentially sandboxed path
+/// @return Host path
+QString sandboxPathToHost(const QString &path);
+} // namespace util
 
 #endif


### PR DESCRIPTION
Flatpak provide sandboxed paths. If they are outside certain folders such as `/home/<username>` or `/tmp`, they are provided as `/run/flatpak`. These paths have to be resolved to a true host path for external tooling to work. Additionally, all tooltips also need to resolve the path in order not to confuse the user.

It's worth noting that within Gittyup we have to interact with the sandboxed path, not the resolved host path. So it's exclusively for presentation or arguments to external tooling

Fixes #937 