### PR TITLE
l10n: add complete Swedish translation

### DIFF
--- a/l10n/CMakeLists.txt
+++ b/l10n/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LANGUAGES
     ja
     pt
     pt_BR
+    sv
     zh_CN)
 
 set(SRC_DIR ${CMAKE_SOURCE_DIR}/src)

--- a/l10n/gittyup_sv.ts
+++ b/l10n/gittyup_sv.ts
@@ -1,0 +1,5736 @@
+<?xml version='1.0' encoding='utf-8'?>
+<TS version="2.1" language="sv_SE">
+    <context>
+        <name>AboutDialog</name>
+        <message>
+            <location filename="../src/dialogs/AboutDialog.cpp" line="71" />
+            <source>About %1</source>
+            <translation>Om %1</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AboutDialog.cpp" line="79" />
+            <source>Understand your history!</source>
+            <translation>Få överblick över din historik!</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AboutDialog.cpp" line="101" />
+            <source>Changelog</source>
+            <translation>Ändringslogg</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AboutDialog.cpp" line="102" />
+            <source>Acknowledgments</source>
+            <translation>Medverkande</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AboutDialog.cpp" line="104" />
+            <source>Privacy</source>
+            <translation>Integritet</translation>
+        </message>
+    </context>
+    <context>
+        <name>Account</name>
+        <message>
+            <location filename="../src/host/Account.cpp" line="127" />
+            <source>Connection failed</source>
+            <translation>Anslutningen misslyckades</translation>
+        </message>
+        <message>
+            <location filename="../src/host/Account.cpp" line="186" />
+            <source>&lt;b&gt;Note:&lt;/b&gt; Basic authentication is not supported if you have two-factor authentication enabled. Use a &lt;a href='https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/'&gt;personal access token&lt;/a&gt; in the password field instead.</source>
+            <translation>&lt;b&gt;Obs!&lt;/b&gt; Grundläggande autentisering stöds inte när tvåfaktorsautentisering är aktiverad. Använd i stället en &lt;a href='https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/'&gt;personlig åtkomsttoken&lt;/a&gt; i lösenordsfältet.</translation>
+        </message>
+        <message>
+            <location filename="../src/host/Account.cpp" line="194" />
+            <source>&lt;b&gt;Note:&lt;/b&gt; Only Basic authentication is currently supported </source>
+            <translation>&lt;b&gt;Obs!&lt;/b&gt; Endast grundläggande autentisering stöds för närvarande </translation>
+        </message>
+        <message>
+            <location filename="../src/host/Account.cpp" line="198" />
+            <source>&lt;b&gt;Note:&lt;/b&gt; Basic authentication is not supported. Use a &lt;a href='https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html'&gt;personal access token&lt;/a&gt; in the password field instead.</source>
+            <translation>&lt;b&gt;Obs!&lt;/b&gt; Grundläggande autentisering stöds inte. Använd i stället en &lt;a href='https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html'&gt;personlig åtkomsttoken&lt;/a&gt; i lösenordsfältet.</translation>
+        </message>
+        <message>
+            <location filename="../src/host/Account.cpp" line="288" />
+            <source>Authentication failed</source>
+            <translation>Autentiseringen misslyckades</translation>
+        </message>
+    </context>
+    <context>
+        <name>AccountDialog</name>
+        <message>
+            <location filename="../src/dialogs/AccountDialog.cpp" line="22" />
+            <source>Add Remote Account</source>
+            <translation>Lägg till fjärrkonto</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AccountDialog.cpp" line="64" />
+            <source>Host:</source>
+            <translation>Värd:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AccountDialog.cpp" line="65" />
+            <source>Username:</source>
+            <translation>Användarnamn:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AccountDialog.cpp" line="66" />
+            <source>Password:</source>
+            <translation>Lösenord:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AccountDialog.cpp" line="68" />
+            <source>Advanced:</source>
+            <translation>Avancerat:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AccountDialog.cpp" line="83" />
+            <source>URL:</source>
+            <translation>URL:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AccountDialog.cpp" line="114" />
+            <source>Replace?</source>
+            <translation>Ersätta?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AccountDialog.cpp" line="115" />
+            <source>An account of this type already exists.</source>
+            <translation>Ett konto av den här typen finns redan.</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AccountDialog.cpp" line="117" />
+            <source>Would you like to replace the previous account?</source>
+            <translation>Vill du ersätta det tidigare kontot?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AccountDialog.cpp" line="118" />
+            <source>Replace</source>
+            <translation>Ersätt</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AccountDialog.cpp" line="119" />
+            <source>Cancel</source>
+            <translation>Avbryt</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AccountDialog.cpp" line="135" />
+            <source>Connection Failed</source>
+            <translation>Anslutningen misslyckades</translation>
+        </message>
+    </context>
+    <context>
+        <name>AddRemoteDialog</name>
+        <message>
+            <location filename="../src/dialogs/AddRemoteDialog.cpp" line="18" />
+            <location filename="../src/dialogs/AddRemoteDialog.cpp" line="31" />
+            <source>Add Remote</source>
+            <translation>Lägg till fjärranslutning</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AddRemoteDialog.cpp" line="34" />
+            <source>Name:</source>
+            <translation>Namn:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AddRemoteDialog.cpp" line="35" />
+            <source>URL:</source>
+            <translation>URL:</translation>
+        </message>
+    </context>
+    <context>
+        <name>AdvancedButton</name>
+        <message>
+            <location filename="../src/ui/SearchField.cpp" line="43" />
+            <source>Advanced Search</source>
+            <translation>Avancerad sökning</translation>
+        </message>
+    </context>
+    <context>
+        <name>AdvancedSearchWidget</name>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="85" />
+            <source>Author:</source>
+            <translation>Författare:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="85" />
+            <source>Author name</source>
+            <translation>Författarnamn</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="86" />
+            <source>Email:</source>
+            <translation>E-post:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="86" />
+            <source>Author email</source>
+            <translation>Författarens e-postadress</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="87" />
+            <source>Message:</source>
+            <translation>Meddelande:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="87" />
+            <source>Commit message</source>
+            <translation>Incheckningsmeddelande</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="91" />
+            <source>Date:</source>
+            <translation>Datum:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="91" />
+            <source>Specific commit date</source>
+            <translation>Specifikt incheckningsdatum</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="92" />
+            <source>After:</source>
+            <translation>Efter:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="92" />
+            <source>Commits after date</source>
+            <translation>Incheckningar efter datumet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="93" />
+            <source>Before:</source>
+            <translation>Före:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="93" />
+            <source>Commits before date</source>
+            <translation>Incheckningar före datumet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="97" />
+            <source>File:</source>
+            <translation>Fil:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="97" />
+            <source>File name</source>
+            <translation>Filnamn</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="98" />
+            <source>Path:</source>
+            <translation>Sökväg:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="98" />
+            <source>File path</source>
+            <translation>Filsökväg</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="99" />
+            <source>Scope:</source>
+            <translation>Omfattning:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="99" />
+            <source>Hunk header text</source>
+            <translation>Rubriktext för diffblock</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="104" />
+            <source>Context:</source>
+            <translation>Kontext:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="104" />
+            <source>Diff context (white)</source>
+            <translation>Diffkontext (vit)</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="105" />
+            <source>Addition:</source>
+            <translation>Tillägg:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="105" />
+            <source>Diff addition (green)</source>
+            <translation>Tillägg i diff (grön)</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="106" />
+            <source>Deletion:</source>
+            <translation>Borttagning:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="106" />
+            <source>Diff deletion (red)</source>
+            <translation>Borttagning i diff (röd)</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="111" />
+            <source>Comment:</source>
+            <translation>Kommentar:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="111" />
+            <source>Source code comment</source>
+            <translation>Kommentar i källkod</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="112" />
+            <source>String:</source>
+            <translation>Sträng:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="112" />
+            <source>Source code string literal</source>
+            <translation>Strängliteral i källkod</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="113" />
+            <source>Identifier:</source>
+            <translation>Identifierare:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="113" />
+            <source>Source code identifier</source>
+            <translation>Identifierare i källkod</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="115" />
+            <source>Search</source>
+            <translation>Sök</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/AdvancedSearchWidget.cpp" line="123" />
+            <source>Return</source>
+            <translation>Retur</translation>
+        </message>
+    </context>
+    <context>
+        <name>AmendDialog</name>
+        <message>
+            <location filename="../src/dialogs/AmendDialog.cpp" line="168" />
+            <source>Author</source>
+            <translation>Författare</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AmendDialog.cpp" line="171" />
+            <source>Committer</source>
+            <translation>Incheckare</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AmendDialog.cpp" line="174" />
+            <source>Commit Message:</source>
+            <translation>Incheckningsmeddelande:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AmendDialog.cpp" line="181" />
+            <source>Amend</source>
+            <translation>Ändra senaste incheckningen</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AmendDialog.cpp" line="182" />
+            <source>Cancel</source>
+            <translation>Avbryt</translation>
+        </message>
+    </context>
+    <context>
+        <name>Application</name>
+        <message>
+            <location filename="../src/app/Application.cpp" line="496" />
+            <source>SSL Errors</source>
+            <translation>SSL-fel</translation>
+        </message>
+        <message>
+            <location filename="../src/app/Application.cpp" line="498" />
+            <source>Failed to set up SSL session. Do you want to ignore these errors?</source>
+            <translation>Det gick inte att upprätta SSL-sessionen. Vill du ignorera de här felen?</translation>
+        </message>
+    </context>
+    <context>
+        <name>AuthorCommitterDate</name>
+        <message>
+            <location filename="../src/ui/DetailView.cpp" line="178" />
+            <source>Author/Committer: </source>
+            <translation>Författare/incheckare: </translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DetailView.cpp" line="182" />
+            <source>Author: </source>
+            <translation>Författare: </translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DetailView.cpp" line="184" />
+            <source>Committer: </source>
+            <translation>Incheckare: </translation>
+        </message>
+    </context>
+    <context>
+        <name>BlameEditor</name>
+        <message>
+            <location filename="../src/ui/BlameEditor.cpp" line="102" />
+            <source>Untitled</source>
+            <translation>Namnlös</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/BlameEditor.cpp" line="116" />
+            <source>Not Tracked</source>
+            <translation>Ospårad</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/BlameEditor.cpp" line="134" />
+            <source>HEAD</source>
+            <translation>HEAD</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/BlameEditor.cpp" line="138" />
+            <source>Working Copy</source>
+            <translation>Arbetskopia</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/BlameEditor.cpp" line="180" />
+            <source>Save File</source>
+            <translation>Spara fil</translation>
+        </message>
+    </context>
+    <context>
+        <name>BlameMargin</name>
+        <message>
+            <location filename="../src/ui/BlameMargin.cpp" line="361" />
+            <source>Not Committed</source>
+            <translation>Inte incheckad</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/BlameMargin.cpp" line="364" />
+            <source>Invalid Signature</source>
+            <translation>Ogiltig signatur</translation>
+        </message>
+    </context>
+    <context>
+        <name>BranchTableModel</name>
+        <message>
+            <location filename="../src/dialogs/BranchTableModel.cpp" line="76" />
+            <source>Name</source>
+            <translation>Namn</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/BranchTableModel.cpp" line="78" />
+            <source>Upstream</source>
+            <translation>Uppströms</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/BranchTableModel.cpp" line="80" />
+            <source>Rebase</source>
+            <translation>Byt bas</translation>
+        </message>
+    </context>
+    <context>
+        <name>CheckoutDialog</name>
+        <message>
+            <location filename="../src/dialogs/CheckoutDialog.cpp" line="28" />
+            <source>Detach HEAD</source>
+            <translation>Koppla från HEAD</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CheckoutDialog.cpp" line="37" />
+            <source>References:</source>
+            <translation>Referenser:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CheckoutDialog.cpp" line="42" />
+            <source>Checkout</source>
+            <translation>Checka ut</translation>
+        </message>
+    </context>
+    <context>
+        <name>ClearButton</name>
+        <message>
+            <location filename="../src/ui/SearchField.cpp" line="68" />
+            <source>Clear</source>
+            <translation>Rensa</translation>
+        </message>
+    </context>
+    <context>
+        <name>CloneDialog</name>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="323" />
+            <source>Initialize Repository</source>
+            <translation>Initiera arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="323" />
+            <source>Clone Repository</source>
+            <translation>Klona arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="359" />
+            <source>Initialized empty repository into '%1'</source>
+            <translation>Initierade ett tomt arkiv i ”%1”</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="360" />
+            <source>Cloned repository from '%1' into '%2'</source>
+            <translation>Klonade arkivet från ”%1” till ”%2”</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="365" />
+            <source>Initialize</source>
+            <translation>Initiera</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="365" />
+            <source>Clone</source>
+            <translation>Klona</translation>
+        </message>
+    </context>
+    <context>
+        <name>ClonePage</name>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="240" />
+            <source>Clone Progress</source>
+            <translation>Kloningsförlopp</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="241" />
+            <source>The new repository will open after the clone finishes.</source>
+            <translation>Det nya arkivet öppnas när kloningen är klar.</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="260" />
+            <source>Clone</source>
+            <translation>Klona</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="269" />
+            <location filename="../src/dialogs/CloneDialog.cpp" line="271" />
+            <source>clone</source>
+            <translation>klona</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="269" />
+            <source>Clone canceled.</source>
+            <translation>Kloningen avbröts.</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="305" />
+            <source>Failed to %1 into '%2' - %3</source>
+            <translation>Kunde inte %1 till ”%2” – %3</translation>
+        </message>
+    </context>
+    <context>
+        <name>CommitDetail</name>
+        <message>
+            <location filename="../src/ui/DetailView.cpp" line="231" />
+            <source>Copy</source>
+            <translation>Kopiera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DetailView.cpp" line="374" />
+            <source>Range:</source>
+            <translation>Intervall:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DetailView.cpp" line="392" />
+            <source>Id:</source>
+            <translation>Id:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DetailView.cpp" line="407" />
+            <source>initial commit</source>
+            <translation>första incheckningen</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DetailView.cpp" line="409" />
+            <source>Parents:</source>
+            <translation>Föräldrar:</translation>
+        </message>
+    </context>
+    <context>
+        <name>CommitDialog</name>
+        <message>
+            <location filename="../src/dialogs/CommitDialog.cpp" line="29" />
+            <source>Merge commit message</source>
+            <translation>Incheckningsmeddelande för sammanfogning</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CommitDialog.cpp" line="33" />
+            <source>Stash commit message</source>
+            <translation>Incheckningsmeddelande för stash</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CommitDialog.cpp" line="37" />
+            <source>Revert commit message</source>
+            <translation>Incheckningsmeddelande för återställning</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CommitDialog.cpp" line="41" />
+            <source>Cherry-pick commit message</source>
+            <translation>Incheckningsmeddelande för cherry-pick</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CommitDialog.cpp" line="71" />
+            <source>Merge</source>
+            <translation>Sammanfoga</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CommitDialog.cpp" line="72" />
+            <location filename="../src/dialogs/CommitDialog.cpp" line="82" />
+            <location filename="../src/dialogs/CommitDialog.cpp" line="87" />
+            <source>Abort</source>
+            <translation>Avbryt</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CommitDialog.cpp" line="76" />
+            <source>Stash</source>
+            <translation>Stash</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CommitDialog.cpp" line="81" />
+            <source>Revert</source>
+            <translation>Återställ</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CommitDialog.cpp" line="86" />
+            <source>Cherry-pick</source>
+            <translation>Cherry-pick</translation>
+        </message>
+    </context>
+    <context>
+        <name>CommitEditor</name>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="259" />
+            <source>T</source>
+            <translation>T</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="283" />
+            <source>&lt;b&gt;Commit Message:&lt;/b&gt;</source>
+            <translation>&lt;b&gt;Incheckningsmeddelande:&lt;/b&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="394" />
+            <location filename="../src/ui/CommitEditor.cpp" line="420" />
+            <source>Spell Check Language</source>
+            <translation>Språk för stavningskontroll</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="395" />
+            <source>The dictionary '%1' is invalid</source>
+            <translation>Ordboken ”%1” är ogiltig</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="396" />
+            <source>Spell checking is disabled.</source>
+            <translation>Stavningskontrollen är inaktiverad.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="397" />
+            <source>The choosen dictionary '%1.dic' is not a valid hunspell dictionary.</source>
+            <translation>Den valda ordboken ”%1.dic” är inte en giltig Hunspell-ordbok.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="404" />
+            <location filename="../src/ui/CommitEditor.cpp" line="462" />
+            <source>Invalid dictionary '%1.dic'</source>
+            <translation>Ogiltig ordbok ”%1.dic”</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="426" />
+            <source>Edit User Dictionary</source>
+            <translation>Redigera användarordbok</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="483" />
+            <source>Stage All</source>
+            <translation>Lägg till alla i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="487" />
+            <source>Unstage All</source>
+            <translation>Ta bort alla från indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="490" />
+            <location filename="../src/ui/CommitEditor.cpp" line="817" />
+            <source>Commit</source>
+            <translation>Checka in</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="494" />
+            <source>Abort rebasing</source>
+            <translation>Avbryt basbyte</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="499" />
+            <source>Continue rebasing</source>
+            <translation>Fortsätt basbyte</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="504" />
+            <source>Abort Merge</source>
+            <translation>Avbryt sammanfogning</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="582" />
+            <source>%1</source>
+            <translation>%1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="584" />
+            <source>%1 and %2</source>
+            <translation>%1 och %2</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="586" />
+            <source>%1, %2, and %3</source>
+            <translation>%1, %2 och %3</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="693" />
+            <source>Merge</source>
+            <translation>Sammanfoga</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="703" />
+            <source>Revert</source>
+            <translation>Återställ</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="709" />
+            <source>Cherry-pick</source>
+            <translation>Cherry-pick</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="715" />
+            <source>Rebase</source>
+            <translation>Byt bas</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="723" />
+            <source>Abort %1</source>
+            <translation>Avbryt %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="812" />
+            <source>Commit Rebase</source>
+            <translation>Checka in basbyte</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="776" />
+            <source>Nothing staged</source>
+            <translation>Inget har lagts till i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="778" />
+            <source>%1 of %2 file staged</source>
+            <translation>%1 av %2 fil har lagts till i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="779" />
+            <source>%1 of %2 files staged</source>
+            <translation>%1 av %2 filer har lagts till i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="783" />
+            <source>%1 file partially staged</source>
+            <translation>%1 fil har delvis lagts till i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="784" />
+            <source>%1 files partially staged</source>
+            <translation>%1 filer har delvis lagts till i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="789" />
+            <source>%1 unresolved conflict</source>
+            <translation>%1 olöst konflikt</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="790" />
+            <source>%1 unresolved conflicts</source>
+            <translation>%1 olösta konflikter</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="793" />
+            <source>all conflicts resolved</source>
+            <translation>alla konflikter är lösta</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="806" />
+            <source>Commit Merge</source>
+            <translation>Checka in sammanfogning</translation>
+        </message>
+    </context>
+    <context>
+        <name>CommitList</name>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1511" />
+            <source>Remove Untracked Files</source>
+            <translation>Ta bort ospårade filer</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1526" />
+            <source>Apply</source>
+            <translation>Tillämpa</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1529" />
+            <source>Pop</source>
+            <translation>Poppa</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1531" />
+            <source>Drop</source>
+            <translation>Ta bort</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1544" />
+            <source>Unstar</source>
+            <translation>Ta bort stjärnmarkering</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1544" />
+            <source>Star</source>
+            <translation>Stjärnmärk</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1554" />
+            <source>Add Tag...</source>
+            <translation>Lägg till tagg…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1557" />
+            <source>New Branch...</source>
+            <translation>Ny gren…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1584" />
+            <source>Rename Branch</source>
+            <translation>Byt namn på gren</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1588" />
+            <source>Delete Branch</source>
+            <translation>Ta bort gren</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1593" />
+            <source>Delete Tag</source>
+            <translation>Ta bort tagg</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1597" />
+            <source>Merge...</source>
+            <translation>Sammanfoga…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1612" />
+            <source>Rebase...</source>
+            <translation>Byt bas…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1627" />
+            <source>Squash...</source>
+            <translation>Slå ihop…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1644" />
+            <source>Revert</source>
+            <translation>Återställ</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1646" />
+            <source>Cherry-pick</source>
+            <translation>Cherry-pick</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1653" />
+            <location filename="../src/ui/CommitList.cpp" line="1686" />
+            <source>Checkout %1</source>
+            <translation>Checka ut %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1655" />
+            <source>Checkout</source>
+            <translation>Checka ut</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1676" />
+            <source>Local branch is already checked out</source>
+            <translation>Den lokala grenen är redan utcheckad</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1679" />
+            <source>This is a bare repository</source>
+            <translation>Det här är ett bart arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1694" />
+            <source>Reset</source>
+            <translation>Återställ</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1695" />
+            <source>Soft</source>
+            <translation>Mjuk</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1696" />
+            <source>Mixed</source>
+            <translation>Blandad</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="1697" />
+            <source>Hard</source>
+            <translation>Hård</translation>
+        </message>
+    </context>
+    <context>
+        <name>CommitModel</name>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="331" />
+            <source>Uncommitted changes</source>
+            <translation>Oincheckade ändringar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitList.cpp" line="332" />
+            <source>Checking for uncommitted changes</source>
+            <translation>Kontrollerar oincheckade ändringar</translation>
+        </message>
+    </context>
+    <context>
+        <name>CommitToolBar</name>
+        <message>
+            <location filename="../src/ui/CommitToolBar.cpp" line="123" />
+            <source>Show All Branches</source>
+            <translation>Visa alla grenar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitToolBar.cpp" line="124" />
+            <source>Show Selected Branch</source>
+            <translation>Visa vald gren</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitToolBar.cpp" line="128" />
+            <source>Sort by Date</source>
+            <translation>Sortera efter datum</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitToolBar.cpp" line="129" />
+            <source>Sort Topologically</source>
+            <translation>Sortera topologiskt</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitToolBar.cpp" line="146" />
+            <source>Show Graph</source>
+            <translation>Visa graf</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitToolBar.cpp" line="156" />
+            <source>Show Clean Status</source>
+            <translation>Visa rent statusläge</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitToolBar.cpp" line="167" />
+            <source>Compact Mode</source>
+            <translation>Kompakt läge</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitToolBar.cpp" line="180" />
+            <source>Show Author</source>
+            <translation>Visa författare</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitToolBar.cpp" line="190" />
+            <source>Show Date</source>
+            <translation>Visa datum</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitToolBar.cpp" line="199" />
+            <source>Show Id</source>
+            <translation>Visa id</translation>
+        </message>
+    </context>
+    <context>
+        <name>ConfigDialog</name>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="744" />
+            <source>Esc</source>
+            <translation>Esc</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="768" />
+            <source>General</source>
+            <translation>Allmänt</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="776" />
+            <source>Diff</source>
+            <translation>Diff</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="784" />
+            <source>Remotes</source>
+            <translation>Fjärranslutningar</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="792" />
+            <source>Branches</source>
+            <translation>Grenar</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="800" />
+            <source>Submodules</source>
+            <translation>Delmoduler</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="807" />
+            <source>Search</source>
+            <translation>Sök</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="814" />
+            <source>Plugins</source>
+            <translation>Insticksmoduler</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="821" />
+            <source>LFS</source>
+            <translation>LFS</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="835" />
+            <source>Edit Config File...</source>
+            <translation>Redigera konfigurationsfil…</translation>
+        </message>
+    </context>
+    <context>
+        <name>DateSelectionGroupWidget</name>
+        <message>
+            <location filename="../src/dialogs/AmendDialog.cpp" line="21" />
+            <source>Datetime source</source>
+            <translation>Källa för datum och tid</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AmendDialog.cpp" line="24" />
+            <source>Current</source>
+            <translation>Aktuell</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AmendDialog.cpp" line="26" />
+            <source>Manual</source>
+            <translation>Manuell</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AmendDialog.cpp" line="28" />
+            <source>Original</source>
+            <translation>Ursprunglig</translation>
+        </message>
+    </context>
+    <context>
+        <name>DefaultWidget</name>
+        <message>
+            <location filename="../src/ui/TabWidget.cpp" line="42" />
+            <source>Clone repository</source>
+            <translation>Klona arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TabWidget.cpp" line="54" />
+            <source>Open existing repository</source>
+            <translation>Öppna befintligt arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TabWidget.cpp" line="58" />
+            <source>Open Repository</source>
+            <translation>Öppna arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TabWidget.cpp" line="68" />
+            <source>Initialize new repository</source>
+            <translation>Initiera nytt arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TabWidget.cpp" line="88" />
+            <source>Add %1 account</source>
+            <translation>Lägg till %1-konto</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TabWidget.cpp" line="103" />
+            <source>Contact us for support</source>
+            <translation>Kontakta oss för support</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeleteBranchDialog</name>
+        <message>
+            <location filename="../src/dialogs/DeleteBranchDialog.cpp" line="31" />
+            <source>Are you sure you want to delete local branch '%1'?</source>
+            <translation>Är du säker på att du vill ta bort den lokala grenen ”%1”?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteBranchDialog.cpp" line="32" />
+            <source>Delete Branch?</source>
+            <translation>Ta bort grenen?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteBranchDialog.cpp" line="38" />
+            <source>Also delete the upstream branch from its remote</source>
+            <translation>Ta även bort uppströmsgrenen från fjärranslutningen</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteBranchDialog.cpp" line="42" />
+            <source>Delete</source>
+            <translation>Ta bort</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteBranchDialog.cpp" line="54" />
+            <source>delete '%1' from '%2'</source>
+            <translation>ta bort ”%1” från ”%2”</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteBranchDialog.cpp" line="55" />
+            <source>Push</source>
+            <translation>Skicka</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteBranchDialog.cpp" line="72" />
+            <source>Push canceled.</source>
+            <translation>Sändningen avbröts.</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteBranchDialog.cpp" line="75" />
+            <source>Unable to push to %1 - %2</source>
+            <translation>Kunde inte skicka till %1 – %2</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteBranchDialog.cpp" line="89" />
+            <source>The branch is not fully merged. Deleting it may cause some commits to be lost.</source>
+            <translation>Grenen har inte sammanfogats helt. Om du tar bort den kan vissa incheckningar gå förlorade.</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeleteTagDialog</name>
+        <message>
+            <location filename="../src/dialogs/DeleteTagDialog.cpp" line="24" />
+            <source>Are you sure you want to delete tag '%1'?</source>
+            <translation>Är du säker på att du vill ta bort taggen ”%1”?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteTagDialog.cpp" line="25" />
+            <source>Delete Tag?</source>
+            <translation>Ta bort taggen?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteTagDialog.cpp" line="32" />
+            <source>Also delete the upstream tag from %1</source>
+            <translation>Ta även bort uppströmstaggen från %1</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteTagDialog.cpp" line="36" />
+            <source>Delete</source>
+            <translation>Ta bort</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteTagDialog.cpp" line="45" />
+            <source>delete '%1' from '%2'</source>
+            <translation>ta bort ”%1” från ”%2”</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteTagDialog.cpp" line="46" />
+            <source>Push</source>
+            <translation>Skicka</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteTagDialog.cpp" line="64" />
+            <source>Push canceled.</source>
+            <translation>Sändningen avbröts.</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteTagDialog.cpp" line="67" />
+            <source>Unable to push to %1 - %2</source>
+            <translation>Kunde inte skicka till %1 – %2</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteTagDialog.cpp" line="76" />
+            <source>Delete Tag</source>
+            <translation>Ta bort tagg</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DeleteTagDialog.cpp" line="77" />
+            <source>delete tag</source>
+            <translation>ta bort tagg</translation>
+        </message>
+    </context>
+    <context>
+        <name>DetailView</name>
+        <message>
+            <location filename="../src/ui/DetailView.cpp" line="644" />
+            <location filename="../src/ui/DetailView.cpp" line="673" />
+            <source>Author:</source>
+            <translation>Författare:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DetailView.cpp" line="658" />
+            <source>reset</source>
+            <translation>återställ</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DetailView.cpp" line="669" />
+            <source>Here you can set the author used for committing
+These settings will not be saved permanently</source>
+            <translation>Här kan du ange författaren som används vid incheckning
+De här inställningarna sparas inte permanent</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DetailView.cpp" line="676" />
+            <source>Email:</source>
+            <translation>E-post:</translation>
+        </message>
+    </context>
+    <context>
+        <name>DiffPanel</name>
+        <message>
+            <location filename="../src/dialogs/DiffPanel.cpp" line="31" />
+            <source>lines</source>
+            <translation>rader</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DiffPanel.cpp" line="49" />
+            <source>System Locale</source>
+            <translation>Systemspråk</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DiffPanel.cpp" line="73" />
+            <source>Wrap lines</source>
+            <translation>Radbryt rader</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DiffPanel.cpp" line="80" />
+            <source>Context lines:</source>
+            <translation>Kontextrader:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DiffPanel.cpp" line="81" />
+            <source>Wrap lines:</source>
+            <translation>Radbryt rader:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DiffPanel.cpp" line="82" />
+            <source>Character Encoding:</source>
+            <translation>Teckenkodning:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DiffPanel.cpp" line="91" />
+            <source>Ignore Whitespace (-w)</source>
+            <translation>Ignorera blanksteg (-w)</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DiffPanel.cpp" line="99" />
+            <source>Added files</source>
+            <translation>Tillagda filer</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DiffPanel.cpp" line="106" />
+            <source>Deleted files</source>
+            <translation>Borttagna filer</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DiffPanel.cpp" line="113" />
+            <source>Whitespace:</source>
+            <translation>Blanksteg:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/DiffPanel.cpp" line="114" />
+            <source>Auto Collapse:</source>
+            <translation>Fäll ihop automatiskt:</translation>
+        </message>
+    </context>
+    <context>
+        <name>DiffTool</name>
+        <message>
+            <location filename="../src/tools/DiffTool.cpp" line="28" />
+            <source>External Diff</source>
+            <translation>Extern diff</translation>
+        </message>
+    </context>
+    <context>
+        <name>DiffTreeModel</name>
+        <message>
+            <location filename="../src/ui/DiffTreeModel.cpp" line="280" />
+            <source>Submodule</source>
+            <translation>Delmodul</translation>
+        </message>
+    </context>
+    <context>
+        <name>DiffView</name>
+        <message>
+            <location filename="../src/ui/DiffView/DiffView.cpp" line="145" />
+            <source>Add new file</source>
+            <translation>Lägg till ny fil</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/DiffView.cpp" line="159" />
+            <source>Or drag files here to copy into the repository</source>
+            <translation>Eller dra filer hit för att kopiera dem till arkivet</translation>
+        </message>
+    </context>
+    <context>
+        <name>DoubleTreeWidget</name>
+        <message>
+            <location filename="../src/ui/DoubleTreeWidget.cpp" line="90" />
+            <source>Blame</source>
+            <translation>Blame</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DoubleTreeWidget.cpp" line="91" />
+            <source>Show Blame Editor</source>
+            <translation>Visa blame-redigerare</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DoubleTreeWidget.cpp" line="92" />
+            <source>Diff</source>
+            <translation>Diff</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DoubleTreeWidget.cpp" line="93" />
+            <source>Show Diff View</source>
+            <translation>Visa diffvy</translation>
+        </message>
+    </context>
+    <context>
+        <name>DownloadDialog</name>
+        <message>
+            <location filename="../src/update/DownloadDialog.cpp" line="25" />
+            <source>Update %1</source>
+            <translation>Uppdatera %1</translation>
+        </message>
+        <message>
+            <location filename="../src/update/DownloadDialog.cpp" line="34" />
+            <source>Downloading %1...</source>
+            <translation>Hämtar %1…</translation>
+        </message>
+        <message>
+            <location filename="../src/update/DownloadDialog.cpp" line="60" />
+            <source>Download Complete!</source>
+            <translation>Hämtningen är klar!</translation>
+        </message>
+        <message>
+            <location filename="../src/update/DownloadDialog.cpp" line="61" />
+            <source>Install and Restart</source>
+            <translation>Installera och starta om</translation>
+        </message>
+    </context>
+    <context>
+        <name>EditButton</name>
+        <message>
+            <location filename="../src/ui/DiffView/EditButton.cpp" line="13" />
+            <source>Edit Working Copy</source>
+            <translation>Redigera arbetskopia</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/EditButton.cpp" line="14" />
+            <source>Edit New Revision</source>
+            <translation>Redigera ny version</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/EditButton.cpp" line="15" />
+            <source>Edit Old Revision</source>
+            <translation>Redigera gammal version</translation>
+        </message>
+    </context>
+    <context>
+        <name>EditTool</name>
+        <message>
+            <location filename="../src/tools/EditTool.cpp" line="26" />
+            <source>Edit in External Editor</source>
+            <translation>Redigera i extern redigerare</translation>
+        </message>
+    </context>
+    <context>
+        <name>EditorPanel</name>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="664" />
+            <source>Show whitespace</source>
+            <translation>Visa blanksteg</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="673" />
+            <source>Tabs</source>
+            <translation>Tabbar</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="674" />
+            <source>Spaces</source>
+            <translation>Mellanslag</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="695" />
+            <source>Show heat map</source>
+            <translation>Visa värmekarta</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="704" />
+            <source>Font:</source>
+            <translation>Typsnitt:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="705" />
+            <source>Font size:</source>
+            <translation>Teckenstorlek:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="706" />
+            <source>Whitespace:</source>
+            <translation>Blanksteg:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="707" />
+            <source>Indent using:</source>
+            <translation>Indrag med:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="708" />
+            <source>Indent width:</source>
+            <translation>Indragsbredd:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="709" />
+            <source>Tab width:</source>
+            <translation>Tabbbredd:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="710" />
+            <source>Blame margin:</source>
+            <translation>Blame-marginal:</translation>
+        </message>
+    </context>
+    <context>
+        <name>EditorWindow</name>
+        <message>
+            <location filename="../src/ui/EditorWindow.cpp" line="89" />
+            <source>'%1' has been modified. Do you want to save your changes?</source>
+            <translation>”%1” har ändrats. Vill du spara dina ändringar?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/EditorWindow.cpp" line="91" />
+            <source>Save Changes?</source>
+            <translation>Spara ändringarna?</translation>
+        </message>
+    </context>
+    <context>
+        <name>ExternalToolsDialog</name>
+        <message>
+            <location filename="../src/dialogs/ExternalToolsDialog.cpp" line="24" />
+            <source>Configure External Tools</source>
+            <translation>Konfigurera externa verktyg</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ExternalToolsDialog.cpp" line="40" />
+            <source>Detected Tools</source>
+            <translation>Upptäckta verktyg</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ExternalToolsDialog.cpp" line="64" />
+            <source>User Defined Tools</source>
+            <translation>Användardefinierade verktyg</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ExternalToolsDialog.cpp" line="83" />
+            <source>Select Executable</source>
+            <translation>Välj körbar fil</translation>
+        </message>
+    </context>
+    <context>
+        <name>ExternalToolsModel</name>
+        <message>
+            <location filename="../src/dialogs/ExternalToolsModel.cpp" line="56" />
+            <source>Name</source>
+            <translation>Namn</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ExternalToolsModel.cpp" line="58" />
+            <source>Command</source>
+            <translation>Kommando</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ExternalToolsModel.cpp" line="60" />
+            <source>Arguments</source>
+            <translation>Argument</translation>
+        </message>
+    </context>
+    <context>
+        <name>FileContextMenu</name>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="36" />
+            <source>Revision Not Found</source>
+            <translation>Versionen hittades inte</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="38" />
+            <source>The selected file doesn't have a %1 revision.</source>
+            <translation>Den valda filen har ingen %1-version.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="135" />
+            <source>Bash Not Found</source>
+            <translation>Bash hittades inte</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="136" />
+            <source>Bash was not found on your PATH.</source>
+            <translation>Bash hittades inte i din PATH.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="140" />
+            <source>Bash is required to execute external tools.</source>
+            <translation>Bash krävs för att köra externa verktyg.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="247" />
+            <source>Stage</source>
+            <translation>Lägg till i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="251" />
+            <source>Unstage</source>
+            <translation>Ta bort från indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="314" />
+            <location filename="../src/ui/FileContextMenu.cpp" line="335" />
+            <source>Discard Changes</source>
+            <translation>Förkasta ändringar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="316" />
+            <source>Discard Changes?</source>
+            <translation>Förkasta ändringarna?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="317" />
+            <source>Are you sure you want to discard changes in the selected files?</source>
+            <translation>Är du säker på att du vill förkasta ändringarna i de valda filerna?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="321" />
+            <source>This action cannot be undone.</source>
+            <translation>Den här åtgärden kan inte ångras.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="324" />
+            <source>(Submodule)</source>
+            <translation>(Delmodul)</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="343" />
+            <source>%1 files</source>
+            <translation>%1 filer</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="344" />
+            <source>Discard</source>
+            <translation>Förkasta</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="345" />
+            <source>discard</source>
+            <translation>förkasta</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="357" />
+            <source>Remove Untracked Files</source>
+            <translation>Ta bort ospårade filer</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="363" />
+            <source>Ignore</source>
+            <translation>Ignorera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="386" />
+            <source>Checkout</source>
+            <translation>Checka ut</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="176" />
+            <source>Unlock</source>
+            <translation>Lås upp</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="176" />
+            <source>Lock</source>
+            <translation>Lås</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="190" />
+            <source>Copy File Name</source>
+            <translation>Kopiera filnamn</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="201" />
+            <source>Filter History</source>
+            <translation>Filtrera historik</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="204" />
+            <source>Navigate to</source>
+            <translation>Navigera till</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="205" />
+            <source>Next Revision</source>
+            <translation>Nästa version</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="210" />
+            <source>next</source>
+            <translation>nästa</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="214" />
+            <source>Previous Revision</source>
+            <translation>Föregående version</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="219" />
+            <source>previous</source>
+            <translation>föregående</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="229" />
+            <source>Unset Executable</source>
+            <translation>Ta bort körbar-markering</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="229" />
+            <source>Set Executable</source>
+            <translation>Markera som körbar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="393" />
+            <source>Save Selected Version as ...</source>
+            <translation>Spara vald version som …</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="397" />
+            <source>Select new file directory</source>
+            <translation>Välj ny filmapp</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="401" />
+            <source>Saving files</source>
+            <translation>Sparar filer</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="402" />
+            <source>Saving files of selected version to disk</source>
+            <translation>Sparar filer från vald version på disken</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="405" />
+            <source>Save file </source>
+            <translation>Spara fil </translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="408" />
+            <source>Invalid Blob</source>
+            <translation>Ogiltigt blob-objekt</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="415" />
+            <source>Open this version</source>
+            <translation>Öppna den här versionen</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="421" />
+            <source>Opening file</source>
+            <translation>Öppnar fil</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="421" />
+            <source>Open </source>
+            <translation>Öppna </translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="427" />
+            <source>open file</source>
+            <translation>öppna fil</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="427" />
+            <source>Blob is invalid.</source>
+            <translation>Blob-objektet är ogiltigt.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="453" />
+            <location filename="../src/ui/FileContextMenu.cpp" line="456" />
+            <source>Unable to checkout bare repositories</source>
+            <translation>Det går inte att checka ut nakna arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="459" />
+            <source>Unable to open files from bare repository</source>
+            <translation>Det går inte att öppna filer från ett naket arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="469" />
+            <source>The file is already in the current working directory</source>
+            <translation>Filen finns redan i den aktuella arbetsmappen</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="525" />
+            <source>edit</source>
+            <translation>redigera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="529" />
+            <source>diff</source>
+            <translation>diff</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="533" />
+            <source>merge</source>
+            <translation>sammanfoga</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="537" />
+            <source>External Tool Not Found</source>
+            <translation>Externt verktyg hittades inte</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FileContextMenu.cpp" line="538" />
+            <source>Failed to execute external %1 tool.</source>
+            <translation>Kunde inte köra det externa verktyget %1.</translation>
+        </message>
+    </context>
+    <context>
+        <name>FileWidget</name>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="71" />
+            <source>LFS</source>
+            <translation>LFS</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="77" />
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="90" />
+            <source>Unlock</source>
+            <translation>Lås upp</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="78" />
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="91" />
+            <source>Lock</source>
+            <translation>Lås</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="95" />
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="423" />
+            <source>Show Object</source>
+            <translation>Visa objekt</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="104" />
+            <source>Edit File</source>
+            <translation>Redigera fil</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="110" />
+            <source>Discard File</source>
+            <translation>Förkasta fil</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="769" />
+            <source>Directory</source>
+            <translation>Mapp</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="770" />
+            <source>File</source>
+            <translation>Fil</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="771" />
+            <source>Remove %1?</source>
+            <translation>Ta bort %1?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="772" />
+            <source>Discard Changes?</source>
+            <translation>Förkasta ändringarna?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="774" />
+            <source>Are you sure you want to remove '%1'?</source>
+            <translation>Är du säker på att du vill ta bort ”%1”?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="775" />
+            <source>Are you sure you want to discard all changes in '%1'?</source>
+            <translation>Är du säker på att du vill förkasta alla ändringar i ”%1”?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="780" />
+            <source>This action cannot be undone.</source>
+            <translation>Den här åtgärden kan inte ångras.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="782" />
+            <source>Remove %1</source>
+            <translation>Ta bort %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="783" />
+            <source>Discard Changes</source>
+            <translation>Förkasta ändringar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/DiffView.cpp" line="482" />
+            <source>Discard</source>
+            <translation>Förkasta</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/DiffView.cpp" line="483" />
+            <source>discard</source>
+            <translation>förkasta</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="117" />
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="121" />
+            <source>Collapse File</source>
+            <translation>Fäll ihop fil</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="118" />
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="122" />
+            <source>Expand File</source>
+            <translation>Expandera fil</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="422" />
+            <source>Show Pointer</source>
+            <translation>Visa pekare</translation>
+        </message>
+    </context>
+    <context>
+        <name>FindWidget</name>
+        <message>
+            <location filename="../src/ui/FindWidget.cpp" line="102" />
+            <source>Search</source>
+            <translation>Sök</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FindWidget.cpp" line="107" />
+            <source>Done</source>
+            <translation>Klar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FindWidget.cpp" line="135" />
+            <source>Esc</source>
+            <translation>Esc</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FindWidget.cpp" line="156" />
+            <source>Not found</source>
+            <translation>Hittades inte</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FindWidget.cpp" line="160" />
+            <source>%1 match</source>
+            <translation>%1 träff</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/FindWidget.cpp" line="164" />
+            <source>%1 matches</source>
+            <translation>%1 träffar</translation>
+        </message>
+    </context>
+    <context>
+        <name>GeneralPanel</name>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="94" />
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="76" />
+            <source>Fetch every</source>
+            <translation>Hämta var</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="101" />
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="83" />
+            <source>minutes</source>
+            <translation>minuter</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="104" />
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="86" />
+            <source>Push after each commit</source>
+            <translation>Skicka efter varje incheckning</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="107" />
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="89" />
+            <source>Prune when fetching</source>
+            <translation>Rensa vid hämtning</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="108" />
+            <source>No translation</source>
+            <translation>Ingen översättning</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="118" />
+            <source>Store credentials in secure storage</source>
+            <translation>Lagra autentiseringsuppgifter i säker lagring</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="106" />
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="88" />
+            <source>Update submodules after pull and clone</source>
+            <translation>Uppdatera delmoduler efter hämtning och kloning</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="122" />
+            <source>&lt;a href='view'&gt;View privacy policy&lt;/a&gt;</source>
+            <translation>&lt;a href='view'&gt;Visa integritetspolicy&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="127" />
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="92" />
+            <source>User name:</source>
+            <translation>Användarnamn:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="128" />
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="93" />
+            <source>User email:</source>
+            <translation>Användarens e-postadress:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="129" />
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="94" />
+            <source>Automatic actions:</source>
+            <translation>Automatiska åtgärder:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="133" />
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="134" />
+            <source>Language:</source>
+            <translation>Språk:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="135" />
+            <source>Credentials:</source>
+            <translation>Autentiseringsuppgifter:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="136" />
+            <source>Credential store type:</source>
+            <translation>Typ av lagring för autentiseringsuppgifter:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="140" />
+            <source>Only allow a single running instance</source>
+            <translation>Tillåt endast en körande instans</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="143" />
+            <source>Single instance:</source>
+            <translation>En instans:</translation>
+        </message>
+    </context>
+    <context>
+        <name>GitLab</name>
+        <message>
+            <location filename="../src/host/GitLab.cpp" line="97" />
+            <source>Authentication failed</source>
+            <translation>Autentiseringen misslyckades</translation>
+        </message>
+    </context>
+    <context>
+        <name>Header</name>
+        <message>
+            <location filename="../src/ui/ReferenceView.cpp" line="81" />
+            <source>Filter %1</source>
+            <translation>Filtrera %1</translation>
+        </message>
+    </context>
+    <context>
+        <name>HostModel</name>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="282" />
+            <source>Connecting</source>
+            <translation>Ansluter</translation>
+        </message>
+    </context>
+    <context>
+        <name>HotkeyModel</name>
+        <message>
+            <location filename="../src/dialogs/HotkeysPanel.cpp" line="266" />
+            <source>Action</source>
+            <translation>Åtgärd</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/HotkeysPanel.cpp" line="269" />
+            <source>Keys</source>
+            <translation>Tangenter</translation>
+        </message>
+    </context>
+    <context>
+        <name>HunkWidget</name>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="66" />
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="129" />
+            <source>Save</source>
+            <translation>Spara</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="70" />
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="133" />
+            <source>Undo</source>
+            <translation>Ångra</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="82" />
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="211" />
+            <source>Use Ours</source>
+            <translation>Använd vår version</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="94" />
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="212" />
+            <source>Use Theirs</source>
+            <translation>Använd deras version</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="104" />
+            <source>Edit Hunk</source>
+            <translation>Redigera diffblock</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="110" />
+            <source>Discard Hunk</source>
+            <translation>Förkasta diffblock</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="511" />
+            <source>Discard selected lines?</source>
+            <translation>Förkasta valda rader?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="515" />
+            <source>Are you sure you want to discard the changes in hunk from line %1 to %2 in '%3'?</source>
+            <translation>Är du säker på att du vill förkasta ändringarna i diffblocket från rad %1 till %2 i ”%3”?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="527" />
+            <source>Discard selected lines</source>
+            <translation>Förkasta valda rader</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="514" />
+            <source>Are you sure you want to remove '%1'?</source>
+            <translation>Är du säker på att du vill ta bort ”%1”?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="524" />
+            <source>This action cannot be undone.</source>
+            <translation>Den här åtgärden kan inte ångras.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="117" />
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="120" />
+            <source>Collapse Hunk</source>
+            <translation>Fäll ihop diffblock</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="118" />
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="121" />
+            <source>Expand Hunk</source>
+            <translation>Expandera diffblock</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="342" />
+            <source>Esc</source>
+            <translation>Esc</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="369" />
+            <source>Fix</source>
+            <translation>Åtgärda</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="422" />
+            <source>Edit</source>
+            <translation>Redigera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/HunkWidget.cpp" line="35" />
+            <source>No newline at end of file</source>
+            <translation>Ingen nyrad i slutet av filen</translation>
+        </message>
+    </context>
+    <context>
+        <name>IgnoreDialog</name>
+        <message>
+            <location filename="../src/ui/IgnoreDialog.cpp" line="10" />
+            <source>Ignore Pattern</source>
+            <translation>Ignorera mönster</translation>
+        </message>
+    </context>
+    <context>
+        <name>Images</name>
+        <message>
+            <location filename="../src/ui/DiffView/Images.cpp" line="128" />
+            <source>&lt;b&gt;Size:&lt;/b&gt; %1</source>
+            <translation>&lt;b&gt;Storlek:&lt;/b&gt; %1</translation>
+        </message>
+    </context>
+    <context>
+        <name>InfoBox</name>
+        <message>
+            <location filename="../src/dialogs/AmendDialog.cpp" line="76" />
+            <source>Name:</source>
+            <translation>Namn:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AmendDialog.cpp" line="83" />
+            <source>Email:</source>
+            <translation>E-post:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/AmendDialog.cpp" line="92" />
+            <source>Commit date:</source>
+            <translation>Incheckningsdatum:</translation>
+        </message>
+    </context>
+    <context>
+        <name>KeybindDialog</name>
+        <message>
+            <location filename="../src/dialogs/HotkeysPanel.cpp" line="333" />
+            <source>The selected key is the same for the following actions:
+%1</source>
+            <translation>Den valda tangenten är samma för följande åtgärder:
+%1</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/HotkeysPanel.cpp" line="339" />
+            <source>Please press the desired hotkey</source>
+            <translation>Tryck på önskat kortkommando</translation>
+        </message>
+    </context>
+    <context>
+        <name>LfsPanel</name>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="469" />
+            <source>Initialize LFS</source>
+            <translation>Initiera LFS</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="518" />
+            <source>Specify a glob pattern for tracking large files.
+
+Generally, large files are greater than 500kB, change frequently,
+and do not compress well with git. This includes binary or video
+files which are already highly compressed.
+
+Examples
+*.png
+*.[pP][nN][gG]
+/images/*
+</source>
+            <translation>Ange ett globmönster för spårning av stora filer.
+
+Stora filer är vanligtvis större än 500 kB, ändras ofta
+och komprimeras dåligt med Git. Det gäller binära filer och videofiler
+som redan är hårt komprimerade.
+
+Exempel
+*.png
+*.[pP][nN][gG]
+/images/*
+</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="533" />
+            <source>Pattern:</source>
+            <translation>Mönster:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="538" />
+            <source>Track</source>
+            <translation>Spåra</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="623" />
+            <source>days</source>
+            <translation>dagar</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="628" />
+            <source>Fetch LFS objects from all references for the past</source>
+            <translation>Hämta LFS-objekt från alla referenser för de senaste</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="650" />
+            <source>reference days or</source>
+            <translation>referensdagarna eller</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="669" />
+            <source>commit days</source>
+            <translation>incheckningsdagarna</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="673" />
+            <source>View Environment</source>
+            <translation>Visa miljö</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="678" />
+            <source>git-lfs env (read only)</source>
+            <translation>git-lfs env (skrivskyddat)</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="694" />
+            <source>Deinitialize LFS</source>
+            <translation>Avinitiera LFS</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="696" />
+            <source>Deinitialize LFS?</source>
+            <translation>Avinitiera LFS?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="698" />
+            <source>Are you sure you want uninstall LFS from this repository?</source>
+            <translation>Är du säker på att du vill avinstallera LFS från det här arkivet?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="704" />
+            <source>Deinitialize</source>
+            <translation>Avinitiera</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="715" />
+            <source>Server URL:</source>
+            <translation>Server-URL:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="716" />
+            <source>Prune Offset:</source>
+            <translation>Rensningsförskjutning:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="717" />
+            <source>Fetch Recent:</source>
+            <translation>Hämta senaste:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="720" />
+            <source>Advanced:</source>
+            <translation>Avancerat:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="724" />
+            <source>Included patterns:</source>
+            <translation>Inkluderade mönster:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="726" />
+            <source>Excluded patterns:</source>
+            <translation>Exkluderade mönster:</translation>
+        </message>
+    </context>
+    <context>
+        <name>Location</name>
+        <message>
+            <location filename="../src/ui/Location.cpp" line="22" />
+            <source>%1 | %2</source>
+            <translation>%1 | %2</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/Location.cpp" line="25" />
+            <source>NC</source>
+            <translation>NC</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/Location.cpp" line="25" />
+            <source>Not Committed</source>
+            <translation>Inte incheckad</translation>
+        </message>
+    </context>
+    <context>
+        <name>LocationPage</name>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="132" />
+            <source>Repository Location</source>
+            <translation>Arkivplats</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="133" />
+            <source>Choose the name and location of the new repository. A new directory will be created if it doesn't already exist.</source>
+            <translation>Välj namn och plats för det nya arkivet. En ny mapp skapas om den inte redan finns.</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="136" />
+            <source>Initialize</source>
+            <translation>Initiera</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="136" />
+            <source>Clone</source>
+            <translation>Klona</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="147" />
+            <source>...</source>
+            <translation>…</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="149" />
+            <source>Choose Directory</source>
+            <translation>Välj mapp</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="172" />
+            <source>Name:</source>
+            <translation>Namn:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="173" />
+            <source>Directory:</source>
+            <translation>Mapp:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="174" />
+            <source>Advanced:</source>
+            <translation>Avancerat:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="176" />
+            <source>Create a bare repository</source>
+            <translation>Skapa ett naket arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="218" />
+            <source>The new repository will be created at:&lt;p style='text-indent: 12px'&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
+            <translation>Det nya arkivet skapas på:&lt;p style='text-indent: 12px'&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</translation>
+        </message>
+    </context>
+    <context>
+        <name>LogView</name>
+        <message>
+            <location filename="../src/log/LogView.cpp" line="50" />
+            <source>Copy</source>
+            <translation>Kopiera</translation>
+        </message>
+    </context>
+    <context>
+        <name>MainWindow</name>
+        <message>
+            <location filename="../src/ui/MainWindow.cpp" line="471" />
+            <source>Invalid Git Repository</source>
+            <translation>Ogiltigt Git-arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MainWindow.cpp" line="472" />
+            <source>%1 does not contain a valid git repository.</source>
+            <translation>%1 innehåller inte ett giltigt Git-arkiv.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MainWindow.cpp" line="536" />
+            <location filename="../src/ui/MainWindow.cpp" line="554" />
+            <source>%1 - %2</source>
+            <translation>%1 – %2</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MainWindow.cpp" line="548" />
+            <source>ahead: %1</source>
+            <translation>före: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MainWindow.cpp" line="550" />
+            <source>behind: %1</source>
+            <translation>efter: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MainWindow.cpp" line="552" />
+            <source>up-to-date</source>
+            <translation>uppdaterad</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MainWindow.cpp" line="553" />
+            <location filename="../src/ui/MainWindow.cpp" line="590" />
+            <source>%1 (%2)</source>
+            <translation>%1 (%2)</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MainWindow.cpp" line="562" />
+            <source>MERGING</source>
+            <translation>SAMMANFOGAR</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MainWindow.cpp" line="567" />
+            <source>REVERTING</source>
+            <translation>ÅTERSTÄLLER</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MainWindow.cpp" line="572" />
+            <source>CHERRY-PICKING</source>
+            <translation>CHERRY-PICKAR</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MainWindow.cpp" line="581" />
+            <source>REBASING</source>
+            <translation>BYTER BAS</translation>
+        </message>
+    </context>
+    <context>
+        <name>MenuBar</name>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="259" />
+            <source>File</source>
+            <translation>Fil</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="261" />
+            <source>New File</source>
+            <translation>Ny fil</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="275" />
+            <source>New Window</source>
+            <translation>Nytt fönster</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="279" />
+            <source>Clone Repository...</source>
+            <translation>Klona arkiv…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="284" />
+            <source>Initialize New Repository...</source>
+            <translation>Initiera nytt arkiv…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="291" />
+            <source>Open Repository...</source>
+            <translation>Öppna arkiv…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="296" />
+            <source>Open Repository</source>
+            <translation>Öppna arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="303" />
+            <source>Open Recent</source>
+            <translation>Öppna senaste</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="317" />
+            <source>Close</source>
+            <translation>Stäng</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="334" />
+            <source>Save</source>
+            <translation>Spara</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="343" />
+            <source>Exit</source>
+            <translation>Avsluta</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="350" />
+            <source>Edit</source>
+            <translation>Redigera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="352" />
+            <source>Undo</source>
+            <translation>Ångra</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="365" />
+            <source>Redo</source>
+            <translation>Gör om</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="380" />
+            <source>Cut</source>
+            <translation>Klipp ut</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="393" />
+            <source>Copy</source>
+            <translation>Kopiera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="408" />
+            <source>Paste</source>
+            <translation>Klistra in</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="421" />
+            <source>Select All</source>
+            <translation>Markera alla</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="436" />
+            <source>Find...</source>
+            <translation>Sök…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="448" />
+            <source>Find Next</source>
+            <translation>Sök nästa</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="459" />
+            <source>Find Previous</source>
+            <translation>Sök föregående</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="470" />
+            <source>Use Selection for Find</source>
+            <translation>Använd markering för sökning</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="1023" />
+            <source>Show Double Tree View</source>
+            <translation>Visa dubbel trädvy</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="487" />
+            <source>View</source>
+            <translation>Visa</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="489" />
+            <source>Refresh</source>
+            <translation>Uppdatera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="495" />
+            <location filename="../src/ui/MenuBar.cpp" line="1021" />
+            <source>Show Log</source>
+            <translation>Visa logg</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="502" />
+            <source>Normal</source>
+            <translation>Normal</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="502" />
+            <source>Maximize</source>
+            <translation>Maximera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="521" />
+            <location filename="../src/ui/MenuBar.cpp" line="1022" />
+            <source>Show Tree View</source>
+            <translation>Visa trädvy</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="529" />
+            <source>Hide Menu Bar</source>
+            <translation>Dölj menyrad</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="537" />
+            <source>Repository</source>
+            <translation>Arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="539" />
+            <source>Configure Repository...</source>
+            <translation>Konfigurera arkiv…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="546" />
+            <source>Stage All</source>
+            <translation>Lägg till alla i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="550" />
+            <source>Unstage All</source>
+            <translation>Ta bort alla från indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="556" />
+            <source>Commit</source>
+            <translation>Checka in</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="560" />
+            <source>Amend Commit</source>
+            <translation>Ändra senaste incheckningen</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="566" />
+            <source>Git LFS</source>
+            <translation>Git LFS</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="567" />
+            <source>Remove all locks</source>
+            <translation>Ta bort alla lås</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="575" />
+            <source>Initialize</source>
+            <translation>Initiera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="581" />
+            <source>Remote</source>
+            <translation>Fjärranslutning</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="583" />
+            <source>Configure Remotes...</source>
+            <translation>Konfigurera fjärranslutningar…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="591" />
+            <source>Fetch</source>
+            <translation>Hämta</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="595" />
+            <source>Fetch All</source>
+            <translation>Hämta alla</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="599" />
+            <source>Fetch From...</source>
+            <translation>Hämta från…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="608" />
+            <source>Pull</source>
+            <translation>Hämta och sammanfoga</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="612" />
+            <source>Pull From...</source>
+            <translation>Hämta och sammanfoga från…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="621" />
+            <source>Push</source>
+            <translation>Skicka</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="625" />
+            <source>Push To...</source>
+            <translation>Skicka till…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="633" />
+            <source>Branch</source>
+            <translation>Gren</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="635" />
+            <source>Configure Branches...</source>
+            <translation>Konfigurera grenar…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="641" />
+            <source>New Branch...</source>
+            <translation>Ny gren…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="646" />
+            <source>Rename Branch</source>
+            <translation>Byt namn på gren</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="654" />
+            <source>Checkout Current</source>
+            <translation>Checka ut aktuell</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="665" />
+            <source>Checkout...</source>
+            <translation>Checka ut…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="672" />
+            <source>Merge...</source>
+            <translation>Sammanfoga…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="684" />
+            <source>Rebase...</source>
+            <translation>Byt bas…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="696" />
+            <source>Squash...</source>
+            <translation>Slå ihop…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="710" />
+            <source>Abort Merge</source>
+            <translation>Avbryt sammanfogning</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="715" />
+            <source>Submodule</source>
+            <translation>Delmodul</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="717" />
+            <source>Configure Submodules...</source>
+            <translation>Konfigurera delmoduler…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="725" />
+            <source>Update All</source>
+            <translation>Uppdatera alla</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="730" />
+            <source>Update...</source>
+            <translation>Uppdatera…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="746" />
+            <source>Open</source>
+            <translation>Öppna</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="764" />
+            <source>Stash</source>
+            <translation>Stash</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="766" />
+            <source>Show Stashes</source>
+            <translation>Visa stashar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="775" />
+            <source>Stash...</source>
+            <translation>Stash…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="779" />
+            <source>Pop Stash</source>
+            <translation>Poppa stash</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="784" />
+            <source>History</source>
+            <translation>Historik</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="786" />
+            <source>Back</source>
+            <translation>Bakåt</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="791" />
+            <source>Forward</source>
+            <translation>Framåt</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="797" />
+            <source>Window</source>
+            <translation>Fönster</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="798" />
+            <source>Show Previous Tab</source>
+            <translation>Visa föregående flik</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="807" />
+            <source>Show Next Tab</source>
+            <translation>Visa nästa flik</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="818" />
+            <source>Show Repository Chooser...</source>
+            <translation>Visa arkivväljare…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="823" />
+            <source>Tools</source>
+            <translation>Verktyg</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="824" />
+            <source>Options...</source>
+            <translation>Alternativ…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="830" />
+            <source>Help</source>
+            <translation>Hjälp</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="832" />
+            <source>About %1</source>
+            <translation>Om %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="837" />
+            <source>Check For Updates...</source>
+            <translation>Sök efter uppdateringar…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="841" />
+            <source>Plugin Documentation...</source>
+            <translation>Dokumentation för insticksmoduler…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="847" />
+            <source>Support us via Liberapay</source>
+            <translation>Stöd oss via Liberapay</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="853" />
+            <source>Debug</source>
+            <translation>Felsökning</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="854" />
+            <source>Abort</source>
+            <translation>Avbryt</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="867" />
+            <source>Log Indexer Progress</source>
+            <translation>Logga indexerarens förlopp</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="873" />
+            <source>Log Credential Helper</source>
+            <translation>Logga hjälpprogram för autentiseringsuppgifter</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="879" />
+            <source>Log Remote Connection</source>
+            <translation>Logga fjärranslutning</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="885" />
+            <source>Log Debug Messages</source>
+            <translation>Logga felsökningsmeddelanden</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="893" />
+            <source>Load All Diffs</source>
+            <translation>Läs in alla diffar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="907" />
+            <source>Walk Commits</source>
+            <translation>Gå igenom incheckningar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="1021" />
+            <source>Hide Log</source>
+            <translation>Dölj logg</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="1071" />
+            <source>Merge</source>
+            <translation>Sammanfoga</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="1081" />
+            <source>Revert</source>
+            <translation>Återställ</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="1087" />
+            <source>Cherry-pick</source>
+            <translation>Cherry-pick</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="1093" />
+            <source>Rebase</source>
+            <translation>Byt bas</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/MenuBar.cpp" line="1099" />
+            <source>Abort %1</source>
+            <translation>Avbryt %1</translation>
+        </message>
+    </context>
+    <context>
+        <name>MergeDialog</name>
+        <message>
+            <location filename="../src/dialogs/MergeDialog.cpp" line="42" />
+            <location filename="../src/dialogs/MergeDialog.cpp" line="138" />
+            <source>Merge</source>
+            <translation>Sammanfoga</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/MergeDialog.cpp" line="43" />
+            <location filename="../src/dialogs/MergeDialog.cpp" line="140" />
+            <source>Rebase</source>
+            <translation>Byt bas</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/MergeDialog.cpp" line="44" />
+            <location filename="../src/dialogs/MergeDialog.cpp" line="140" />
+            <source>Squash</source>
+            <translation>Slå ihop</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/MergeDialog.cpp" line="45" />
+            <source>Merge (No Fast-forward)</source>
+            <translation>Sammanfoga (ingen fast-forward)</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/MergeDialog.cpp" line="46" />
+            <source>Merge (Fast-forward Only)</source>
+            <translation>Sammanfoga (endast fast-forward)</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/MergeDialog.cpp" line="51" />
+            <source>No commit</source>
+            <translation>Ingen incheckning</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/MergeDialog.cpp" line="76" />
+            <source>Reference:</source>
+            <translation>Referens:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/MergeDialog.cpp" line="77" />
+            <source>Action:</source>
+            <translation>Åtgärd:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/MergeDialog.cpp" line="124" />
+            <source>Choose a reference to merge into '%1'.</source>
+            <translation>Välj en referens att sammanfoga med ”%1”.</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/MergeDialog.cpp" line="126" />
+            <source>Choose a reference to rebase '%1' on.</source>
+            <translation>Välj en referens som ”%1” ska byta bas till.</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/MergeDialog.cpp" line="128" />
+            <source>Choose a reference to squash into '%1'.</source>
+            <translation>Välj en referens att slå ihop med ”%1”.</translation>
+        </message>
+    </context>
+    <context>
+        <name>MergeTool</name>
+        <message>
+            <location filename="../src/tools/MergeTool.cpp" line="35" />
+            <source>External Merge</source>
+            <translation>Extern sammanfogning</translation>
+        </message>
+    </context>
+    <context>
+        <name>MiscPanel</name>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="776" />
+            <source>Path to SSH config file:</source>
+            <translation>Sökväg till SSH-konfigurationsfil:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="777" />
+            <source>Path to default / fallback SSH key file:</source>
+            <translation>Sökväg till standard- eller reservnyckel för SSH:</translation>
+        </message>
+    </context>
+    <context>
+        <name>NewBranchDialog</name>
+        <message>
+            <location filename="../src/dialogs/NewBranchDialog.cpp" line="41" />
+            <source>Checkout branch</source>
+            <translation>Checka ut gren</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/NewBranchDialog.cpp" line="48" />
+            <source>Name:</source>
+            <translation>Namn:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/NewBranchDialog.cpp" line="50" />
+            <source>Start Point:</source>
+            <translation>Startpunkt:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/NewBranchDialog.cpp" line="53" />
+            <source>Advanced:</source>
+            <translation>Avancerat:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/NewBranchDialog.cpp" line="61" />
+            <source>Upstream:</source>
+            <translation>Uppströms:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/NewBranchDialog.cpp" line="72" />
+            <source>Create Branch</source>
+            <translation>Skapa gren</translation>
+        </message>
+    </context>
+    <context>
+        <name>PathspecWidget</name>
+        <message>
+            <location filename="../src/ui/PathspecWidget.cpp" line="105" />
+            <source>Filter by Path</source>
+            <translation>Filtrera efter sökväg</translation>
+        </message>
+    </context>
+    <context>
+        <name>PluginsPanel</name>
+        <message>
+            <location filename="../src/dialogs/PluginsPanel.cpp" line="25" />
+            <source>Name</source>
+            <translation>Namn</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PluginsPanel.cpp" line="25" />
+            <source>Kind</source>
+            <translation>Typ</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PluginsPanel.cpp" line="25" />
+            <source>Description</source>
+            <translation>Beskrivning</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PluginsPanel.cpp" line="60" />
+            <source>Options</source>
+            <translation>Alternativ</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PluginsPanel.cpp" line="71" />
+            <source>%1 Options</source>
+            <translation>Alternativ för %1</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PluginsPanel.cpp" line="152" />
+            <source>Note</source>
+            <translation>Obs</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PluginsPanel.cpp" line="153" />
+            <source>Warning</source>
+            <translation>Varning</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PluginsPanel.cpp" line="154" />
+            <source>Error</source>
+            <translation>Fel</translation>
+        </message>
+    </context>
+    <context>
+        <name>Popup</name>
+        <message>
+            <location filename="../src/ui/IndexCompleter.cpp" line="89" />
+            <source>Show Advanced Search</source>
+            <translation>Visa avancerad sökning</translation>
+        </message>
+    </context>
+    <context>
+        <name>PreviewWidget</name>
+        <message>
+            <location filename="../src/ui/ColumnView.cpp" line="67" />
+            <source>Added</source>
+            <translation>Tillagd</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ColumnView.cpp" line="68" />
+            <source>Modified</source>
+            <translation>Ändrad</translation>
+        </message>
+    </context>
+    <context>
+        <name>PullRequestButton</name>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="413" />
+            <source>Create Pull Request</source>
+            <translation>Skapa pull request</translation>
+        </message>
+    </context>
+    <context>
+        <name>PullRequestDialog</name>
+        <message>
+            <location filename="../src/dialogs/PullRequestDialog.cpp" line="24" />
+            <source>Create Pull Request</source>
+            <translation>Skapa pull request</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PullRequestDialog.cpp" line="28" />
+            <source>Title</source>
+            <translation>Rubrik</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PullRequestDialog.cpp" line="31" />
+            <source>Body</source>
+            <translation>Brödtext</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PullRequestDialog.cpp" line="35" />
+            <source>Maintainer can modify</source>
+            <translation>Underhållaren kan ändra</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PullRequestDialog.cpp" line="49" />
+            <source>From:</source>
+            <translation>Från:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PullRequestDialog.cpp" line="57" />
+            <source>owner/repository</source>
+            <translation>ägare/arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PullRequestDialog.cpp" line="61" />
+            <source>branch</source>
+            <translation>gren</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PullRequestDialog.cpp" line="76" />
+            <source>To:</source>
+            <translation>Till:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/PullRequestDialog.cpp" line="87" />
+            <source>Create</source>
+            <translation>Skapa</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <location filename="../src/ui/DoubleTreeWidget.cpp" line="37" />
+            <source>Expand all</source>
+            <translation>Expandera alla</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DoubleTreeWidget.cpp" line="38" />
+            <source>Collapse all</source>
+            <translation>Fäll ihop alla</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DoubleTreeWidget.cpp" line="39" />
+            <source>Staged Files</source>
+            <translation>Filer i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DoubleTreeWidget.cpp" line="40" />
+            <source>Unstaged Files</source>
+            <translation>Filer utanför indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DoubleTreeWidget.cpp" line="41" />
+            <source>Committed Files</source>
+            <translation>Incheckade filer</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DoubleTreeWidget.cpp" line="42" />
+            <source>Workdir Files</source>
+            <translation>Filer i arbetsmappen</translation>
+        </message>
+        <message>
+            <location filename="../src/app/Gittyup.cpp" line="27" />
+            <source>Your global GIT configuration is invalid, Gittyup won't run properly until this is fixed</source>
+            <translation>Din globala Git-konfiguration är ogiltig. Gittyup fungerar inte korrekt förrän detta har åtgärdats.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffTreeModel.cpp" line="26" />
+            <source>File Name</source>
+            <translation>Filnamn</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffTreeModel.cpp" line="27" />
+            <source>Relative Path</source>
+            <translation>Relativ sökväg</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffTreeModel.cpp" line="28" />
+            <source>State</source>
+            <translation>Tillstånd</translation>
+        </message>
+    </context>
+    <context>
+        <name>RebaseConflictDialog</name>
+        <message>
+            <location filename="../src/dialogs/RebaseConflictDialog.cpp" line="17" />
+            <source>Rebase conflict</source>
+            <translation>Konflikt vid basbyte</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RebaseConflictDialog.cpp" line="21" />
+            <source>Abort rebase</source>
+            <translation>Avbryt basbyte</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RebaseConflictDialog.cpp" line="27" />
+            <source>Continue</source>
+            <translation>Fortsätt</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RebaseConflictDialog.cpp" line="35" />
+            <source>The rebase caused a merge conflict. 
+Would you like to fix the merge conflict and continue?</source>
+            <translation>Basbytet orsakade en sammanfogningskonflikt. 
+Vill du åtgärda sammanfogningskonflikten och fortsätta?</translation>
+        </message>
+    </context>
+    <context>
+        <name>Reference</name>
+        <message>
+            <location filename="../src/git/Reference.cpp" line="65" />
+            <source>HEAD detached at %1</source>
+            <translation>HEAD frånkopplad vid %1</translation>
+        </message>
+    </context>
+    <context>
+        <name>ReferenceList</name>
+        <message>
+            <location filename="../src/ui/ReferenceList.cpp" line="163" />
+            <source>Commit</source>
+            <translation>Checka in</translation>
+        </message>
+    </context>
+    <context>
+        <name>ReferenceModel</name>
+        <message>
+            <location filename="../src/ui/ReferenceModel.cpp" line="115" />
+            <source>Branches</source>
+            <translation>Grenar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ReferenceModel.cpp" line="134" />
+            <source>Remotes</source>
+            <translation>Fjärranslutningar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ReferenceModel.cpp" line="151" />
+            <source>Tags</source>
+            <translation>Taggar</translation>
+        </message>
+    </context>
+    <context>
+        <name>ReferenceView</name>
+        <message>
+            <location filename="../src/ui/ReferenceView.cpp" line="255" />
+            <source>Branch</source>
+            <translation>Gren</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ReferenceView.cpp" line="258" />
+            <source>Remote</source>
+            <translation>Fjärranslutning</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ReferenceView.cpp" line="261" />
+            <source>Tag</source>
+            <translation>Tagg</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ReferenceView.cpp" line="286" />
+            <source>Checkout</source>
+            <translation>Checka ut</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ReferenceView.cpp" line="294" />
+            <source>Rename</source>
+            <translation>Byt namn</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ReferenceView.cpp" line="304" />
+            <source>Delete</source>
+            <translation>Ta bort</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ReferenceView.cpp" line="323" />
+            <source>Push Tag to %1</source>
+            <translation>Skicka tagg till %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ReferenceView.cpp" line="329" />
+            <source>New Local Branch</source>
+            <translation>Ny lokal gren</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ReferenceView.cpp" line="337" />
+            <source>Merge...</source>
+            <translation>Sammanfoga…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ReferenceView.cpp" line="348" />
+            <source>Rebase...</source>
+            <translation>Byt bas…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ReferenceView.cpp" line="359" />
+            <source>Squash...</source>
+            <translation>Slå ihop…</translation>
+        </message>
+    </context>
+    <context>
+        <name>RefreshButton</name>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="360" />
+            <source>Refresh</source>
+            <translation>Uppdatera</translation>
+        </message>
+    </context>
+    <context>
+        <name>RemoteButton</name>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="258" />
+            <source>999+</source>
+            <translation>999+</translation>
+        </message>
+    </context>
+    <context>
+        <name>RemoteCallbacks</name>
+        <message>
+            <location filename="../src/ui/RemoteCallbacks.cpp" line="162" />
+            <source>remote: %1</source>
+            <translation>fjärranslutning: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RemoteCallbacks.cpp" line="212" />
+            <source>failed to execute pre-push hook: bash not found</source>
+            <translation>kunde inte köra pre-push-krok: Bash hittades inte</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RemoteCallbacks.cpp" line="247" />
+            <source>failed to execute pre-push hook: %1</source>
+            <translation>kunde inte köra pre-push-krok: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RemoteCallbacks.cpp" line="295" />
+            <source>HTTPS Credentials</source>
+            <translation>HTTPS-autentiseringsuppgifter</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RemoteCallbacks.cpp" line="295" />
+            <source>SSH Passphrase</source>
+            <translation>SSH-lösenfras</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RemoteCallbacks.cpp" line="310" />
+            <source>Username:</source>
+            <translation>Användarnamn:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RemoteCallbacks.cpp" line="311" />
+            <source>Password:</source>
+            <translation>Lösenord:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RemoteCallbacks.cpp" line="311" />
+            <source>Passphrase:</source>
+            <translation>Lösenfras:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RemoteCallbacks.cpp" line="326" />
+            <location filename="../src/ui/RemoteCallbacks.cpp" line="374" />
+            <source>authentication canceled</source>
+            <translation>autentiseringen avbröts</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RemoteCallbacks.cpp" line="459" />
+            <source>From %1</source>
+            <translation>Från %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RemoteCallbacks.cpp" line="459" />
+            <location filename="../src/ui/RemoteCallbacks.cpp" line="501" />
+            <source>To %1</source>
+            <translation>Till %1</translation>
+        </message>
+    </context>
+    <context>
+        <name>RemoteDialog</name>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="44" />
+            <source>Push all tags</source>
+            <translation>Skicka alla taggar</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="44" />
+            <source>Update existing tags</source>
+            <translation>Uppdatera befintliga taggar</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="52" />
+            <source>Merge</source>
+            <translation>Sammanfoga</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="53" />
+            <source>Rebase</source>
+            <translation>Byt bas</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="54" />
+            <source>Merge (No Fast-forward)</source>
+            <translation>Sammanfoga (ingen fast-forward)</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="55" />
+            <source>Merge (Fast-forward Only)</source>
+            <translation>Sammanfoga (endast fast-forward)</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="65" />
+            <source>Set upstream</source>
+            <translation>Ange uppströmsgren</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="66" />
+            <source>Force</source>
+            <translation>Tvinga</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="79" />
+            <source>Remote Reference:</source>
+            <translation>Fjärrreferens:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="106" />
+            <source>Prune references</source>
+            <translation>Rensa referenser</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="113" />
+            <source>Fetch</source>
+            <translation>Hämta</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="117" />
+            <source>Pull</source>
+            <translation>Hämta och sammanfoga</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="121" />
+            <source>Push</source>
+            <translation>Skicka</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="127" />
+            <source>Remote:</source>
+            <translation>Fjärranslutning:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="129" />
+            <source>Reference:</source>
+            <translation>Referens:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="131" />
+            <source>Action:</source>
+            <translation>Åtgärd:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteDialog.cpp" line="140" />
+            <source>Advanced:</source>
+            <translation>Avancerat:</translation>
+        </message>
+    </context>
+    <context>
+        <name>RemotePage</name>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="41" />
+            <source>Remote Repository URL</source>
+            <translation>URL till fjärrarkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="44" />
+            <source>Choose protocol to authenticate with the remote.</source>
+            <translation>Välj protokoll för autentisering med fjärranslutningen.</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="45" />
+            <source>Enter the URL of the remote repository or browse for a local directory</source>
+            <translation>Ange URL:en till fjärrarkivet eller bläddra efter en lokal mapp</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="72" />
+            <source>...</source>
+            <translation>…</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="74" />
+            <source>Choose Directory</source>
+            <translation>Välj mapp</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="96" />
+            <source>Examples of valid URLs include:&lt;table cellspacing='8'&gt;&lt;tr&gt;&lt;td align='right'&gt;&lt;b&gt;HTTPS&lt;/b&gt;&lt;/td&gt;&lt;td&gt;https://hostname/path/to/repo.git&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td align='right'&gt;&lt;b&gt;SSH&lt;/b&gt;&lt;/td&gt;&lt;td&gt;git@hostname:path/to/repo.git&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td align='right'&gt;&lt;b&gt;Git&lt;/b&gt;&lt;/td&gt;&lt;td&gt;git://hostname/path/to/repo.git&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td align='right'&gt;&lt;b&gt;Local&lt;/b&gt;&lt;/td&gt;&lt;td&gt;/path/to/repo, C:\path\to\repo&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
+            <translation>Exempel på giltiga URL:er:&lt;table cellspacing='8'&gt;&lt;tr&gt;&lt;td align='right'&gt;&lt;b&gt;HTTPS&lt;/b&gt;&lt;/td&gt;&lt;td&gt;https://värdnamn/sökväg/till/arkiv.git&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td align='right'&gt;&lt;b&gt;SSH&lt;/b&gt;&lt;/td&gt;&lt;td&gt;git@värdnamn:sökväg/till/arkiv.git&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td align='right'&gt;&lt;b&gt;Git&lt;/b&gt;&lt;/td&gt;&lt;td&gt;git://värdnamn/sökväg/till/arkiv.git&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td align='right'&gt;&lt;b&gt;Lokal&lt;/b&gt;&lt;/td&gt;&lt;td&gt;/sökväg/till/arkiv, C:\sökväg\till\arkiv&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="110" />
+            <source>Protocol:</source>
+            <translation>Protokoll:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/CloneDialog.cpp" line="111" />
+            <source>URL:</source>
+            <translation>URL:</translation>
+        </message>
+    </context>
+    <context>
+        <name>RemoteTableModel</name>
+        <message>
+            <location filename="../src/dialogs/RemoteTableModel.cpp" line="57" />
+            <source>Name</source>
+            <translation>Namn</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RemoteTableModel.cpp" line="59" />
+            <source>URL</source>
+            <translation>URL</translation>
+        </message>
+    </context>
+    <context>
+        <name>RemotesPanel</name>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="202" />
+            <source>Delete Remote?</source>
+            <translation>Ta bort fjärranslutningen?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="203" />
+            <source>Are you sure you want to delete '%1'?</source>
+            <translation>Är du säker på att du vill ta bort ”%1”?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="208" />
+            <source>Delete</source>
+            <translation>Ta bort</translation>
+        </message>
+    </context>
+    <context>
+        <name>RenameBranchDialog</name>
+        <message>
+            <location filename="../src/dialogs/RenameBranchDialog.cpp" line="33" />
+            <source>Name:</source>
+            <translation>Namn:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/RenameBranchDialog.cpp" line="38" />
+            <source>Rename Branch</source>
+            <translation>Byt namn på gren</translation>
+        </message>
+    </context>
+    <context>
+        <name>RepoModel</name>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="314" />
+            <source>Connecting</source>
+            <translation>Ansluter</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="338" />
+            <source>open</source>
+            <translation>öppna</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="340" />
+            <source>recent</source>
+            <translation>senaste</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="342" />
+            <source>remote</source>
+            <translation>fjärranslutning</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="358" />
+            <location filename="../src/ui/SideBar.cpp" line="367" />
+            <source>none</source>
+            <translation>ingen</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="95" />
+            <source>Clone Repository</source>
+            <translation>Klona arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="97" />
+            <source>Open Existing Repository</source>
+            <translation>Öppna befintligt arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="99" />
+            <source>Initialize New Repository</source>
+            <translation>Initiera nytt arkiv</translation>
+        </message>
+    </context>
+    <context>
+        <name>RepoView</name>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="182" />
+            <source>Indexing...</source>
+            <translation>Indexerar…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="190" />
+            <source>Search</source>
+            <translation>Sök</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="196" />
+            <source>Indexer Crashed</source>
+            <translation>Indexeraren kraschade</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="319" />
+            <source>Stage Directory?</source>
+            <translation>Lägg till mappen i indexet?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="320" />
+            <source>Are you sure you want to stage '%1'?</source>
+            <translation>Är du säker på att du vill lägga till ”%1” i indexet?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="321" />
+            <source>This will result in the addition of %1 files.</source>
+            <translation>Detta lägger till %1 filer i indexet.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="323" />
+            <source>more than 100</source>
+            <translation>fler än 100</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="327" />
+            <source>Stage Directory</source>
+            <translation>Lägg till mapp i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="330" />
+            <source>Stop prompting to stage directories</source>
+            <translation>Sluta fråga om mappar ska läggas till i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="346" />
+            <source>Stage Large File?</source>
+            <translation>Lägg till stor fil i indexet?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="348" />
+            <source>Are you sure you want to stage '%1' with a size of %2?</source>
+            <translation>Är du säker på att du vill lägga till ”%1”, med storleken %2, i indexet?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="353" />
+            <source>Stage</source>
+            <translation>Lägg till i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="357" />
+            <source>Track with LFS</source>
+            <translation>Spåra med LFS</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="360" />
+            <source>This repository has LFS enabled. Do you want to track the file with LFS instead?</source>
+            <translation>Det här arkivet har LFS aktiverat. Vill du spåra filen med LFS i stället?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="364" />
+            <source>Stop prompting to stage large files</source>
+            <translation>Sluta fråga om stora filer ska läggas till i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="407" />
+            <source>Esc</source>
+            <translation>Esc</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="413" />
+            <source>stage</source>
+            <translation>lägg till i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="418" />
+            <source>Git LFS was not found on the PATH. &lt;a href='https://git-lfs.github.com'&gt;Install Git LFS&lt;/a&gt; to use LFS integration.</source>
+            <translation>Git LFS hittades inte i PATH. &lt;a href='https://git-lfs.github.com'&gt;Installera Git LFS&lt;/a&gt; för att använda LFS-integrering.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="465" />
+            <source>untracked file</source>
+            <translation>ospårad fil</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="466" />
+            <source>untracked files</source>
+            <translation>ospårade filer</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="469" />
+            <source>Remove Untracked Files</source>
+            <translation>Ta bort ospårade filer</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="470" />
+            <source>Remove %1 %2?</source>
+            <translation>Ta bort %1 %2?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="473" />
+            <source>This action cannot be undone.</source>
+            <translation>Den här åtgärden kan inte ångras.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="476" />
+            <source>Remove</source>
+            <translation>Ta bort</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="703" />
+            <location filename="../src/ui/RepoView.cpp" line="719" />
+            <source>Certificate Error</source>
+            <translation>Certifikatfel</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="704" />
+            <source>SSL verification disabled for this repository</source>
+            <translation>SSL-verifiering har inaktiverats för det här arkivet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="706" />
+            <source>[http]
+  sslVerify = false
+
+was added to %1/config</source>
+            <translation>[http]
+  sslVerify = false
+
+lades till i %1/config</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="720" />
+            <source>SSL verification disabled for all git repositories</source>
+            <translation>SSL-verifiering har inaktiverats för alla Git-arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="722" />
+            <source>[http]
+  sslVerify = false
+
+was added to %1</source>
+            <translation>[http]
+  sslVerify = false
+
+lades till i %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="746" />
+            <source>Pull Request</source>
+            <translation>Pull request</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="746" />
+            <source>Create</source>
+            <translation>Skapa</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="747" />
+            <source>create pull request</source>
+            <translation>skapa pull request</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="761" />
+            <location filename="../src/ui/RepoView.cpp" line="771" />
+            <location filename="../src/ui/RepoView.cpp" line="794" />
+            <source>Git LFS</source>
+            <translation>Git LFS</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="761" />
+            <source>Initialize</source>
+            <translation>Initiera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="763" />
+            <source>initialize</source>
+            <translation>initiera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="767" />
+            <source>Git LFS initialized.</source>
+            <translation>Git LFS har initierats.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="771" />
+            <source>Deinitialize</source>
+            <translation>Avinitiera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="773" />
+            <source>deinitialize</source>
+            <translation>avinitiera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="777" />
+            <source>Git LFS Deinitialized.</source>
+            <translation>Git LFS har avinitierats.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="782" />
+            <source>Lock</source>
+            <translation>Lås</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="782" />
+            <source>Unlock</source>
+            <translation>Lås upp</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="787" />
+            <location filename="../src/ui/RepoView.cpp" line="910" />
+            <source>Unable to %1 '%2' - %3</source>
+            <translation>Kunde inte %1 ”%2” – %3</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="909" />
+            <source>Unable to %1 - %2</source>
+            <translation>Kunde inte %1 – %2</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="954" />
+            <source>%1 remotes</source>
+            <translation>%1 fjärranslutningar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="955" />
+            <source>Fetch All</source>
+            <translation>Hämta alla</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="983" />
+            <source>Fetch</source>
+            <translation>Hämta</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="985" />
+            <location filename="../src/ui/RepoView.cpp" line="1080" />
+            <location filename="../src/ui/RepoView.cpp" line="1666" />
+            <source>&lt;i&gt;no remote&lt;/i&gt;</source>
+            <translation>&lt;i&gt;ingen fjärranslutning&lt;/i&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="992" />
+            <source>Unable to fetch. No upstream is configured for the current branch, and there isn't a remote called 'origin'.</source>
+            <translation>Kunde inte hämta. Ingen uppströmsgren är konfigurerad för den aktuella grenen och det finns ingen fjärranslutning med namnet ”origin”.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1006" />
+            <location filename="../src/ui/RepoView.cpp" line="2508" />
+            <source>Fetch canceled.</source>
+            <translation>Hämtningen avbröts.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1008" />
+            <source>fetch from</source>
+            <translation>hämta från</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1015" />
+            <source>You may disable ssl verification &lt;a href='action:sslverifyrepo'&gt;for this repository&lt;/a&gt; or overall disable ssl verification &lt;a href='action:sslverifygit'&gt;for all repositories&lt;/a&gt;.</source>
+            <translation>Du kan inaktivera SSL-verifiering &lt;a href='action:sslverifyrepo'&gt;för det här arkivet&lt;/a&gt; eller inaktivera SSL-verifiering generellt &lt;a href='action:sslverifygit'&gt;för alla arkiv&lt;/a&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1025" />
+            <location filename="../src/ui/RepoView.cpp" line="1734" />
+            <location filename="../src/ui/RepoView.cpp" line="1784" />
+            <source>Everything up-to-date.</source>
+            <translation>Allt är uppdaterat.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1079" />
+            <location filename="../src/ui/RepoView.cpp" line="1184" />
+            <location filename="../src/ui/RepoView.cpp" line="2222" />
+            <source>&lt;i&gt;no branch&lt;/i&gt;</source>
+            <translation>&lt;i&gt;ingen gren&lt;/i&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1081" />
+            <source>%1 from %2</source>
+            <translation>%1 från %2</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1082" />
+            <source>Pull</source>
+            <translation>Hämta och sammanfoga</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1151" />
+            <source>&lt;i&gt;no upstream&lt;/i&gt;</source>
+            <translation>&lt;i&gt;ingen uppströmsgren&lt;/i&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1174" />
+            <source>Merge</source>
+            <translation>Sammanfoga</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1175" />
+            <source>%1 into %2</source>
+            <translation>%1 till %2</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1177" />
+            <source>Fast-forward</source>
+            <translation>Fast-forward</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1178" />
+            <source>%2 to %1</source>
+            <translation>%2 till %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1180" />
+            <location filename="../src/ui/RepoView.cpp" line="1498" />
+            <source>Rebase</source>
+            <translation>Byt bas</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1181" />
+            <source>%2 on %1</source>
+            <translation>%2 på %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1190" />
+            <source>The repository is empty.</source>
+            <translation>Arkivet är tomt.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1198" />
+            <location filename="../src/ui/RepoView.cpp" line="1718" />
+            <source>The current branch '%1' has no upstream branch.</source>
+            <translation>Den aktuella grenen ”%1” har ingen uppströmsgren.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1204" />
+            <location filename="../src/ui/RepoView.cpp" line="2477" />
+            <source>Already up-to-date.</source>
+            <translation>Redan uppdaterad.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1209" />
+            <source>Unable to fast-forward.</source>
+            <translation>Kunde inte utföra fast-forward.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1245" />
+            <source>fast-forward</source>
+            <translation>fast-forward</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1258" />
+            <source>You may be able to reconcile your changes with the conflicting files by &lt;a href='action:stash'&gt;stashing&lt;/a&gt; before you &lt;a href='%1'&gt;fast-forward&lt;/a&gt;. Then &lt;a href='action:unstash'&gt;unstash&lt;/a&gt; to restore your changes.</source>
+            <translation>Du kanske kan lösa dina ändringar med de konfliktdrabbade filerna genom att &lt;a href='action:stash'&gt;stasha&lt;/a&gt; innan du utför &lt;a href='%1'&gt;fast-forward&lt;/a&gt;. &lt;a href='action:unstash'&gt;Återställ sedan stashen&lt;/a&gt; för att få tillbaka dina ändringar.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1270" />
+            <source>If you want to create a new merge commit instead of fast-forwarding, you can &lt;a href='%1'&gt;merge without fast-forwarding &lt;/a&gt; instead.</source>
+            <translation>Om du vill skapa en ny incheckning för sammanfogning i stället för fast-forward kan du &lt;a href='%1'&gt;sammanfoga utan fast-forward&lt;/a&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1290" />
+            <location filename="../src/ui/RepoView.cpp" line="1307" />
+            <location filename="../src/ui/RepoView.cpp" line="1372" />
+            <location filename="../src/ui/RepoView.cpp" line="1384" />
+            <source>merge</source>
+            <translation>sammanfoga</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1297" />
+            <location filename="../src/ui/RepoView.cpp" line="1515" />
+            <source>You may be able to rebase by &lt;a href='action:stash'&gt;stashing&lt;/a&gt; before trying to &lt;a href='action:merge'&gt;merge&lt;/a&gt;. Then &lt;a href='action:unstash'&gt;unstash&lt;/a&gt; to restore your changes.</source>
+            <translation>Du kanske kan byta bas genom att &lt;a href='action:stash'&gt;stasha&lt;/a&gt; innan du försöker &lt;a href='action:merge'&gt;sammanfoga&lt;/a&gt;. &lt;a href='action:unstash'&gt;Återställ sedan stashen&lt;/a&gt; för att få tillbaka dina ändringar.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1372" />
+            <location filename="../src/ui/RepoView.cpp" line="1403" />
+            <location filename="../src/ui/RepoView.cpp" line="1426" />
+            <source>Abort</source>
+            <translation>Avbryt</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1373" />
+            <source>Some merged files have unstaged changes</source>
+            <translation>Vissa sammanfogade filer har ändringar utanför indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1374" />
+            <source>abort merge</source>
+            <translation>avbryt sammanfogning</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1388" />
+            <location filename="../src/ui/RepoView.cpp" line="1540" />
+            <location filename="../src/ui/RepoView.cpp" line="1545" />
+            <source>revert</source>
+            <translation>återställ</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1393" />
+            <location filename="../src/ui/RepoView.cpp" line="1590" />
+            <location filename="../src/ui/RepoView.cpp" line="1595" />
+            <source>cherry-pick</source>
+            <translation>cherry-pick</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1399" />
+            <location filename="../src/ui/RepoView.cpp" line="1438" />
+            <location filename="../src/ui/RepoView.cpp" line="1454" />
+            <source>rebase</source>
+            <translation>byt bas</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1418" />
+            <source>Continue ongoing rebase</source>
+            <translation>Fortsätt pågående basbyte</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1426" />
+            <source>Invalid head.</source>
+            <translation>Ogiltigt HEAD.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1444" />
+            <source>You may be able to rebase by &lt;a href='action:stash'&gt;stashing&lt;/a&gt; before trying to &lt;a href='action:rebase'&gt;rebase&lt;/a&gt;. Then &lt;a href='action:unstash'&gt;unstash&lt;/a&gt; to restore your changes.</source>
+            <translation>Du kanske kan byta bas genom att &lt;a href='action:stash'&gt;stasha&lt;/a&gt; innan du försöker &lt;a href='action:rebase'&gt;byta bas&lt;/a&gt;. &lt;a href='action:unstash'&gt;Återställ sedan stashen&lt;/a&gt; för att få tillbaka dina ändringar.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1460" />
+            <location filename="../src/ui/RepoView.cpp" line="1480" />
+            <source>%1/%2</source>
+            <translation>%1/%2</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1461" />
+            <source>%1 - %2</source>
+            <translation>%1 – %2</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1462" />
+            <source>Apply</source>
+            <translation>Tillämpa</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1485" />
+            <source>%1 - %2 &lt;i&gt;already applied&lt;/i&gt;</source>
+            <translation>%1 – %2 &lt;i&gt;redan tillämpad&lt;/i&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1486" />
+            <source>%1 - %2 as %3</source>
+            <translation>%1 – %2 som %3</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1508" />
+            <location filename="../src/ui/RepoView.cpp" line="1528" />
+            <location filename="../src/ui/RepoView.cpp" line="2961" />
+            <source>squash</source>
+            <translation>slå ihop</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1536" />
+            <source>Revert</source>
+            <translation>Återställ</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1553" />
+            <source>Revert "%1"
+
+This reverts commit %2.</source>
+            <translation>Återställ ”%1”
+
+Detta återställer incheckningen %2.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1584" />
+            <source>&lt;i&gt;detached HEAD&lt;/i&gt;</source>
+            <translation>&lt;i&gt;frånkopplad HEAD&lt;/i&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1585" />
+            <source>%1 on %2</source>
+            <translation>%1 på %2</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1586" />
+            <source>Cherry-pick</source>
+            <translation>Cherry-pick</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1631" />
+            <source>Are you sure you want to force push?</source>
+            <translation>Är du säker på att du vill tvångsskicka?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1637" />
+            <source>The remote will lose any commits that are reachable only from the overwritten reference. Dropped commits may be unexpectedly reintroduced by clones that already contain those commits locally.</source>
+            <translation>Fjärranslutningen förlorar alla incheckningar som bara kan nås från den överskrivna referensen. Borttagna incheckningar kan oväntat återinföras av kloner som redan har dem lokalt.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1642" />
+            <source>Force Push</source>
+            <translation>Tvångsskicka</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1663" />
+            <source>&lt;i&gt;no reference&lt;/i&gt;</source>
+            <translation>&lt;i&gt;ingen referens&lt;/i&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1674" />
+            <source>Push</source>
+            <translation>Skicka</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1674" />
+            <source>Push (Force)</source>
+            <translation>Skicka (tvinga)</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1675" />
+            <location filename="../src/ui/RepoView.cpp" line="2281" />
+            <source>%1 to %2</source>
+            <translation>%1 till %2</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1679" />
+            <location filename="../src/ui/RepoView.cpp" line="2223" />
+            <source>You are not currently on a branch.</source>
+            <translation>Du är inte på någon gren just nu.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1682" />
+            <source>Create a commit to add the default '%1' branch.</source>
+            <translation>Skapa en incheckning för att lägga till standardgrenen ”%1”.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1686" />
+            <source>You can &lt;a href='action:checkout'&gt;checkout&lt;/a&gt; a branch then &lt;a href='action:push'&gt;push&lt;/a&gt; again, or &lt;a href='action:push-to'&gt;push to an explicit branch&lt;/a&gt;.</source>
+            <translation>Du kan &lt;a href='action:checkout'&gt;checka ut&lt;/a&gt; en gren och sedan &lt;a href='action:push'&gt;skicka&lt;/a&gt; igen, eller &lt;a href='action:push-to'&gt;skicka till en uttrycklig gren&lt;/a&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1696" />
+            <source>The current branch '%1' has no default remote.</source>
+            <translation>Den aktuella grenen ”%1” har ingen standardfjärranslutning.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1699" />
+            <source>You may want to &lt;a href='action:add-remote?name=origin'&gt;add a remote named 'origin'&lt;/a&gt;. Then &lt;a href='action:push?set-upstream=true'&gt;push and set the current branch's upstream&lt;/a&gt; to begin tracking a remote branch called 'origin/%1'.</source>
+            <translation>Du kanske vill &lt;a href='action:add-remote?name=origin'&gt;lägga till en fjärranslutning med namnet ”origin”&lt;/a&gt;. &lt;a href='action:push?set-upstream=true'&gt;Skicka sedan och ange den aktuella grenens uppströmsgren&lt;/a&gt; för att börja spåra fjärrgrenen ”origin/%1”.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1706" />
+            <source>You can also &lt;a href='action:push-to'&gt;push to an explicit URL&lt;/a&gt; if you don't want to track a remote branch.</source>
+            <translation>Du kan också &lt;a href='action:push-to'&gt;skicka till en uttrycklig URL&lt;/a&gt; om du inte vill spåra en fjärrgren.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1719" />
+            <source>To begin tracking a remote branch called '%1', &lt;a href='action:push?set-upstream=true'&gt;push and set the current branch's upstream&lt;/a&gt;.</source>
+            <translation>&lt;a href='action:push?set-upstream=true'&gt;Skicka och ange den aktuella grenens uppströmsgren&lt;/a&gt; för att börja spåra fjärrgrenen ”%1”.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1723" />
+            <source>To push without setting up tracking information, &lt;a href='action:push?ref=%1'&gt;push '%2'&lt;/a&gt; explicitly.</source>
+            <translation>&lt;a href='action:push?ref=%1'&gt;Skicka ”%2”&lt;/a&gt; uttryckligen om du vill skicka utan att ange spårningsinformation.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1746" />
+            <source>Push canceled.</source>
+            <translation>Sändningen avbröts.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1750" />
+            <source>push to</source>
+            <translation>skicka till</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1754" />
+            <source>The tag update may cause the remote to lose commits.</source>
+            <translation>Tagguppdateringen kan leda till att fjärranslutningen förlorar incheckningar.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1756" />
+            <source>If you want to risk the remote losing commits, you can &lt;a href='action:push?ref=%1&amp;to=%2&amp;force=true'&gt;force push&lt;/a&gt;.</source>
+            <translation>Om du vill riskera att fjärranslutningen förlorar incheckningar kan du &lt;a href='action:push?ref=%1&amp;to=%2&amp;force=true'&gt;tvångsskicka&lt;/a&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1831" />
+            <source>Commit?</source>
+            <translation>Checka in?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1832" />
+            <source>Are you sure you want to commit on a detached HEAD?</source>
+            <translation>Är du säker på att du vill checka in med frånkopplad HEAD?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1838" />
+            <source>&lt;p&gt;You are in a detached HEAD state. You can still commit, but the new commit will not be reachable from any branch. If you want to commit to an existing branch, checkout the branch first.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;Du är i ett läge med frånkopplad HEAD. Du kan fortfarande checka in, men den nya incheckningen kommer inte att kunna nås från någon gren. Om du vill checka in på en befintlig gren ska du checka ut grenen först.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1843" />
+            <location filename="../src/ui/RepoView.cpp" line="1854" />
+            <source>Commit</source>
+            <translation>Checka in</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1853" />
+            <location filename="../src/ui/RepoView.cpp" line="1986" />
+            <source>&lt;i&gt;no commit&lt;/i&gt;</source>
+            <translation>&lt;i&gt;ingen incheckning&lt;/i&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1859" />
+            <source>commit</source>
+            <translation>checka in</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1867" />
+            <source>This commit was signed with a generated user name and email.</source>
+            <translation>Den här incheckningen signerades med ett genererat användarnamn och en genererad e-postadress.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1869" />
+            <source>Consider setting the user name and email in &lt;a href='action:config?global=true'&gt;global settings&lt;/a&gt;.</source>
+            <translation>Överväg att ange användarnamn och e-postadress i &lt;a href='action:config?global=true'&gt;globala inställningar&lt;/a&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1871" />
+            <source>If you want to limit the name and email settings to this repository, &lt;a href='action:config'&gt;edit repository settings&lt;/a&gt; instead.</source>
+            <translation>Om du vill begränsa inställningarna för namn och e-postadress till det här arkivet kan du &lt;a href='action:config'&gt;redigera arkivinställningarna&lt;/a&gt; i stället.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1875" />
+            <source>After settings have been updated, &lt;a href='action:amend'&gt; amend this commit&lt;/a&gt; to record the new user name and email.</source>
+            <translation>När inställningarna har uppdaterats kan du &lt;a href='action:amend'&gt;ändra den här incheckningen&lt;/a&gt; för att spara det nya användarnamnet och e-postadressen.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1916" />
+            <source>file</source>
+            <translation>fil</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1916" />
+            <source>files</source>
+            <translation>filer</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1917" />
+            <source>%1 - %2 %3</source>
+            <translation>%1 – %2 %3</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1918" />
+            <location filename="../src/ui/RepoView.cpp" line="1993" />
+            <source>Checkout</source>
+            <translation>Checka ut</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1940" />
+            <source>Checkout Detached HEAD?</source>
+            <translation>Checka ut frånkopplad HEAD?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1942" />
+            <source>Checkout Detached HEAD</source>
+            <translation>Checka ut frånkopplad HEAD</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1951" />
+            <source>Checking out remote branch '%1' will result in a detached HEAD state. Do you want to reset the existing local branch '%2' to this commit instead?</source>
+            <translation>Om du checkar ut fjärrgrenen ”%1” får du en frånkopplad HEAD. Vill du i stället återställa den befintliga lokala grenen ”%2” till den här incheckningen?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1957" />
+            <source>Reset Local Branch</source>
+            <translation>Återställ lokal gren</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1963" />
+            <source>Checking out remote branch '%1' will result in a detached HEAD state. Do you want to create a new local branch called '%2' to track it instead?</source>
+            <translation>Om du checkar ut fjärrgrenen ”%1” får du en frånkopplad HEAD. Vill du i stället skapa en ny lokal gren med namnet ”%2” som spårar den?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1968" />
+            <source>Create a local branch to start tracking remote changes and make new commits. Check out the detached HEAD to temporarily put your working directory into the state of the remote branch.</source>
+            <translation>Skapa en lokal gren för att börja spåra fjärrändringar och göra nya incheckningar. Checka ut den frånkopplade HEAD för att tillfälligt försätta arbetsmappen i fjärrgrenens tillstånd.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1973" />
+            <source>Create Local Branch</source>
+            <translation>Skapa lokal gren</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1998" />
+            <source>checkout</source>
+            <translation>checka ut</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2010" />
+            <source>You may be able to reconcile your changes with the conflicting files by &lt;a href='action:stash'&gt;stashing&lt;/a&gt; before you &lt;a href='action:checkout?%1'&gt;checkout '%2'&lt;/a&gt;. Then &lt;a href='action:unstash'&gt;unstash&lt;/a&gt; to restore your changes.</source>
+            <translation>Du kanske kan lösa dina ändringar med de konfliktdrabbade filerna genom att &lt;a href='action:stash'&gt;stasha&lt;/a&gt; innan du &lt;a href='action:checkout?%1'&gt;checkar ut ”%2”&lt;/a&gt;. &lt;a href='action:unstash'&gt;Återställ sedan stashen&lt;/a&gt; för att få tillbaka dina ändringar.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2037" />
+            <source>New Branch</source>
+            <translation>Ny gren</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2040" />
+            <source>create new branch</source>
+            <translation>skapa ny gren</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2078" />
+            <source>(no branch)</source>
+            <translation>(ingen gren)</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2079" />
+            <source>WIP on %1: %2 %3</source>
+            <translation>Pågående arbete på %1: %2 %3</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2090" />
+            <source>&lt;i&gt;working directory&lt;/i&gt;</source>
+            <translation>&lt;i&gt;arbetsmapp&lt;/i&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2091" />
+            <source>Stash</source>
+            <translation>Stash</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2095" />
+            <source>stash</source>
+            <translation>stash</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2108" />
+            <source>Apply Stash</source>
+            <translation>Tillämpa stash</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2110" />
+            <source>apply stash</source>
+            <translation>tillämpa stash</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2122" />
+            <source>Drop Stash</source>
+            <translation>Ta bort stash</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2124" />
+            <source>drop stash</source>
+            <translation>ta bort stash</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2139" />
+            <source>Pop Stash</source>
+            <translation>Poppa stash</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2141" />
+            <source>pop stash</source>
+            <translation>poppa stash</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2164" />
+            <source>%1 as %2</source>
+            <translation>%1 som %2</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2165" />
+            <source>Tag</source>
+            <translation>Tagg</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2167" />
+            <source>tag</source>
+            <translation>tagg</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2203" />
+            <location filename="../src/ui/RepoView.cpp" line="2280" />
+            <source>Amend</source>
+            <translation>Ändra senaste incheckningen</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2206" />
+            <source>Amending commit %1</source>
+            <translation>Ändrar incheckningen %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2213" />
+            <source>%1 to %2</source>
+            <comment>update ref</comment>
+            <translation>%1 till %2</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2221" />
+            <location filename="../src/ui/RepoView.cpp" line="2228" />
+            <location filename="../src/ui/RepoView.cpp" line="2267" />
+            <location filename="../src/ui/RepoView.cpp" line="2280" />
+            <location filename="../src/ui/RepoView.cpp" line="2338" />
+            <location filename="../src/ui/RepoView.cpp" line="2410" />
+            <source>Reset</source>
+            <translation>Återställ</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2243" />
+            <source>Are you sure you want to reset '%1' to '%2'?</source>
+            <translation>Är du säker på att du vill återställa ”%1” till ”%2”?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2250" />
+            <source>&lt;p&gt;Some commits may become unreachable from the current branch.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;Vissa incheckningar kan bli onåbara från den aktuella grenen.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2256" />
+            <source>&lt;p&gt;Resetting will cause you to lose uncommitted changes. Untracked and ignored files will not be affected.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;Återställning gör att du förlorar oincheckade ändringar. Ospårade och ignorerade filer påverkas inte.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2260" />
+            <source>&lt;p&gt;Your branch appears to be up-to-date with its upstream branch. Resetting may cause your branch history to diverge from the remote branch history.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;Din gren verkar vara uppdaterad med sin uppströmsgren. Återställning kan få din grenhistorik att avvika från fjärrgrenens historik.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2207" />
+            <location filename="../src/ui/RepoView.cpp" line="2285" />
+            <source>amend</source>
+            <translation>ändra senaste incheckningen</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2285" />
+            <source>reset</source>
+            <translation>återställ</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2409" />
+            <location filename="../src/ui/RepoView.cpp" line="2473" />
+            <source>%1 of %2 submodules</source>
+            <translation>%1 av %2 delmoduler</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2474" />
+            <location filename="../src/ui/RepoView.cpp" line="2498" />
+            <source>Update</source>
+            <translation>Uppdatera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2350" />
+            <location filename="../src/ui/RepoView.cpp" line="2511" />
+            <source>update submodule</source>
+            <translation>uppdatera delmodul</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="193" />
+            <source>The indexer worker process crashed. If this problem persists please contact us at &lt;TODO: replace.support@gitahead.com&gt;.</source>
+            <translation>Indexeraren kraschade. Om problemet kvarstår, kontakta oss på &lt;TODO: replace.support@gitahead.com&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1467" />
+            <source>Please resolve conflicts before continue</source>
+            <translation>Lös konflikterna innan du fortsätter</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1468" />
+            <source>Conflict</source>
+            <translation>Konflikt</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1497" />
+            <source>Rebase finished</source>
+            <translation>Basbyte klart</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1630" />
+            <source>Force Push to %1?</source>
+            <translation>Tvångsskicka till %1?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1768" />
+            <source>You may want to integrate remote commits first by &lt;a href='action:pull'&gt;pulling&lt;/a&gt;. Then &lt;a href='action:push?to=%1'&gt;push&lt;/a&gt; again.</source>
+            <translation>Du kanske vill integrera fjärrincheckningar först genom att &lt;a href='action:pull'&gt;hämta och sammanfoga&lt;/a&gt;. &lt;a href='action:push?to=%1'&gt;Skicka sedan&lt;/a&gt; igen.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="1773" />
+            <source>If you really want the remote to lose commits, you may be able to &lt;a href='action:push?to=%1&amp;force=true'&gt;force push&lt;/a&gt;.</source>
+            <translation>Om du verkligen vill att fjärranslutningen ska förlora incheckningar kan du &lt;a href='action:push?to=%1&amp;force=true'&gt;tvångsskicka&lt;/a&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2347" />
+            <source>Reset canceled.</source>
+            <translation>Återställningen avbröts.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2413" />
+            <source>Untouched</source>
+            <translation>Orörd</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2553" />
+            <source>Invalid Submodule Repository</source>
+            <translation>Ogiltigt arkiv för delmodul</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2555" />
+            <source>The submodule '%1' doesn't have a valid repository. You may need to init and/or update the submodule to check out a repository.</source>
+            <translation>Delmodulen ”%1” har inget giltigt arkiv. Du kan behöva initiera och/eller uppdatera delmodulen för att checka ut ett arkiv.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2684" />
+            <source>No terminal executable found</source>
+            <translation>Ingen körbar terminal hittades</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2685" />
+            <source>No terminal executable was found. Please configure a terminal in the configuration.</source>
+            <translation>Ingen körbar terminal hittades. Konfigurera en terminal i inställningarna.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2688" />
+            <source>Open Configuration</source>
+            <translation>Öppna konfiguration</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2935" />
+            <source>There was a merge conflict.</source>
+            <translation>En sammanfogningskonflikt uppstod.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2938" />
+            <source>Resolve conflicts, then commit to conclude the %1. See &lt;a href='expand'&gt;details&lt;/a&gt;.</source>
+            <translation>Lös konflikterna och checka sedan in för att slutföra %1. Se &lt;a href='expand'&gt;detaljer&lt;/a&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2940" />
+            <source>Resolve conflicts in each conflicted (!) file in one of the following ways:</source>
+            <translation>Lös konflikterna i varje konfliktdrabbad (!) fil på något av följande sätt:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2942" />
+            <source>1. Click the 'Ours' or 'Theirs' button to choose the correct change. Then click the 'Save' button to apply.</source>
+            <translation>1. Klicka på knappen ”Vår version” eller ”Deras version” för att välja rätt ändring. Klicka sedan på ”Spara” för att tillämpa den.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2944" />
+            <source>2. Edit the file in the editor to make a different change. Remember to remove conflict markers.</source>
+            <translation>2. Redigera filen i redigeraren för att göra en annan ändring. Kom ihåg att ta bort konfliktmarkörer.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2946" />
+            <source>3. Use an external merge tool. Right-click on the files in the list and choose 'External Merge'.</source>
+            <translation>3. Använd ett externt sammanfogningsverktyg. Högerklicka på filerna i listan och välj ”Extern sammanfogning”.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2948" />
+            <source>After all conflicts in the file are resolved, click the check box to mark it as resolved.</source>
+            <translation>När alla konflikter i filen är lösta, markera kryssrutan för att markera den som löst.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2950" />
+            <source>After all conflicted files are staged, commit to conclude the %1.</source>
+            <translation>När alla konfliktdrabbade filer har lagts till i indexet, checka in för att slutföra %1.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/RepoView.cpp" line="2962" />
+            <source>You can &lt;a href='action:abort'&gt;abort&lt;/a&gt; the %1 to return the repository to its previous state.</source>
+            <translation>Du kan &lt;a href='action:abort'&gt;avbryta&lt;/a&gt; %1 för att återställa arkivet till dess tidigare tillstånd.</translation>
+        </message>
+    </context>
+    <context>
+        <name>Repository</name>
+        <message>
+            <location filename="../src/git/Repository.cpp" line="1147" />
+            <source>Unknown error</source>
+            <translation>Okänt fel</translation>
+        </message>
+        <message>
+            <location filename="../src/git/Repository.cpp" line="1218" />
+            <source>git-lfs not found</source>
+            <translation>git-lfs hittades inte</translation>
+        </message>
+    </context>
+    <context>
+        <name>SearchField</name>
+        <message>
+            <location filename="../src/ui/SearchField.cpp" line="92" />
+            <source>Search</source>
+            <translation>Sök</translation>
+        </message>
+    </context>
+    <context>
+        <name>SearchPanel</name>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="383" />
+            <source>Enable indexing</source>
+            <translation>Aktivera indexering</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="398" />
+            <source>terms</source>
+            <translation>termer</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="414" />
+            <source>lines</source>
+            <translation>rader</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="428" />
+            <source>Limit commits to:</source>
+            <translation>Begränsa incheckningar till:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="429" />
+            <source>Diff context:</source>
+            <translation>Diffkontext:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ConfigDialog.cpp" line="445" />
+            <source>Remove Index</source>
+            <translation>Ta bort index</translation>
+        </message>
+    </context>
+    <context>
+        <name>Settings</name>
+        <message>
+            <location filename="../src/conf/Settings.cpp" line="166" />
+            <source>Prompt to edit stash message before stashing</source>
+            <translation>Fråga om stashmeddelandet ska redigeras före stashning</translation>
+        </message>
+        <message>
+            <location filename="../src/conf/Settings.cpp" line="169" />
+            <source>Prompt to edit commit message before merging</source>
+            <translation>Fråga om incheckningsmeddelandet ska redigeras före sammanfogning</translation>
+        </message>
+        <message>
+            <location filename="../src/conf/Settings.cpp" line="172" />
+            <source>Prompt to edit commit message before reverting</source>
+            <translation>Fråga om incheckningsmeddelandet ska redigeras före återställning</translation>
+        </message>
+        <message>
+            <location filename="../src/conf/Settings.cpp" line="175" />
+            <source>Prompt to edit commit message before cherry-picking</source>
+            <translation>Fråga om incheckningsmeddelandet ska redigeras före cherry-pick</translation>
+        </message>
+        <message>
+            <location filename="../src/conf/Settings.cpp" line="178" />
+            <source>Prompt to stage directories</source>
+            <translation>Fråga om mappar ska läggas till i indexet</translation>
+        </message>
+        <message>
+            <location filename="../src/conf/Settings.cpp" line="181" />
+            <source>Prompt to stage large files</source>
+            <translation>Fråga om stora filer ska läggas till i indexet</translation>
+        </message>
+    </context>
+    <context>
+        <name>SettingsDialog</name>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="847" />
+            <source>Esc</source>
+            <translation>Esc</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="862" />
+            <source>Global git settings can be overridden for each repository in the corresponding repository configuration page.</source>
+            <translation>Globala Git-inställningar kan åsidosättas för varje arkiv på respektive konfigurationssida för arkivet.</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="879" />
+            <source>Edit Config File...</source>
+            <translation>Redigera konfigurationsfil…</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="908" />
+            <source>General</source>
+            <translation>Allmänt</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="916" />
+            <source>Diff</source>
+            <translation>Diff</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="924" />
+            <source>Tools</source>
+            <translation>Verktyg</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="934" />
+            <source>Window</source>
+            <translation>Fönster</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="942" />
+            <source>Editor</source>
+            <translation>Redigerare</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="950" />
+            <source>Update</source>
+            <translation>Uppdatera</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="958" />
+            <source>Plugins</source>
+            <translation>Insticksmoduler</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="966" />
+            <source>Misc</source>
+            <translation>Övrigt</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="974" />
+            <source>Hotkeys</source>
+            <translation>Kortkommandon</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="984" />
+            <source>Terminal</source>
+            <translation>Terminal</translation>
+        </message>
+    </context>
+    <context>
+        <name>ShowTool</name>
+        <message>
+            <location filename="../src/tools/ShowTool.cpp" line="20" />
+            <source>Finder</source>
+            <translation>Finder</translation>
+        </message>
+        <message>
+            <location filename="../src/tools/ShowTool.cpp" line="22" />
+            <source>Explorer</source>
+            <translation>Utforskaren</translation>
+        </message>
+        <message>
+            <location filename="../src/tools/ShowTool.cpp" line="24" />
+            <source>Default File Browser</source>
+            <translation>Standardfilhanterare</translation>
+        </message>
+        <message>
+            <location filename="../src/tools/ShowTool.cpp" line="103" />
+            <source>Show in %1</source>
+            <translation>Visa i %1</translation>
+        </message>
+    </context>
+    <context>
+        <name>SideBar</name>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="687" />
+            <source>Close</source>
+            <translation>Stäng</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="690" />
+            <location filename="../src/ui/SideBar.cpp" line="793" />
+            <location filename="../src/ui/SideBar.cpp" line="879" />
+            <source>Remove</source>
+            <translation>Ta bort</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="695" />
+            <source>Authorize</source>
+            <translation>Auktorisera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="709" />
+            <source>Clone Repository</source>
+            <translation>Klona arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="720" />
+            <source>Open Existing Repository</source>
+            <translation>Öppna befintligt arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="724" />
+            <source>Open Repository</source>
+            <translation>Öppna arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="733" />
+            <source>Initialize New Repository</source>
+            <translation>Initiera nytt arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="748" />
+            <source>Add %1 Account</source>
+            <translation>Lägg till %1-konto</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="783" />
+            <source>&lt;p&gt;Are you sure you want to remove the remote repository association for %1?&lt;/p&gt;&lt;p&gt;The local clone itself will not be affected.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;Är du säker på att du vill ta bort fjärrarkivskopplingen för %1?&lt;/p&gt;&lt;p&gt;Den lokala klonen påverkas inte.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="788" />
+            <source>Remove Repository Association?</source>
+            <translation>Ta bort arkivkoppling?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="812" />
+            <source>Clear All Recent</source>
+            <translation>Rensa alla senaste</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="816" />
+            <source>Show Full Path</source>
+            <translation>Visa fullständig sökväg</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="826" />
+            <source>Filter Non-existent Paths</source>
+            <translation>Filtrera bort sökvägar som inte finns</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="834" />
+            <source>Refresh Remote Accounts</source>
+            <translation>Uppdatera fjärrkonton</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="841" />
+            <source>Show Full Name</source>
+            <translation>Visa fullständigt namn</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="868" />
+            <source>&lt;p&gt;Are you sure you want to remove the %1 account for '%2'?&lt;/p&gt;&lt;p&gt;Only the account association will be removed. Remote configurations and local clones will not be affected.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;Är du säker på att du vill ta bort %1-kontot för ”%2”?&lt;/p&gt;&lt;p&gt;Endast kontokopplingen tas bort. Fjärrkonfigurationer och lokala kloner påverkas inte.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/SideBar.cpp" line="873" />
+            <source>Remove Account?</source>
+            <translation>Ta bort konto?</translation>
+        </message>
+    </context>
+    <context>
+        <name>StartDialog</name>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="371" />
+            <source>Choose Repository</source>
+            <translation>Välj arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="379" />
+            <source>Understand your history!</source>
+            <translation>Få överblick över din historik!</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="434" />
+            <source>Clone Repository</source>
+            <translation>Klona arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="445" />
+            <source>Open Existing Repository</source>
+            <translation>Öppna befintligt arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="449" />
+            <source>Open Repository</source>
+            <translation>Öppna arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="457" />
+            <source>Initialize New Repository</source>
+            <translation>Initiera nytt arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="471" />
+            <source>Clear All</source>
+            <translation>Rensa alla</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="476" />
+            <source>Show Full Path</source>
+            <translation>Visa fullständig sökväg</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="486" />
+            <source>Filter Non-existent Paths</source>
+            <translation>Filtrera bort sökvägar som inte finns</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="494" />
+            <source>Repositories:</source>
+            <translation>Arkiv:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="542" />
+            <source>Refresh</source>
+            <translation>Uppdatera</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="549" />
+            <source>Show Full Name</source>
+            <translation>Visa fullständigt namn</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="577" />
+            <source>Remote:</source>
+            <translation>Fjärranslutning:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="595" />
+            <source>View Getting Started Video</source>
+            <translation>Visa introduktionsvideo</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="710" />
+            <source>Clone</source>
+            <translation>Klona</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="710" />
+            <source>Open</source>
+            <translation>Öppna</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="776" />
+            <source>&lt;p&gt;Are you sure you want to remove the %1 account for '%2'?&lt;/p&gt;&lt;p&gt;Only the account association will be removed. Remote configurations and local clones will not be affected.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;Är du säker på att du vill ta bort %1-kontot för ”%2”?&lt;/p&gt;&lt;p&gt;Endast kontokopplingen tas bort. Fjärrkonfigurationer och lokala kloner påverkas inte.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="780" />
+            <source>Remove Account?</source>
+            <translation>Ta bort konto?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="783" />
+            <location filename="../src/dialogs/StartDialog.cpp" line="803" />
+            <source>Remove</source>
+            <translation>Ta bort</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="798" />
+            <source>&lt;p&gt;Are you sure you want to remove the remote repository association for %1?&lt;/p&gt;&lt;p&gt;The local clone itself will not be affected.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;Är du säker på att du vill ta bort fjärrarkivskopplingen för %1?&lt;/p&gt;&lt;p&gt;Den lokala klonen påverkas inte.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/StartDialog.cpp" line="801" />
+            <source>Remove Repository Association?</source>
+            <translation>Ta bort arkivkoppling?</translation>
+        </message>
+    </context>
+    <context>
+        <name>SubmoduleTableModel</name>
+        <message>
+            <location filename="../src/dialogs/SubmoduleTableModel.cpp" line="65" />
+            <source>Name</source>
+            <translation>Namn</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SubmoduleTableModel.cpp" line="67" />
+            <source>URL</source>
+            <translation>URL</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SubmoduleTableModel.cpp" line="69" />
+            <source>Branch</source>
+            <translation>Gren</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SubmoduleTableModel.cpp" line="71" />
+            <source>Initialized</source>
+            <translation>Initierad</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SubmoduleTableModel.cpp" line="122" />
+            <source>Deinitializing '%1' will remove its working directory. Are you sure you want to deinitialize?</source>
+            <translation>Avinitiering av ”%1” tar bort dess arbetsmapp. Är du säker på att du vill avinitiera?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SubmoduleTableModel.cpp" line="126" />
+            <source>Deinitialize Submodule?</source>
+            <translation>Avinitiera delmodul?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SubmoduleTableModel.cpp" line="131" />
+            <source>The submodule working directory contains uncommitted changes that will be lost if you continue.</source>
+            <translation>Delmodulens arbetsmapp innehåller oincheckade ändringar som förloras om du fortsätter.</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SubmoduleTableModel.cpp" line="135" />
+            <source>Deinitialize</source>
+            <translation>Avinitiera</translation>
+        </message>
+    </context>
+    <context>
+        <name>TagDialog</name>
+        <message>
+            <location filename="../src/dialogs/TagDialog.cpp" line="34" />
+            <location filename="../src/dialogs/TagDialog.cpp" line="71" />
+            <source>Create Tag</source>
+            <translation>Skapa tagg</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/TagDialog.cpp" line="35" />
+            <source>Add a new tag at %1</source>
+            <translation>Lägg till en ny tagg vid %1</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/TagDialog.cpp" line="39" />
+            <source>Force (replace existing tag)</source>
+            <translation>Tvinga (ersätt befintlig tagg)</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/TagDialog.cpp" line="42" />
+            <source>Push to %1</source>
+            <translation>Skicka till %1</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/TagDialog.cpp" line="46" />
+            <source>Annotated</source>
+            <translation>Kommenterad</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/TagDialog.cpp" line="117" />
+            <source>Name</source>
+            <translation>Namn</translation>
+        </message>
+    </context>
+    <context>
+        <name>TemplateDialog</name>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="32" />
+            <source>Name</source>
+            <translation>Namn</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="38" />
+            <source>Content</source>
+            <translation>Innehåll</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="43" />
+            <location filename="../src/ui/TemplateDialog.cpp" line="327" />
+            <source>Add</source>
+            <translation>Lägg till</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="52" />
+            <source>use %1 to declare the position of the cursor.</source>
+            <translation>använd %1 för att ange markörens position.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="56" />
+            <source>use ${files:x} to add all updated file names,
+x (number) determines the number of maximum files shown</source>
+            <translation>använd ${files:x} för att lägga till alla uppdaterade filnamn,
+x (tal) anger det högsta antal filer som visas</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="66" />
+            <source>Remove</source>
+            <translation>Ta bort</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="72" />
+            <source>First template will be applied automatically</source>
+            <translation>Den första mallen tillämpas automatiskt</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="79" />
+            <source>Up</source>
+            <translation>Upp</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="80" />
+            <source>Down</source>
+            <translation>Ned</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="95" />
+            <source>Import</source>
+            <translation>Importera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="96" />
+            <source>Export</source>
+            <translation>Exportera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="243" />
+            <source>Open File</source>
+            <translation>Öppna fil</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="244" />
+            <location filename="../src/ui/TemplateDialog.cpp" line="297" />
+            <source>Gittyup Templates (*%1)</source>
+            <translation>Gittyup-mallar (*%1)</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="294" />
+            <source>Save Templates</source>
+            <translation>Spara mallar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TemplateDialog.cpp" line="323" />
+            <source>Replace</source>
+            <translation>Ersätt</translation>
+        </message>
+    </context>
+    <context>
+        <name>TerminalPanel</name>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="804" />
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="828" />
+            <source>Install</source>
+            <translation>Installera</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="817" />
+            <source>Name:</source>
+            <translation>Namn:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="818" />
+            <source>Location:</source>
+            <translation>Plats:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="828" />
+            <source>Uninstall</source>
+            <translation>Avinstallera</translation>
+        </message>
+    </context>
+    <context>
+        <name>TextEdit</name>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="87" />
+            <source>Replace...</source>
+            <translation>Ersätt…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="88" />
+            <source>Replace All...</source>
+            <translation>Ersätt alla…</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="117" />
+            <source>Ignore</source>
+            <translation>Ignorera</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="136" />
+            <source>Ignore All</source>
+            <translation>Ignorera alla</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="142" />
+            <source>Add to User Dictionary</source>
+            <translation>Lägg till i användarordbok</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/CommitEditor.cpp" line="156" />
+            <source>Do not Ignore</source>
+            <translation>Ignorera inte</translation>
+        </message>
+    </context>
+    <context>
+        <name>ThemeDialog</name>
+        <message>
+            <location filename="../src/dialogs/ThemeDialog.cpp" line="102" />
+            <source>A flexible look matching system colors</source>
+            <translation>Ett flexibelt utseende som matchar systemfärgerna</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ThemeDialog.cpp" line="96" />
+            <source>Dark Theme</source>
+            <translation>Mörkt tema</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ThemeDialog.cpp" line="89" />
+            <source>Pick a theme for Gittyup</source>
+            <translation>Välj ett tema för Gittyup</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ThemeDialog.cpp" line="92" />
+            <source>Default Theme</source>
+            <translation>Standardtema</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ThemeDialog.cpp" line="93" />
+            <source>A consistent bright theme</source>
+            <translation>Ett enhetligt ljust tema</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ThemeDialog.cpp" line="97" />
+            <source>A consistent look optimal for reducing eye strain</source>
+            <translation>Ett enhetligt utseende som är optimalt för att minska ansträngningen för ögonen</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/ThemeDialog.cpp" line="101" />
+            <source>System Theme</source>
+            <translation>Systemtema</translation>
+        </message>
+    </context>
+    <context>
+        <name>ToolBar</name>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="736" />
+            <source>Show repository sidebar</source>
+            <translation>Visa sidofält för arkiv</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="750" />
+            <source>Previous</source>
+            <translation>Föregående</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="762" />
+            <source>Next</source>
+            <translation>Nästa</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="778" />
+            <source>Fetch</source>
+            <translation>Hämta</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="783" />
+            <source>Pull</source>
+            <translation>Hämta och sammanfoga</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="789" />
+            <source>Merge</source>
+            <translation>Sammanfoga</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="793" />
+            <source>Rebase</source>
+            <translation>Byt bas</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="800" />
+            <source>Push</source>
+            <translation>Skicka</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="806" />
+            <source>Checkout</source>
+            <translation>Checka ut</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="818" />
+            <source>Stash</source>
+            <translation>Stash</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="823" />
+            <source>Pop Stash</source>
+            <translation>Poppa stash</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="848" />
+            <source>Open Terminal</source>
+            <translation>Öppna terminal</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="860" />
+            <source>Open file manager</source>
+            <translation>Öppna filhanterare</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="872" />
+            <source>Configure Settings</source>
+            <translation>Konfigurera inställningar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="880" />
+            <source>Repository settings</source>
+            <translation>Arkivinställningar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="884" />
+            <source>Application settings</source>
+            <translation>Programinställningar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="891" />
+            <location filename="../src/ui/ToolBar.cpp" line="1020" />
+            <source>Show Log</source>
+            <translation>Visa logg</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="909" />
+            <source>Double Tree View</source>
+            <translation>Dubbel trädvy</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="914" />
+            <source>Tree View</source>
+            <translation>Trädvy</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="927" />
+            <source>Show Starred Commits</source>
+            <translation>Visa stjärnmärkta incheckningar</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/ToolBar.cpp" line="1020" />
+            <source>Hide Log</source>
+            <translation>Dölj logg</translation>
+        </message>
+    </context>
+    <context>
+        <name>ToolsPanel</name>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="315" />
+            <source>Keep backup of merge files (.orig)</source>
+            <translation>Behåll säkerhetskopia av sammanfogningsfiler (.orig)</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="322" />
+            <source>External editor:</source>
+            <translation>Extern redigerare:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="323" />
+            <source>External diff:</source>
+            <translation>Extern diff:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="324" />
+            <source>External merge:</source>
+            <translation>Extern sammanfogning:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="325" />
+            <source>Backup files:</source>
+            <translation>Säkerhetskopior:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="328" />
+            <source>Terminal emulator command:</source>
+            <translation>Kommando för terminalemulator:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="340" />
+            <source>File manager command:</source>
+            <translation>Kommando för filhanterare:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="368" />
+            <source>Configure</source>
+            <translation>Konfigurera</translation>
+        </message>
+    </context>
+    <context>
+        <name>TreeModel</name>
+        <message>
+            <location filename="../src/ui/TreeModel.cpp" line="143" />
+            <source>Submodule</source>
+            <translation>Delmodul</translation>
+        </message>
+    </context>
+    <context>
+        <name>TreeView</name>
+        <message>
+            <location filename="../src/ui/TreeView.cpp" line="99" />
+            <source>Directory</source>
+            <translation>Mapp</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TreeView.cpp" line="99" />
+            <source>File</source>
+            <translation>Fil</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TreeView.cpp" line="100" />
+            <source>Remove or discard %1?</source>
+            <translation>Ta bort eller förkasta %1?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TreeView.cpp" line="102" />
+            <source>Are you sure you want to remove or discard all changes in '%1'?</source>
+            <translation>Är du säker på att du vill ta bort eller förkasta alla ändringar i ”%1”?</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TreeView.cpp" line="107" />
+            <source>This action cannot be undone.</source>
+            <translation>Den här åtgärden kan inte ångras.</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TreeView.cpp" line="110" />
+            <location filename="../src/ui/TreeView.cpp" line="122" />
+            <source>Discard</source>
+            <translation>Förkasta</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TreeView.cpp" line="123" />
+            <source>discard</source>
+            <translation>förkasta</translation>
+        </message>
+    </context>
+    <context>
+        <name>TreeWidget</name>
+        <message>
+            <location filename="../src/ui/TreeWidget.cpp" line="54" />
+            <source>Search:</source>
+            <translation>Sök:</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TreeWidget.cpp" line="57" />
+            <source>Regex</source>
+            <translation>Reguljärt uttryck</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/TreeWidget.cpp" line="59" />
+            <source>Case Sensitive</source>
+            <translation>Skiftlägeskänslig</translation>
+        </message>
+    </context>
+    <context>
+        <name>UpToDateDialog</name>
+        <message>
+            <location filename="../src/update/UpToDateDialog.cpp" line="19" />
+            <source>Already Up-to-date</source>
+            <translation>Redan uppdaterad</translation>
+        </message>
+        <message>
+            <location filename="../src/update/UpToDateDialog.cpp" line="30" />
+            <source>%1 is already up-to-date. You have version %2.</source>
+            <translation>%1 är redan uppdaterad. Du har version %2.</translation>
+        </message>
+    </context>
+    <context>
+        <name>UpdateDialog</name>
+        <message>
+            <location filename="../src/update/UpdateDialog.cpp" line="51" />
+            <source>Update %1</source>
+            <translation>Uppdatera %1</translation>
+        </message>
+        <message>
+            <location filename="../src/update/UpdateDialog.cpp" line="61" />
+            <location filename="../src/update/UpdateDialog.cpp" line="85" />
+            <source>&lt;h3&gt;A new version of %1 is available!&lt;/h3&gt;&lt;p&gt;%1 %2 is now available - you have %3. The new version will be soon available in your package manager. Just update your system.&lt;/p&gt;&lt;b&gt;Release Notes:&lt;/b&gt;</source>
+            <translation>&lt;h3&gt;En ny version av %1 finns tillgänglig!&lt;/h3&gt;&lt;p&gt;%1 %2 finns nu tillgänglig – du har %3. Den nya versionen blir snart tillgänglig i din pakethanterare. Uppdatera bara systemet.&lt;/p&gt;&lt;b&gt;Versionsinformation:&lt;/b&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/update/UpdateDialog.cpp" line="68" />
+            <source>&lt;h3&gt;A new version of %1 is available!&lt;/h3&gt;&lt;p&gt;%1 %2 is now available - you have %3. Would you like to download it now?&lt;/p&gt;&lt;b&gt;Release Notes:&lt;/b&gt;</source>
+            <translation>&lt;h3&gt;En ny version av %1 finns tillgänglig!&lt;/h3&gt;&lt;p&gt;%1 %2 finns nu tillgänglig – du har %3. Vill du hämta den nu?&lt;/p&gt;&lt;b&gt;Versionsinformation:&lt;/b&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/update/UpdateDialog.cpp" line="75" />
+            <source>&lt;h3&gt;A new version of %1 is available!&lt;/h3&gt;&lt;p&gt;%1 %2 is now available - you have %3.&lt;/p&gt;&lt;p&gt;If you downloaded the flatpak package over a package manager or from flathub.org &lt;br/&gt;you don't have to install manually a new version. It will be available within the next &lt;br/&gt;days during your system update: &lt;code&gt;flatpak update&lt;/code&gt;&lt;/p&gt;&lt;b&gt;Release Notes:&lt;/b&gt;</source>
+            <translation>&lt;h3&gt;En ny version av %1 finns tillgänglig!&lt;/h3&gt;&lt;p&gt;%1 %2 finns nu tillgänglig – du har %3.&lt;/p&gt;&lt;p&gt;Om du hämtade Flatpak-paketet via en pakethanterare eller från flathub.org &lt;br/&gt;behöver du inte installera den nya versionen manuellt. Den blir tillgänglig inom de närmaste &lt;br/&gt;dagarna via systemuppdateringen: &lt;code&gt;flatpak update&lt;/code&gt;&lt;/p&gt;&lt;b&gt;Versionsinformation:&lt;/b&gt;</translation>
+        </message>
+        <message>
+            <location filename="../src/update/UpdateDialog.cpp" line="100" />
+            <source>Automatically download and install updates</source>
+            <translation>Hämta och installera uppdateringar automatiskt</translation>
+        </message>
+        <message>
+            <location filename="../src/update/UpdateDialog.cpp" line="112" />
+            <source>Install Update</source>
+            <translation>Installera uppdatering</translation>
+        </message>
+        <message>
+            <location filename="../src/update/UpdateDialog.cpp" line="114" />
+            <source>Remind Me Later</source>
+            <translation>Påminn mig senare</translation>
+        </message>
+        <message>
+            <location filename="../src/update/UpdateDialog.cpp" line="118" />
+            <source>Skip This Version</source>
+            <translation>Hoppa över den här versionen</translation>
+        </message>
+        <message>
+            <location filename="../src/update/UpdateDialog.cpp" line="138" />
+            <source>Ok</source>
+            <translation>OK</translation>
+        </message>
+        <message>
+            <location filename="../src/update/UpdateDialog.cpp" line="150" />
+            <source>Donate</source>
+            <translation>Donera</translation>
+        </message>
+    </context>
+    <context>
+        <name>UpdatePanel</name>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="721" />
+            <source>Check for updates automatically</source>
+            <translation>Sök automatiskt efter uppdateringar</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="733" />
+            <source>Automatically download and install updates</source>
+            <translation>Hämta och installera uppdateringar automatiskt</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="743" />
+            <source>Check Now</source>
+            <translation>Sök nu</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="748" />
+            <source>Software Update:</source>
+            <translation>Programuppdatering:</translation>
+        </message>
+    </context>
+    <context>
+        <name>UpdateSubmodulesDialog</name>
+        <message>
+            <location filename="../src/dialogs/UpdateSubmodulesDialog.cpp" line="109" />
+            <source>Recursive</source>
+            <translation>Rekursiv</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/UpdateSubmodulesDialog.cpp" line="112" />
+            <source>Init</source>
+            <translation>Initiera</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/UpdateSubmodulesDialog.cpp" line="117" />
+            <source>Update</source>
+            <translation>Uppdatera</translation>
+        </message>
+    </context>
+    <context>
+        <name>Updater</name>
+        <message>
+            <location filename="../src/update/Updater_win.cpp" line="23" />
+            <source>Installer failed to start</source>
+            <translation>Installationsprogrammet kunde inte starta</translation>
+        </message>
+        <message>
+            <location filename="../src/update/Updater_mac.mm" line="77" />
+            <source>The disk image failed to mount successfully</source>
+            <translation>Diskavbildningen kunde inte monteras</translation>
+        </message>
+        <message>
+            <location filename="../src/update/Updater_mac.mm" line="96" />
+            <source>The existing bundle could not be moved to the trash</source>
+            <translation>Det befintliga paketet kunde inte flyttas till papperskorgen</translation>
+        </message>
+        <message>
+            <location filename="../src/update/Updater_mac.mm" line="108" />
+            <source>The new bundle could not be copied into place</source>
+            <translation>Det nya paketet kunde inte kopieras till rätt plats</translation>
+        </message>
+        <message>
+            <location filename="../src/update/Updater_mac.mm" line="117" />
+            <location filename="../src/update/Updater.cpp" line="334" />
+            <location filename="../src/update/Updater.cpp" line="355" />
+            <source>Helper application failed to start</source>
+            <translation>Hjälpprogrammet kunde inte starta</translation>
+        </message>
+        <message>
+            <location filename="../src/update/Updater.cpp" line="100" />
+            <source>Update Failed</source>
+            <translation>Uppdateringen misslyckades</translation>
+        </message>
+        <message>
+            <location filename="../src/update/Updater.cpp" line="115" />
+            <source>Unable to check for updates</source>
+            <translation>Kunde inte söka efter uppdateringar</translation>
+        </message>
+        <message>
+            <location filename="../src/update/Updater.cpp" line="185" />
+            <source>Unable to download update</source>
+            <translation>Kunde inte hämta uppdatering</translation>
+        </message>
+        <message>
+            <location filename="../src/update/Updater.cpp" line="188" />
+            <source>Unable to open temporary file</source>
+            <translation>Kunde inte öppna temporär fil</translation>
+        </message>
+        <message>
+            <location filename="../src/update/Updater.cpp" line="245" />
+            <source>Unable to install update</source>
+            <translation>Kunde inte installera uppdatering</translation>
+        </message>
+        <message>
+            <location filename="../src/update/Updater.cpp" line="248" />
+            <source>Some windows failed to close. You can download the binary manually from %1</source>
+            <translation>Vissa fönster kunde inte stängas. Du kan hämta binärfilen manuellt från %1</translation>
+        </message>
+        <message>
+            <location filename="../src/update/Updater.cpp" line="256" />
+            <source>Unknown install error</source>
+            <translation>Okänt installationsfel</translation>
+        </message>
+        <message>
+            <location filename="../src/update/Updater.cpp" line="319" />
+            <location filename="../src/update/Updater.cpp" line="347" />
+            <source>Installer script failed: %1</source>
+            <translation>Installationsskriptet misslyckades: %1</translation>
+        </message>
+    </context>
+    <context>
+        <name>WindowPanel</name>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="437" />
+            <source>Add New Theme</source>
+            <translation>Lägg till nytt tema</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="438" />
+            <source>Edit Current Theme</source>
+            <translation>Redigera aktuellt tema</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="462" />
+            <source>Create Theme</source>
+            <translation>Skapa tema</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="472" />
+            <source>Theme Name</source>
+            <translation>Temanamn</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="504" />
+            <source>Restart?</source>
+            <translation>Starta om?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="505" />
+            <source>The application must be restarted for the theme change to take effect.</source>
+            <translation>Programmet måste startas om för att temaändringen ska träda i kraft.</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="507" />
+            <source>Do you want to restart now?</source>
+            <translation>Vill du starta om nu?</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="509" />
+            <source>Restart</source>
+            <translation>Starta om</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="510" />
+            <source>Later</source>
+            <translation>Senare</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="528" />
+            <source>Show full repository path</source>
+            <translation>Visa fullständig arkivsökväg</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="535" />
+            <source>Hide automatically</source>
+            <translation>Dölj automatiskt</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="543" />
+            <source>Open submodules in tabs</source>
+            <translation>Öppna delmoduler i flikar</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="551" />
+            <source>Open all repositories in tabs</source>
+            <translation>Öppna alla arkiv i flikar</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="558" />
+            <source>Hide Menubar</source>
+            <translation>Dölj menyrad</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="563" />
+            <source>Show Avatars</source>
+            <translation>Visa avatarer</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="569" />
+            <source>Show Window Maximized when opened</source>
+            <translation>Visa fönstret maximerat när det öppnas</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="622" />
+            <source>Theme:</source>
+            <translation>Tema:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="623" />
+            <source>Title:</source>
+            <translation>Rubrik:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="624" />
+            <source>Log:</source>
+            <translation>Logg:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="625" />
+            <source>Tabs:</source>
+            <translation>Flikar:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="627" />
+            <source>View:</source>
+            <translation>Visa:</translation>
+        </message>
+        <message>
+            <location filename="../src/dialogs/SettingsDialog.cpp" line="630" />
+            <source>Prompt:</source>
+            <translation>Fråga:</translation>
+        </message>
+    </context>
+    <context>
+        <name>_FileWidget::Header</name>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="219" />
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="245" />
+            <source>Use Theirs: Delete</source>
+            <translation>Använd deras version: Ta bort</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="227" />
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="238" />
+            <source>Use Ours: Delete</source>
+            <translation>Använd vår version: Ta bort</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="253" />
+            <source>both: %1</source>
+            <translation>båda: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="257" />
+            <source>ours: %1</source>
+            <translation>vår: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/ui/DiffView/FileWidget.cpp" line="261" />
+            <source>theirs: %1</source>
+            <translation>deras: %1</translation>
+        </message>
+    </context>
+</TS>


### PR DESCRIPTION
## Summary
- add a complete Swedish Qt translation catalogue
- register Swedish in the CMake language list

## Validation
- `/usr/lib/qt6/bin/lrelease l10n/gittyup_sv.ts` — 1,051 finished, 0 unfinished translations
- XML and Qt placeholder parity checks — 0 mismatches

The translation covers the desktop UI, Git safety warnings, credentials, SSH/SSL, LFS, conflict resolution, update flows, and accessibility-visible menu labels.