### PR TITLE
task: fix compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ else()
 endif()
 
 find_package(
-  Qt6 6.6
+  Qt6 6.4
   COMPONENTS ${QT_MODULES} LinguistTools
   REQUIRED)
 if(FLATPAK)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ submodules are optional or may also be satisfied by system libraries.
 
 **External Dependencies**
 
-* Qt (required >= 6.6)
+* Qt (required >= 6.4)
 
 **Included Dependencies**
 

--- a/test/Filter.cpp
+++ b/test/Filter.cpp
@@ -80,7 +80,7 @@ void TestFilter::rejectsShellInjectionInFilename() {
   // new, attacker-controlled statements.
   QString maliciousName = "evil';>injected_marker;echo'safe";
 
-  QString path = Test::extractRepository("FilterCommandInjection.zip", true);
+  QString path = Test::extractRepository("FilterCommandInjection.zip");
   QVERIFY(!path.isEmpty());
   git::Repository repo = git::Repository::open(path);
   QVERIFY(repo.isValid());


### PR DESCRIPTION
This PR changes two separate things.

The first is a fix, specifically, a coding error in the tests. In `test/Filter.cpp:83` an extra parameter was added to a call to `Test::extractRepository()`.

The second is a build-time change. Specifically, to reduce the QT version requirement from 6.6 to 6.4 in order to support building natively on Ubuntu24 LTS. This compiles cleanly so there does not appear to be a strict requirement for QT6.6 just yet.